### PR TITLE
Improve doc comments around ast::Value::Interval

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -35,22 +35,60 @@ pub enum Value {
     /// `TIMESTAMP '...'` literals
     Timestamp(String),
     /// INTERVAL literals, roughly in the following format:
-    /// `INTERVAL '<value>' <leading_field> [ (<leading_precision>) ]
-    /// [ TO <last_field> [ (<fractional_seconds_precision>) ] ]`,
-    /// e.g. `INTERVAL '123:45.67' MINUTE(3) TO SECOND(2)`.
     ///
-    /// The parser does not validate the `<value>`, nor does it ensure
-    /// that the `<leading_field>` units >= the units in `<last_field>`,
-    /// so the user will have to reject intervals like `HOUR TO YEAR`.
+    /// ```ignore
+    /// INTERVAL '<value>' <leading_field> [ (<leading_precision>) ]
+    ///     [ TO <last_field> [ (<fractional_seconds_precision>) ] ]
+    /// ```
+    ///
+    /// For example: `INTERVAL '123:45.67' MINUTE (3) TO SECOND (2)`
+    ///
+    /// The parser does not validate the `<value>`, nor does it ensure that the
+    /// `<leading_field>` units are coarser than the units in `<last_field>`, as
+    /// required by the SQL specification. Downstream consumers are responsible
+    /// for rejecting intervals with invalid values, like `'foobar'`, and
+    /// invalid unit specifications, like `HOUR TO YEAR`.
     Interval {
+        /// The raw `<value>` that was present in `INTERVAL '<value>'`.
         value: String,
+        /// The unit of the first field in the interval. `INTERVAL 'T' MINUTE`
+        /// means `T` is in minutes, for example.
         leading_field: DateTimeField,
+        /// How many digits the leading field is allowed to occupy.
+        ///
+        /// Note that, according to the SQL specification, the interval
+        /// `INTERVAL '1234' MINUTE(3)` is invalid, but `INTERVAL '123'
+        /// MINUTE(3)` is valid. At present, such validation is left to
+        /// downstream consumers.
         leading_precision: Option<u64>,
+        /// How much precision to keep track of.
+        ///
+        /// If this is omitted, then clients should ignore all but the leading
+        /// field. If it is less precise than the final field, clients should
+        /// ignore the final field.
+        ///
+        /// For the following specifications:
+        ///
+        /// * in `INTERVAL '1:1:1' HOUR TO SECOND`, `last_field` will be
+        ///   `Some(DateTimeField::Second)`, and clients should compute an
+        ///   interval of 3661 seconds;
+        /// * in `INTERVAL '1:1:1' HOUR TO MINUTE`, `last_field` will be
+        ///   `Some(DateTimeField::Minute)`, and clients should compute an
+        ///   interval of 3660 seconds;
+        /// * in `INTERVAL '1:1:1' HOUR`, `last_field` will be `None`, and
+        ///   clients should compute an interval of 3600 seconds.
+        ///
         last_field: Option<DateTimeField>,
-        /// The seconds precision can be specified in SQL source as
-        /// `INTERVAL '__' SECOND(_, x)` (in which case the `leading_field`
-        /// will be `Second` and the `last_field` will be `None`),
-        /// or as `__ TO SECOND(x)`.
+        /// If the last field is `SECOND`, the SQL standard permits the user to
+        /// specify the fractional precision of the seconds. This specification
+        /// can occur in either of two syntactic forms, depending on whether the
+        /// interval's leading field is also `SECOND`.
+        ///
+        /// If both the leading and last fields are `SECOND`, then the
+        /// fractional seconds precision is specified with the syntax `INTERVAL
+        /// '_' SECOND (_, frac_prec)`. If only the last field is `SECOND`, then
+        /// the fractional seconds precision is specified with the syntax
+        /// `INTERVAL '_' {HOUR|MINUTE} TO SECOND (frac_prec)`.
         fractional_seconds_precision: Option<u64>,
     },
     /// `NULL` value

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1260,7 +1260,7 @@ impl Parser {
                 }
                 // Interval types can be followed by a complicated interval
                 // qualifier that we don't currently support. See
-                // parse_interval_literal for a taste.
+                // parse_literal_interval for a taste.
                 "INTERVAL" => Ok(DataType::Interval),
                 "REGCLASS" => Ok(DataType::Regclass),
                 "TEXT" => {


### PR DESCRIPTION
Intervals are confusing. This makes the interpretation of the individual
fields more obvious.