### PR TITLE
Lossless syntax tree prototype and discussion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,13 @@ edition = "2018"
 name = "sqlparser"
 path = "src/lib.rs"
 
+[features]
+cst = ["rowan"]  # Retain a concrete synatax tree, available as `parser.syntax()`
+
 [dependencies]
 bigdecimal = { version = "0.1.0", optional = true }
 log = "0.4.5"
-rowan = "0.10.0"
+rowan = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 simple_logger = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ path = "src/lib.rs"
 cst = ["rowan"]  # Retain a concrete synatax tree, available as `parser.syntax()`
 
 [dependencies]
-bigdecimal = { version = "0.1.0", optional = true }
+bigdecimal = { version = "0.1.0", optional = true, features = ["serde"] }
 log = "0.4.5"
-rowan = { version = "0.10.0", optional = true }
+rowan = { version = "0.10.0", optional = true, features = ["serde1"] }
+serde = { version = "1.0.106", features = ["derive"] }
+serde_json = "1.0.52"
 
 [dev-dependencies]
 simple_logger = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 [dependencies]
 bigdecimal = { version = "0.1.0", optional = true }
 log = "0.4.5"
+rowan = "0.10.0"
 
 [dev-dependencies]
 simple_logger = "1.0.1"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -58,17 +58,20 @@ fn main() {
 
     match parse_result {
         Ok(statements) => {
-            println!(
-                "Round-trip:\n'{}'",
-                statements
-                    .iter()
-                    .map(std::string::ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            );
-            println!("Parse results:\n{:#?}", statements);
-
-            println!("Parse tree:\n{:#?}", parser.syntax());
+            if cfg!(not(feature = "cst")) {
+                println!(
+                    "Round-trip:\n'{}'",
+                    statements
+                        .iter()
+                        .map(std::string::ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                );
+                println!("Parse results:\n{:#?}", statements);
+            } else {
+                #[cfg(feature = "cst")]
+                println!("Parse tree:\n{:#?}", parser.syntax());
+            }
         }
         Err(e) => {
             println!("Error during parsing: {:?}", e);

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -70,7 +70,14 @@ fn main() {
                 println!("Parse results:\n{:#?}", statements);
             } else {
                 #[cfg(feature = "cst")]
-                println!("Parse tree:\n{:#?}", parser.syntax());
+                {
+                    let syn = parser.syntax();
+                    println!("Parse tree:\n{:#?}", syn);
+                    let serialized = serde_json::to_string(&syn).unwrap();
+                    println!("Parse tree as json:\n{}", serialized);
+                    let serialized = serde_json::to_string(&statements).unwrap();
+                    println!("AST as JSON:\n{}", serialized);
+                }
             }
         }
         Err(e) => {

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -11,10 +11,11 @@
 // limitations under the License.
 
 use super::ObjectName;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// SQL data types
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DataType {
     /// Fixed-length character type e.g. CHAR(10)
     Char(Option<u64>),

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -13,10 +13,11 @@
 //! AST types specific to CREATE/ALTER variants of [Statement]
 //! (commonly referred to as Data Definition Language, or DDL)
 use super::{display_comma_separated, DataType, Expr, Ident, ObjectName};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// An `ALTER TABLE` (`Statement::AlterTable`) operation
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AlterTableOperation {
     /// `ADD <table_constraint>`
     AddConstraint(TableConstraint),
@@ -35,7 +36,7 @@ impl fmt::Display for AlterTableOperation {
 
 /// A table-level constraint, specified in a `CREATE TABLE` or an
 /// `ALTER TABLE ADD <constraint>` statement.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TableConstraint {
     /// `[ CONSTRAINT <name> ] { PRIMARY KEY | UNIQUE } (<columns>)`
     Unique {
@@ -94,7 +95,7 @@ impl fmt::Display for TableConstraint {
 }
 
 /// SQL column definition
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ColumnDef {
     pub name: Ident,
     pub data_type: DataType,
@@ -128,7 +129,7 @@ impl fmt::Display for ColumnDef {
 /// For maximum flexibility, we don't distinguish between constraint and
 /// non-constraint options, lumping them all together under the umbrella of
 /// "column options," and we allow any column option to be named.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ColumnOptionDef {
     pub name: Option<Ident>,
     pub option: ColumnOption,
@@ -142,7 +143,7 @@ impl fmt::Display for ColumnOptionDef {
 
 /// `ColumnOption`s are modifiers that follow a column definition in a `CREATE
 /// TABLE` statement.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ColumnOption {
     /// `NULL`
     Null,
@@ -219,7 +220,7 @@ fn display_constraint_name<'a>(name: &'a Option<Ident>) -> impl fmt::Display + '
 /// { RESTRICT | CASCADE | SET NULL | NO ACTION | SET DEFAULT }`
 ///
 /// Used in foreign key constraints in `ON UPDATE` and `ON DELETE` options.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ReferentialAction {
     Restrict,
     Cascade,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -18,6 +18,7 @@ mod operator;
 mod query;
 mod value;
 
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 pub use self::data_type::DataType;
@@ -70,7 +71,7 @@ where
 }
 
 /// An identifier, decomposed into its value or character data and the quote style.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Ident {
     /// The value of the identifier without quotes.
     pub value: String,
@@ -126,7 +127,7 @@ impl fmt::Display for Ident {
 }
 
 /// A name of a table, view, custom type, etc., possibly multi-part, i.e. db.schema.obj
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ObjectName(pub Vec<Ident>);
 
 impl fmt::Display for ObjectName {
@@ -140,7 +141,7 @@ impl fmt::Display for ObjectName {
 /// The parser does not distinguish between expressions of different types
 /// (e.g. boolean vs string), so the caller must handle expressions of
 /// inappropriate type, like `WHERE 1` or `SELECT 1=1`, as necessary.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Expr {
     /// Identifier e.g. table name or column name
     Identifier(Ident),
@@ -303,7 +304,7 @@ impl fmt::Display for Expr {
 /// Note: we only recognize a complete single expression as `<condition>`,
 /// not `< 0` nor `1, 2, 3` as allowed in a `<simple when clause>` per
 /// <https://jakewheat.github.io/sql-overview/sql-2011-foundation-grammar.html#simple-when-clause>
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct WhenClause {
     pub condition: Expr,
     pub result: Expr,
@@ -316,7 +317,7 @@ impl fmt::Display for WhenClause {
 }
 
 /// A window specification (i.e. `OVER (PARTITION BY .. ORDER BY .. etc.)`)
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct WindowSpec {
     pub partition_by: Vec<Expr>,
     pub order_by: Vec<OrderByExpr>,
@@ -361,7 +362,7 @@ impl fmt::Display for WindowSpec {
 ///
 /// Note: The parser does not validate the specified bounds; the caller should
 /// reject invalid bounds like `ROWS UNBOUNDED FOLLOWING` before execution.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct WindowFrame {
     pub units: WindowFrameUnits,
     pub start_bound: WindowFrameBound,
@@ -372,7 +373,7 @@ pub struct WindowFrame {
     // TBD: EXCLUDE
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum WindowFrameUnits {
     Rows,
     Range,
@@ -406,7 +407,7 @@ impl FromStr for WindowFrameUnits {
 }
 
 /// Specifies [WindowFrame]'s `start_bound` and `end_bound`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum WindowFrameBound {
     /// `CURRENT ROW`
     CurrentRow,
@@ -430,7 +431,7 @@ impl fmt::Display for WindowFrameBound {
 
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Statement {
     /// SELECT
     Query(Box<Query>),
@@ -774,7 +775,7 @@ impl fmt::Display for Statement {
 }
 
 /// SQL assignment `foo = expr` as used in SQLUpdate
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Assignment {
     pub id: Ident,
     pub value: Expr,
@@ -787,7 +788,7 @@ impl fmt::Display for Assignment {
 }
 
 /// A function call
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Function {
     pub name: ObjectName,
     pub args: Vec<Expr>,
@@ -813,7 +814,7 @@ impl fmt::Display for Function {
 }
 
 /// External table's available file format
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum FileFormat {
     TEXTFILE,
     SEQUENCEFILE,
@@ -864,7 +865,7 @@ impl FromStr for FileFormat {
 
 /// A `LISTAGG` invocation `LISTAGG( [ DISTINCT ] <expr>[, <separator> ] [ON OVERFLOW <on_overflow>] ) )
 /// [ WITHIN GROUP (ORDER BY <within_group1>[, ...] ) ]`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ListAgg {
     pub distinct: bool,
     pub expr: Box<Expr>,
@@ -900,7 +901,7 @@ impl fmt::Display for ListAgg {
 }
 
 /// The `ON OVERFLOW` clause of a LISTAGG invocation
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ListAggOnOverflow {
     /// `ON OVERFLOW ERROR`
     Error,
@@ -933,7 +934,7 @@ impl fmt::Display for ListAggOnOverflow {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ObjectType {
     Table,
     View,
@@ -952,7 +953,7 @@ impl fmt::Display for ObjectType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SqlOption {
     pub name: Ident,
     pub value: Value,
@@ -964,7 +965,7 @@ impl fmt::Display for SqlOption {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TransactionMode {
     AccessMode(TransactionAccessMode),
     IsolationLevel(TransactionIsolationLevel),
@@ -980,7 +981,7 @@ impl fmt::Display for TransactionMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TransactionAccessMode {
     ReadOnly,
     ReadWrite,
@@ -996,7 +997,7 @@ impl fmt::Display for TransactionAccessMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TransactionIsolationLevel {
     ReadUncommitted,
     ReadCommitted,
@@ -1016,7 +1017,7 @@ impl fmt::Display for TransactionIsolationLevel {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ShowStatementFilter {
     Like(String),
     Where(Expr),
@@ -1032,7 +1033,7 @@ impl fmt::Display for ShowStatementFilter {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SetVariableValue {
     Ident(Ident),
     Literal(Value),

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -10,10 +10,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Unary operators
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum UnaryOperator {
     Plus,
     Minus,
@@ -31,7 +32,7 @@ impl fmt::Display for UnaryOperator {
 }
 
 /// Binary operators
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BinaryOperator {
     Plus,
     Minus,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -14,7 +14,7 @@ use super::*;
 
 /// The most complete variant of a `SELECT` query expression, optionally
 /// including `WITH`, `UNION` / other set operations, and `ORDER BY`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Query {
     /// WITH (common table expressions, or CTEs)
     pub ctes: Vec<Cte>,
@@ -54,7 +54,7 @@ impl fmt::Display for Query {
 
 /// A node in a tree, representing a "query body" expression, roughly:
 /// `SELECT ... [ {UNION|EXCEPT|INTERSECT} SELECT ...]`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SetExpr {
     /// Restricted SELECT .. FROM .. HAVING (no ORDER BY or set operations)
     Select(Box<Select>),
@@ -91,7 +91,7 @@ impl fmt::Display for SetExpr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SetOperator {
     Union,
     Except,
@@ -111,7 +111,7 @@ impl fmt::Display for SetOperator {
 /// A restricted variant of `SELECT` (without CTEs/`ORDER BY`), which may
 /// appear either as the only body item of an `SQLQuery`, or as an operand
 /// to a set operation like `UNION`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Select {
     pub distinct: bool,
     /// MSSQL syntax: `TOP (<N>) [ PERCENT ] [ WITH TIES ]`
@@ -155,7 +155,7 @@ impl fmt::Display for Select {
 /// The names in the column list before `AS`, when specified, replace the names
 /// of the columns returned by the query. The parser does not validate that the
 /// number of columns in the query matches the number of columns in the query.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Cte {
     pub alias: TableAlias,
     pub query: Query,
@@ -168,7 +168,7 @@ impl fmt::Display for Cte {
 }
 
 /// One item of the comma-separated list following `SELECT`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SelectItem {
     /// Any expression, not followed by `[ AS ] alias`
     UnnamedExpr(Expr),
@@ -191,7 +191,7 @@ impl fmt::Display for SelectItem {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TableWithJoins {
     pub relation: TableFactor,
     pub joins: Vec<Join>,
@@ -208,7 +208,7 @@ impl fmt::Display for TableWithJoins {
 }
 
 /// A table name or a parenthesized subquery with an optional alias
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TableFactor {
     Table {
         name: ObjectName,
@@ -273,7 +273,7 @@ impl fmt::Display for TableFactor {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TableAlias {
     pub name: Ident,
     pub columns: Vec<Ident>,
@@ -289,7 +289,7 @@ impl fmt::Display for TableAlias {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Join {
     pub relation: TableFactor,
     pub join_operator: JoinOperator,
@@ -354,7 +354,7 @@ impl fmt::Display for Join {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum JoinOperator {
     Inner(JoinConstraint),
     LeftOuter(JoinConstraint),
@@ -367,7 +367,7 @@ pub enum JoinOperator {
     OuterApply,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum JoinConstraint {
     On(Expr),
     Using(Vec<Ident>),
@@ -375,7 +375,7 @@ pub enum JoinConstraint {
 }
 
 /// An `ORDER BY` expression
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct OrderByExpr {
     pub expr: Expr,
     /// Optional `ASC` or `DESC`
@@ -401,7 +401,7 @@ impl fmt::Display for OrderByExpr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Offset {
     pub value: Expr,
     pub rows: OffsetRows,
@@ -414,7 +414,7 @@ impl fmt::Display for Offset {
 }
 
 /// Stores the keyword after `OFFSET <number>`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum OffsetRows {
     /// Omitting ROW/ROWS is non-standard MySQL quirk.
     None,
@@ -432,7 +432,7 @@ impl fmt::Display for OffsetRows {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Fetch {
     pub with_ties: bool,
     pub percent: bool,
@@ -451,7 +451,7 @@ impl fmt::Display for Fetch {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Top {
     /// SQL semantic equivalent of LIMIT but with same structure as FETCH.
     pub with_ties: bool,
@@ -471,7 +471,7 @@ impl fmt::Display for Top {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Values(pub Vec<Vec<Expr>>);
 
 impl fmt::Display for Values {

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -12,10 +12,11 @@
 
 #[cfg(feature = "bigdecimal")]
 use bigdecimal::BigDecimal;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Primitive SQL values such as number and string
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Value {
     /// Numeric literal
     #[cfg(not(feature = "bigdecimal"))]
@@ -117,7 +118,7 @@ impl fmt::Display for Value {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DateTimeField {
     Year,
     Month,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,215 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Concrete syntax (green) tree builder
+//!
+//! Based on the code from rowan:
+//! https://github.com/rust-analyzer/rowan/blob/v0.10.0/src/green/builder.rs
+//!
+//! The deviations are marked with `CHANGED(sqlparser)`.
+
+// CHANGED(sqlparser): parts of the imported code may be unused
+#![allow(dead_code)]
+
+use rowan::{GreenNode, GreenToken, NodeOrToken, SmolStr, SyntaxKind};
+
+// CHANGED(sqlparser): Use HashSet from std instead of FxHashSet to avoid the
+// extra dependency
+use std::collections::HashSet;
+// CHANGED(sqlparser): Redefine `GreenElement`, as it's not public in rowan
+pub type GreenElement = NodeOrToken<GreenNode, GreenToken>;
+
+#[derive(Default, Debug)]
+pub struct NodeCache {
+    nodes: HashSet<GreenNode>,
+    tokens: HashSet<GreenToken>,
+}
+
+impl NodeCache {
+    fn node<I>(&mut self, kind: SyntaxKind, children: I) -> GreenNode
+    where
+        I: IntoIterator<Item = GreenElement>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let mut node = GreenNode::new(kind, children);
+        // Green nodes are fully immutable, so it's ok to deduplicate them.
+        // This is the same optimization that Roslyn does
+        // https://github.com/KirillOsenkov/Bliki/wiki/Roslyn-Immutable-Trees
+        //
+        // For example, all `#[inline]` in this file share the same green node!
+        // For `libsyntax/parse/parser.rs`, measurements show that deduping saves
+        // 17% of the memory for green nodes!
+        // Future work: make hashing faster by avoiding rehashing of subtrees.
+        if node.children().len() <= 3 {
+            match self.nodes.get(&node) {
+                Some(existing) => node = existing.clone(),
+                None => assert!(self.nodes.insert(node.clone())),
+            }
+        }
+        node
+    }
+
+    fn token(&mut self, kind: SyntaxKind, text: SmolStr) -> GreenToken {
+        let mut token = GreenToken::new(kind, text);
+        match self.tokens.get(&token) {
+            Some(existing) => token = existing.clone(),
+            None => assert!(self.tokens.insert(token.clone())),
+        }
+        token
+    }
+}
+
+#[derive(Debug)]
+enum MaybeOwned<'a, T> {
+    Owned(T),
+    Borrowed(&'a mut T),
+}
+
+impl<T> std::ops::Deref for MaybeOwned<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        match self {
+            MaybeOwned::Owned(it) => it,
+            MaybeOwned::Borrowed(it) => *it,
+        }
+    }
+}
+
+impl<T> std::ops::DerefMut for MaybeOwned<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        match self {
+            MaybeOwned::Owned(it) => it,
+            MaybeOwned::Borrowed(it) => *it,
+        }
+    }
+}
+
+impl<T: Default> Default for MaybeOwned<'_, T> {
+    fn default() -> Self {
+        MaybeOwned::Owned(T::default())
+    }
+}
+
+/// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.
+#[derive(Clone, Copy, Debug)]
+pub struct Checkpoint(usize);
+
+/// A builder for a green tree.
+#[derive(Default, Debug)]
+pub struct GreenNodeBuilder<'cache> {
+    cache: MaybeOwned<'cache, NodeCache>,
+    parents: Vec<(SyntaxKind, usize)>,
+    children: Vec<GreenElement>,
+}
+
+impl GreenNodeBuilder<'_> {
+    /// Creates new builder.
+    pub fn new() -> GreenNodeBuilder<'static> {
+        GreenNodeBuilder::default()
+    }
+
+    /// Reusing `NodeCache` between different `GreenNodeBuilder`s saves memory.
+    /// It allows to structurally share underlying trees.
+    pub fn with_cache(cache: &mut NodeCache) -> GreenNodeBuilder<'_> {
+        GreenNodeBuilder {
+            cache: MaybeOwned::Borrowed(cache),
+            parents: Vec::new(),
+            children: Vec::new(),
+        }
+    }
+
+    /// Adds new token to the current branch.
+    #[inline]
+    pub fn token(&mut self, kind: SyntaxKind, text: SmolStr) {
+        let token = self.cache.token(kind, text);
+        self.children.push(token.into());
+    }
+
+    /// Start new node and make it current.
+    #[inline]
+    pub fn start_node(&mut self, kind: SyntaxKind) {
+        let len = self.children.len();
+        self.parents.push((kind, len));
+    }
+
+    /// Finish current branch and restore previous
+    /// branch as current.
+    #[inline]
+    pub fn finish_node(&mut self) {
+        let (kind, first_child) = self.parents.pop().unwrap();
+        let children = self.children.drain(first_child..);
+        let node = self.cache.node(kind, children);
+        self.children.push(node.into());
+    }
+
+    /// Prepare for maybe wrapping the next node.
+    /// The way wrapping works is that you first of all get a checkpoint,
+    /// then you place all tokens you want to wrap, and then *maybe* call
+    /// `start_node_at`.
+    /// Example:
+    /// ```rust
+    /// # use rowan::{GreenNodeBuilder, SyntaxKind};
+    /// # const PLUS: SyntaxKind = SyntaxKind(0);
+    /// # const OPERATION: SyntaxKind = SyntaxKind(1);
+    /// # struct Parser;
+    /// # impl Parser {
+    /// #     fn peek(&self) -> Option<SyntaxKind> { None }
+    /// #     fn parse_expr(&mut self) {}
+    /// # }
+    /// # let mut builder = GreenNodeBuilder::new();
+    /// # let mut parser = Parser;
+    /// let checkpoint = builder.checkpoint();
+    /// parser.parse_expr();
+    /// if parser.peek() == Some(PLUS) {
+    ///   // 1 + 2 = Add(1, 2)
+    ///   builder.start_node_at(checkpoint, OPERATION);
+    ///   parser.parse_expr();
+    ///   builder.finish_node();
+    /// }
+    /// ```
+    #[inline]
+    pub fn checkpoint(&self) -> Checkpoint {
+        Checkpoint(self.children.len())
+    }
+
+    /// Wrap the previous branch marked by `checkpoint` in a new branch and
+    /// make it current.
+    #[inline]
+    pub fn start_node_at(&mut self, checkpoint: Checkpoint, kind: SyntaxKind) {
+        let Checkpoint(checkpoint) = checkpoint;
+        assert!(
+            checkpoint <= self.children.len(),
+            "checkpoint no longer valid, was finish_node called early?"
+        );
+
+        if let Some(&(_, first_child)) = self.parents.last() {
+            assert!(
+                checkpoint >= first_child,
+                "checkpoint no longer valid, was an unmatched start_node_at called?"
+            );
+        }
+
+        self.parents.push((kind, checkpoint));
+    }
+
+    /// Complete tree building. Make sure that
+    /// `start_node_at` and `finish_node` calls
+    /// are paired!
+    #[inline]
+    pub fn finish(mut self) -> GreenNode {
+        assert_eq!(self.children.len(), 1);
+        match self.children.pop().unwrap() {
+            NodeOrToken::Node(node) => node,
+            NodeOrToken::Token(_) => panic!(),
+        }
+    }
+}

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -120,6 +120,7 @@ impl Token {
     }
 }
 
+#[cfg(feature = "cst")]
 impl From<SyntaxKind> for rowan::SyntaxKind {
     fn from(kind: SyntaxKind) -> Self {
         Self(kind as u16)
@@ -128,6 +129,7 @@ impl From<SyntaxKind> for rowan::SyntaxKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Lang {}
+#[cfg(feature = "cst")]
 impl rowan::Language for Lang {
     type Kind = SyntaxKind;
     fn kind_from_raw(raw: rowan::SyntaxKind) -> Self::Kind {
@@ -139,4 +141,5 @@ impl rowan::Language for Lang {
     }
 }
 
+#[cfg(feature = "cst")]
 pub type SyntaxNode = rowan::SyntaxNode<Lang>;

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -1,0 +1,142 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A lossless syntax tree that preserves the full fidelity of the source text,
+//! including whitespace.
+//!
+//! We refer to it as a CST, short for Concrete Syntax Tree, in order to
+//! contrast it with an AST, although it's not a grammar-based parse tree.
+//!
+//! The design is based on rust-analyzer's
+//! https://github.com/rust-analyzer/rust-analyzer/blob/2020-04-27/docs/dev/syntax.md
+//! The RA folks generously made their syntax tree implementation available as the
+//! `rowan` crate, which we re-use.
+use crate::tokenizer::Token;
+
+/// Each node of the CST has a "kind", a variant from this enum representing
+/// its type.
+///
+/// There are separate kinds for leaf nodes (tokens, such as "whitespace"
+/// or "number") and non-leafs, such as "expresssion", but they are not
+/// distinguished at the type level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[allow(non_camel_case_types)]
+#[repr(u16)]
+#[rustfmt::skip]
+pub enum SyntaxKind {
+    // First, the variants from the `Token` enum.
+
+    // Note: we rely on the token "kinds" having the same internal `u16`
+    // representation as the `Token` enum, meaning the number and the
+    // order of these must match the `Token` enum exactly.
+
+    // TBD: change `Token` to be a `(SyntaxKind, SmolStr)`.
+
+    /// A keyword (like SELECT) or an optionally quoted SQL identifier
+    Word = 0,
+    /// An unsigned numeric literal
+    Number,
+    /// A character that could not be tokenized
+    Char,
+    /// Single quoted string: i.e: 'string'
+    SingleQuotedString,
+    /// "National" string literal: i.e: N'string'
+    NationalStringLiteral,
+    /// Hexadecimal string literal: i.e.: X'deadbeef'
+    HexStringLiteral,
+    /// Comma
+    Comma,
+    /// Whitespace (space, tab, etc)
+    Whitespace,
+    /// Equality operator `=`
+    Eq,
+    /// Not Equals operator `<>` (or `!=` in some dialects)
+    Neq,
+    /// Less Than operator `<`
+    Lt,
+    /// Greater han operator `>`
+    Gt,
+    /// Less Than Or Equals operator `<=`
+    LtEq,
+    /// Greater Than Or Equals operator `>=`
+    GtEq,
+    /// Plus operator `+`
+    Plus,
+    /// Minus operator `-`
+    Minus,
+    /// Multiplication operator `*`
+    Mult,
+    /// Division operator `/`
+    Div,
+    /// Modulo Operator `%`
+    Mod,
+    /// Left parenthesis `(`
+    LParen,
+    /// Right parenthesis `)`
+    RParen,
+    /// Period (used for compound identifiers or projections into nested types)
+    Period,
+    /// Colon `:`
+    Colon,
+    /// DoubleColon `::` (used for casting in postgresql)
+    DoubleColon,
+    /// SemiColon `;` used as separator for COPY and payload
+    SemiColon,
+    /// Backslash `\` used in terminating the COPY payload with `\.`
+    Backslash,
+    /// Left bracket `[`
+    LBracket,
+    /// Right bracket `]`
+    RBracket,
+    /// Ampersand &
+    Ampersand,
+    /// Left brace `{`
+    LBrace,
+    /// Right brace `}`
+    RBrace,
+
+    // Other kinds representing non-leaf nodes in the Syntax tree.
+    ROOT,
+    ERR,
+    KW,
+
+    // Sentinel value
+    LAST
+}
+
+impl Token {
+    pub fn kind(&self) -> SyntaxKind {
+        // From https://github.com/rust-lang/rfcs/blob/master/text/2363-arbitrary-enum-discriminant.md
+        unsafe { *(self as *const Self as *const SyntaxKind) }
+    }
+}
+
+impl From<SyntaxKind> for rowan::SyntaxKind {
+    fn from(kind: SyntaxKind) -> Self {
+        Self(kind as u16)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Lang {}
+impl rowan::Language for Lang {
+    type Kind = SyntaxKind;
+    fn kind_from_raw(raw: rowan::SyntaxKind) -> Self::Kind {
+        assert!(raw.0 <= SyntaxKind::LAST as u16);
+        unsafe { std::mem::transmute::<u16, SyntaxKind>(raw.0) }
+    }
+    fn kind_to_raw(kind: Self::Kind) -> rowan::SyntaxKind {
+        kind.into()
+    }
+}
+
+pub type SyntaxNode = rowan::SyntaxNode<Lang>;

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -108,6 +108,25 @@ pub enum SyntaxKind {
     ROOT,
     ERR,
     KW,
+    IDENT,
+    OBJECT_NAME,
+    QUERY,
+        CTES,
+        BODY,
+        SELECT,
+            PROJECTION,
+            SELECT_ITEM_WILDCARD, SELECT_ITEM_QWILDCARD, SELECT_ITEM_EXPR_WITH_ALIAS, SELECT_ITEM_UNNAMED,
+            FROM,
+            WHERE,
+        ORDER_BY,
+
+        JoinConstraint__On, JoinConstraint__Using,
+
+    EXPR_PREFIX, // TBD
+    EXPR,
+    EXPR_NESTED,
+    EXPR_SUBQUERY,
+    BIN_EXPR,
 
     // Sentinel value
     LAST

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 #![warn(clippy::all)]
 
 pub mod ast;
+mod builder;
 pub mod cst;
 pub mod dialect;
 pub mod parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 #![warn(clippy::all)]
 
 pub mod ast;
+#[cfg(feature = "cst")]
 mod builder;
 pub mod cst;
 pub mod dialect;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 #![warn(clippy::all)]
 
 pub mod ast;
+pub mod cst;
 pub mod dialect;
 pub mod parser;
 pub mod tokenizer;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,6 +21,7 @@ use super::tokenizer::*;
 use std::error::Error;
 use std::fmt;
 
+use crate::builder;
 use crate::{cst, cst::SyntaxKind as SK};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -40,7 +41,7 @@ macro_rules! parser_err {
 pub struct Marker {
     /// position in the token stream (`parser.index`)
     index: usize,
-    builder_checkpoint: rowan::Checkpoint,
+    builder_checkpoint: builder::Checkpoint,
 }
 
 #[derive(PartialEq)]
@@ -82,7 +83,7 @@ pub struct Parser {
     tokens: Vec<Token>,
     /// The index of the first unprocessed token in `self.tokens`
     index: usize,
-    builder: rowan::GreenNodeBuilder<'static>,
+    builder: builder::GreenNodeBuilder<'static>,
 
     // TBD: the parser currently provides an API to move around the token
     // stream without restrictions (`next_token`/`prev_token`), while the
@@ -114,7 +115,7 @@ impl Parser {
         let mut parser = Parser {
             tokens,
             index: 0,
-            builder: rowan::GreenNodeBuilder::new(),
+            builder: builder::GreenNodeBuilder::new(),
             pending: vec![],
         };
         parser.builder.start_node(SK::ROOT.into());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -827,7 +827,7 @@ impl Parser {
     pub fn reset(&mut self, m: Marker) {
         self.index = m.index;
         self.pending.truncate(0);
-        // TBD: rowan's builder does not allow reverting to a checkpoint
+        self.builder.reset(m.builder_checkpoint);
     }
 
     pub fn complete<T>(&mut self, m: Marker, kind: cst::SyntaxKind, rv: T) -> T {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -86,22 +86,26 @@ impl Parser {
         let mut tokenizer = Tokenizer::new(dialect, &sql);
         let tokens = tokenizer.tokenize()?;
         let mut parser = Parser::new(tokens);
+        parser.parse_statements()
+    }
+
+    /// Parse zero or more SQL statements delimited with semicolon.
+    pub fn parse_statements(&mut self) -> Result<Vec<Statement>, ParserError> {
         let mut stmts = Vec::new();
         let mut expecting_statement_delimiter = false;
-        debug!("Parsing sql '{}'...", sql);
         loop {
             // ignore empty statements (between successive statement delimiters)
-            while parser.consume_token(&Token::SemiColon) {
+            while self.consume_token(&Token::SemiColon) {
                 expecting_statement_delimiter = false;
             }
 
-            if parser.peek_token().is_none() {
+            if self.peek_token().is_none() {
                 break;
             } else if expecting_statement_delimiter {
-                return parser.expected("end of statement", parser.peek_token());
+                return self.expected("end of statement", self.peek_token());
             }
 
-            let statement = parser.parse_statement()?;
+            let statement = self.parse_statement()?;
             stmts.push(statement);
             expecting_statement_delimiter = true;
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -360,12 +360,12 @@ impl Parser {
             operand = Some(Box::new(self.parse_expr()?));
             self.expect_keyword("WHEN")?;
         }
-        let mut conditions = vec![];
-        let mut results = vec![];
+        let mut when_clauses = vec![];
         loop {
-            conditions.push(self.parse_expr()?);
+            let condition = self.parse_expr()?;
             self.expect_keyword("THEN")?;
-            results.push(self.parse_expr()?);
+            let result = self.parse_expr()?;
+            when_clauses.push(WhenClause { condition, result });
             if !self.parse_keyword("WHEN") {
                 break;
             }
@@ -378,8 +378,7 @@ impl Parser {
         self.expect_keyword("END")?;
         Ok(Expr::Case {
             operand,
-            conditions,
-            results,
+            when_clauses,
             else_result,
         })
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -24,7 +24,10 @@ use super::dialect::Dialect;
 use std::fmt;
 
 /// SQL Token enumeration
+///
+/// N.B.! keep in sync with `SyntaxKind`.
 #[derive(Debug, Clone, PartialEq)]
+#[repr(u16)]
 pub enum Token {
     /// A keyword (like SELECT) or an optionally quoted SQL identifier
     Word(Word),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -413,6 +413,7 @@ fn parse_null_in_select() {
 }
 
 #[test]
+#[ignore = r#"TBD: Token::SingleQuotedString("foo''bar").to_string() does not round-trip"#]
 fn parse_escaped_single_quote_string_predicate() {
     use self::BinaryOperator::*;
     let sql = "SELECT id, fname, lname FROM customer \
@@ -1401,6 +1402,7 @@ fn parse_literal_decimal() {
 }
 
 #[test]
+#[ignore = r#"TBD: Token::HexStringLiteral("deadBEEF").to_string() does not round-trip"#]
 fn parse_literal_string() {
     let sql = "SELECT 'one', N'national string', X'deadBEEF'";
     let select = verified_only_select(sql);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1942,7 +1942,6 @@ fn parse_complex_join() {
 }
 
 #[test]
-#[ignore = "TBD (fixed in a later commit): backtracking"]
 fn parse_join_nesting() {
     fn table(name: impl Into<String>) -> TableFactor {
         TableFactor::Table {
@@ -2110,7 +2109,6 @@ fn parse_cte_renamed_columns() {
 }
 
 #[test]
-#[ignore = "TBD (fixed in a later commit): backtracking"]
 fn parse_derived_tables() {
     let sql = "SELECT a.x, b.y FROM (SELECT x FROM foo) AS a CROSS JOIN (SELECT y FROM bar) AS b";
     let _ = verified_only_select(sql);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1641,23 +1641,27 @@ fn parse_searched_case_expr() {
     assert_eq!(
         &Case {
             operand: None,
-            conditions: vec![
-                IsNull(Box::new(Identifier(Ident::new("bar")))),
-                BinaryOp {
-                    left: Box::new(Identifier(Ident::new("bar"))),
-                    op: Eq,
-                    right: Box::new(Expr::Value(number("0")))
+            when_clauses: vec![
+                WhenClause {
+                    condition: IsNull(Box::new(Identifier(Ident::new("bar")))),
+                    result: Expr::Value(Value::SingleQuotedString("null".to_string())),
                 },
-                BinaryOp {
-                    left: Box::new(Identifier(Ident::new("bar"))),
-                    op: GtEq,
-                    right: Box::new(Expr::Value(number("0")))
-                }
-            ],
-            results: vec![
-                Expr::Value(Value::SingleQuotedString("null".to_string())),
-                Expr::Value(Value::SingleQuotedString("=0".to_string())),
-                Expr::Value(Value::SingleQuotedString(">=0".to_string()))
+                WhenClause {
+                    condition: BinaryOp {
+                        left: Box::new(Identifier(Ident::new("bar"))),
+                        op: Eq,
+                        right: Box::new(Expr::Value(number("0")))
+                    },
+                    result: Expr::Value(Value::SingleQuotedString("=0".to_string())),
+                },
+                WhenClause {
+                    condition: BinaryOp {
+                        left: Box::new(Identifier(Ident::new("bar"))),
+                        op: GtEq,
+                        right: Box::new(Expr::Value(number("0")))
+                    },
+                    result: Expr::Value(Value::SingleQuotedString(">=0".to_string())),
+                },
             ],
             else_result: Some(Box::new(Expr::Value(Value::SingleQuotedString(
                 "<0".to_string()
@@ -1676,8 +1680,10 @@ fn parse_simple_case_expr() {
     assert_eq!(
         &Case {
             operand: Some(Box::new(Identifier(Ident::new("foo")))),
-            conditions: vec![Expr::Value(number("1"))],
-            results: vec![Expr::Value(Value::SingleQuotedString("Y".to_string())),],
+            when_clauses: vec![WhenClause {
+                condition: Expr::Value(number("1")),
+                result: Expr::Value(Value::SingleQuotedString("Y".to_string())),
+            }],
             else_result: Some(Box::new(Expr::Value(Value::SingleQuotedString(
                 "N".to_string()
             ))))

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1940,6 +1940,7 @@ fn parse_complex_join() {
 }
 
 #[test]
+#[ignore = "TBD (fixed in a later commit): backtracking"]
 fn parse_join_nesting() {
     fn table(name: impl Into<String>) -> TableFactor {
         TableFactor::Table {
@@ -2107,6 +2108,7 @@ fn parse_cte_renamed_columns() {
 }
 
 #[test]
+#[ignore = "TBD (fixed in a later commit): backtracking"]
 fn parse_derived_tables() {
     let sql = "SELECT a.x, b.y FROM (SELECT x FROM foo) AS a CROSS JOIN (SELECT y FROM bar) AS b";
     let _ = verified_only_select(sql);

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -251,6 +251,7 @@ fn parse_create_table_if_not_exists() {
 }
 
 #[test]
+#[ignore = "TBD (fixed in a later commit): backtracking"]
 fn parse_bad_if_not_exists() {
     let res = pg().parse_sql_statements("CREATE TABLE NOT EXISTS uk_cities ()");
     assert_eq!(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -251,7 +251,6 @@ fn parse_create_table_if_not_exists() {
 }
 
 #[test]
-#[ignore = "TBD (fixed in a later commit): backtracking"]
 fn parse_bad_if_not_exists() {
     let res = pg().parse_sql_statements("CREATE TABLE NOT EXISTS uk_cities ()");
     assert_eq!(

--- a/util/ast-fields.tsv
+++ b/util/ast-fields.tsv
@@ -1,0 +1,226 @@
+struct_name	enum_name	variant_name	field_name	field_type
+ColumnDef			name	Ident
+ColumnDef			data_type	DataType
+ColumnDef			collation	Option<ObjectName>
+ColumnDef			options	Vec<ColumnOptionDef>
+ColumnOptionDef			name	Option<Ident>
+ColumnOptionDef			option	ColumnOption
+Ident			value	String
+Ident			quote_style	Option<char>
+ObjectName			unnamed	Vec<Ident>
+WhenClause			condition	Expr
+WhenClause			result	Expr
+WindowSpec			partition_by	Vec<Expr>
+WindowSpec			order_by	Vec<OrderByExpr>
+WindowSpec			window_frame	Option<WindowFrame>
+WindowFrame			units	WindowFrameUnits
+WindowFrame			start_bound	WindowFrameBound
+WindowFrame			end_bound	Option<WindowFrameBound>
+Assignment			id	Ident
+Assignment			value	Expr
+Function			name	ObjectName
+Function			args	Vec<Expr>
+Function			over	Option<WindowSpec>
+Function			distinct	bool
+ListAgg			distinct	bool
+ListAgg			expr	Box<Expr>
+ListAgg			separator	Option<Box<Expr>>
+ListAgg			on_overflow	Option<ListAggOnOverflow>
+ListAgg			within_group	Vec<OrderByExpr>
+SqlOption			name	Ident
+SqlOption			value	Value
+Query			ctes	Vec<Cte>
+Query			body	SetExpr
+Query			order_by	Vec<OrderByExpr>
+Query			limit	Option<Expr>
+Query			offset	Option<Offset>
+Query			fetch	Option<Fetch>
+Select			distinct	bool
+Select			top	Option<Top>
+Select			projection	Vec<SelectItem>
+Select			from	Vec<TableWithJoins>
+Select			selection	Option<Expr>
+Select			group_by	Vec<Expr>
+Select			having	Option<Expr>
+Cte			alias	TableAlias
+Cte			query	Query
+TableWithJoins			relation	TableFactor
+TableWithJoins			joins	Vec<Join>
+TableAlias			name	Ident
+TableAlias			columns	Vec<Ident>
+Join			relation	TableFactor
+Join			join_operator	JoinOperator
+OrderByExpr			expr	Expr
+OrderByExpr			asc	Option<bool>
+OrderByExpr			nulls_first	Option<bool>
+Offset			value	Expr
+Offset			rows	OffsetRows
+Fetch			with_ties	bool
+Fetch			percent	bool
+Fetch			quantity	Option<Expr>
+Top			with_ties	bool
+Top			percent	bool
+Top			quantity	Option<Expr>
+Values			unnamed	Vec<Vec<Expr>>
+DataType::Char	DataType	Char	unnamed	Option<u64>
+DataType::Varchar	DataType	Varchar	unnamed	Option<u64>
+DataType::Clob	DataType	Clob	unnamed	u64
+DataType::Binary	DataType	Binary	unnamed	u64
+DataType::Varbinary	DataType	Varbinary	unnamed	u64
+DataType::Blob	DataType	Blob	unnamed	u64
+DataType::Decimal	DataType	Decimal	unnamed	Option<u64>
+DataType::Decimal	DataType	Decimal	unnamed	Option<u64>
+DataType::Float	DataType	Float	unnamed	Option<u64>
+DataType::Custom	DataType	Custom	unnamed	ObjectName
+DataType::Array	DataType	Array	unnamed	Box<DataType>
+AlterTableOperation::AddConstraint	AlterTableOperation	AddConstraint	unnamed	TableConstraint
+AlterTableOperation::DropConstraint	AlterTableOperation	DropConstraint	name	Ident
+TableConstraint::Unique	TableConstraint	Unique	name	Option<Ident>
+TableConstraint::Unique	TableConstraint	Unique	columns	Vec<Ident>
+TableConstraint::Unique	TableConstraint	Unique	is_primary	bool
+TableConstraint::ForeignKey	TableConstraint	ForeignKey	name	Option<Ident>
+TableConstraint::ForeignKey	TableConstraint	ForeignKey	columns	Vec<Ident>
+TableConstraint::ForeignKey	TableConstraint	ForeignKey	foreign_table	ObjectName
+TableConstraint::ForeignKey	TableConstraint	ForeignKey	referred_columns	Vec<Ident>
+TableConstraint::Check	TableConstraint	Check	name	Option<Ident>
+TableConstraint::Check	TableConstraint	Check	expr	Box<Expr>
+ColumnOption::Default	ColumnOption	Default	unnamed	Expr
+ColumnOption::Unique	ColumnOption	Unique	is_primary	bool
+ColumnOption::ForeignKey	ColumnOption	ForeignKey	foreign_table	ObjectName
+ColumnOption::ForeignKey	ColumnOption	ForeignKey	referred_columns	Vec<Ident>
+ColumnOption::ForeignKey	ColumnOption	ForeignKey	on_delete	Option<ReferentialAction>
+ColumnOption::ForeignKey	ColumnOption	ForeignKey	on_update	Option<ReferentialAction>
+ColumnOption::Check	ColumnOption	Check	unnamed	Expr
+Expr::Identifier	Expr	Identifier	unnamed	Ident
+Expr::QualifiedWildcard	Expr	QualifiedWildcard	unnamed	Vec<Ident>
+Expr::CompoundIdentifier	Expr	CompoundIdentifier	unnamed	Vec<Ident>
+Expr::IsNull	Expr	IsNull	unnamed	Box<Expr>
+Expr::IsNotNull	Expr	IsNotNull	unnamed	Box<Expr>
+Expr::InList	Expr	InList	expr	Box<Expr>
+Expr::InList	Expr	InList	list	Vec<Expr>
+Expr::InList	Expr	InList	negated	bool
+Expr::InSubquery	Expr	InSubquery	expr	Box<Expr>
+Expr::InSubquery	Expr	InSubquery	subquery	Box<Query>
+Expr::InSubquery	Expr	InSubquery	negated	bool
+Expr::Between	Expr	Between	expr	Box<Expr>
+Expr::Between	Expr	Between	negated	bool
+Expr::Between	Expr	Between	low	Box<Expr>
+Expr::Between	Expr	Between	high	Box<Expr>
+Expr::BinaryOp	Expr	BinaryOp	left	Box<Expr>
+Expr::BinaryOp	Expr	BinaryOp	op	BinaryOperator
+Expr::BinaryOp	Expr	BinaryOp	right	Box<Expr>
+Expr::UnaryOp	Expr	UnaryOp	op	UnaryOperator
+Expr::UnaryOp	Expr	UnaryOp	expr	Box<Expr>
+Expr::Cast	Expr	Cast	expr	Box<Expr>
+Expr::Cast	Expr	Cast	data_type	DataType
+Expr::Extract	Expr	Extract	field	DateTimeField
+Expr::Extract	Expr	Extract	expr	Box<Expr>
+Expr::Collate	Expr	Collate	expr	Box<Expr>
+Expr::Collate	Expr	Collate	collation	ObjectName
+Expr::Nested	Expr	Nested	unnamed	Box<Expr>
+Expr::Value	Expr	Value	unnamed	Value
+Expr::Function	Expr	Function	unnamed	Function
+Expr::Case	Expr	Case	operand	Option<Box<Expr>>
+Expr::Case	Expr	Case	when_clauses	Vec<WhenClause>
+Expr::Case	Expr	Case	else_result	Option<Box<Expr>>
+Expr::Exists	Expr	Exists	unnamed	Box<Query>
+Expr::Subquery	Expr	Subquery	unnamed	Box<Query>
+Expr::ListAgg	Expr	ListAgg	unnamed	ListAgg
+WindowFrameBound::Preceding	WindowFrameBound	Preceding	unnamed	Option<u64>
+WindowFrameBound::Following	WindowFrameBound	Following	unnamed	Option<u64>
+Statement::Query	Statement	Query	unnamed	Box<Query>
+Statement::Insert	Statement	Insert	table_name	ObjectName
+Statement::Insert	Statement	Insert	columns	Vec<Ident>
+Statement::Insert	Statement	Insert	source	Box<Query>
+Statement::Copy	Statement	Copy	table_name	ObjectName
+Statement::Copy	Statement	Copy	columns	Vec<Ident>
+Statement::Copy	Statement	Copy	values	Vec<Option<String>>
+Statement::Update	Statement	Update	table_name	ObjectName
+Statement::Update	Statement	Update	assignments	Vec<Assignment>
+Statement::Update	Statement	Update	selection	Option<Expr>
+Statement::Delete	Statement	Delete	table_name	ObjectName
+Statement::Delete	Statement	Delete	selection	Option<Expr>
+Statement::CreateView	Statement	CreateView	name	ObjectName
+Statement::CreateView	Statement	CreateView	columns	Vec<Ident>
+Statement::CreateView	Statement	CreateView	query	Box<Query>
+Statement::CreateView	Statement	CreateView	materialized	bool
+Statement::CreateView	Statement	CreateView	with_options	Vec<SqlOption>
+Statement::CreateTable	Statement	CreateTable	name	ObjectName
+Statement::CreateTable	Statement	CreateTable	columns	Vec<ColumnDef>
+Statement::CreateTable	Statement	CreateTable	constraints	Vec<TableConstraint>
+Statement::CreateTable	Statement	CreateTable	with_options	Vec<SqlOption>
+Statement::CreateTable	Statement	CreateTable	if_not_exists	bool
+Statement::CreateTable	Statement	CreateTable	external	bool
+Statement::CreateTable	Statement	CreateTable	file_format	Option<FileFormat>
+Statement::CreateTable	Statement	CreateTable	location	Option<String>
+Statement::CreateIndex	Statement	CreateIndex	name	ObjectName
+Statement::CreateIndex	Statement	CreateIndex	table_name	ObjectName
+Statement::CreateIndex	Statement	CreateIndex	columns	Vec<Ident>
+Statement::CreateIndex	Statement	CreateIndex	unique	bool
+Statement::CreateIndex	Statement	CreateIndex	if_not_exists	bool
+Statement::AlterTable	Statement	AlterTable	name	ObjectName
+Statement::AlterTable	Statement	AlterTable	operation	AlterTableOperation
+Statement::Drop	Statement	Drop	object_type	ObjectType
+Statement::Drop	Statement	Drop	if_exists	bool
+Statement::Drop	Statement	Drop	names	Vec<ObjectName>
+Statement::Drop	Statement	Drop	cascade	bool
+Statement::SetVariable	Statement	SetVariable	local	bool
+Statement::SetVariable	Statement	SetVariable	variable	Ident
+Statement::SetVariable	Statement	SetVariable	value	SetVariableValue
+Statement::ShowVariable	Statement	ShowVariable	variable	Ident
+Statement::ShowColumns	Statement	ShowColumns	extended	bool
+Statement::ShowColumns	Statement	ShowColumns	full	bool
+Statement::ShowColumns	Statement	ShowColumns	table_name	ObjectName
+Statement::ShowColumns	Statement	ShowColumns	filter	Option<ShowStatementFilter>
+Statement::StartTransaction	Statement	StartTransaction	modes	Vec<TransactionMode>
+Statement::SetTransaction	Statement	SetTransaction	modes	Vec<TransactionMode>
+Statement::Commit	Statement	Commit	chain	bool
+Statement::Rollback	Statement	Rollback	chain	bool
+Statement::CreateSchema	Statement	CreateSchema	schema_name	ObjectName
+ListAggOnOverflow::Truncate	ListAggOnOverflow	Truncate	filler	Option<Box<Expr>>
+ListAggOnOverflow::Truncate	ListAggOnOverflow	Truncate	with_count	bool
+TransactionMode::AccessMode	TransactionMode	AccessMode	unnamed	TransactionAccessMode
+TransactionMode::IsolationLevel	TransactionMode	IsolationLevel	unnamed	TransactionIsolationLevel
+ShowStatementFilter::Like	ShowStatementFilter	Like	unnamed	String
+ShowStatementFilter::Where	ShowStatementFilter	Where	unnamed	Expr
+SetVariableValue::Ident	SetVariableValue	Ident	unnamed	Ident
+SetVariableValue::Literal	SetVariableValue	Literal	unnamed	Value
+SetExpr::Select	SetExpr	Select	unnamed	Box<Select>
+SetExpr::Query	SetExpr	Query	unnamed	Box<Query>
+SetExpr::SetOperation	SetExpr	SetOperation	op	SetOperator
+SetExpr::SetOperation	SetExpr	SetOperation	all	bool
+SetExpr::SetOperation	SetExpr	SetOperation	left	Box<SetExpr>
+SetExpr::SetOperation	SetExpr	SetOperation	right	Box<SetExpr>
+SetExpr::Values	SetExpr	Values	unnamed	Values
+SelectItem::UnnamedExpr	SelectItem	UnnamedExpr	unnamed	Expr
+SelectItem::ExprWithAlias	SelectItem	ExprWithAlias	expr	Expr
+SelectItem::ExprWithAlias	SelectItem	ExprWithAlias	alias	Ident
+SelectItem::QualifiedWildcard	SelectItem	QualifiedWildcard	unnamed	ObjectName
+TableFactor::Table	TableFactor	Table	name	ObjectName
+TableFactor::Table	TableFactor	Table	alias	Option<TableAlias>
+TableFactor::Table	TableFactor	Table	args	Vec<Expr>
+TableFactor::Table	TableFactor	Table	with_hints	Vec<Expr>
+TableFactor::Derived	TableFactor	Derived	lateral	bool
+TableFactor::Derived	TableFactor	Derived	subquery	Box<Query>
+TableFactor::Derived	TableFactor	Derived	alias	Option<TableAlias>
+TableFactor::NestedJoin	TableFactor	NestedJoin	unnamed	Box<TableWithJoins>
+JoinOperator::Inner	JoinOperator	Inner	unnamed	JoinConstraint
+JoinOperator::LeftOuter	JoinOperator	LeftOuter	unnamed	JoinConstraint
+JoinOperator::RightOuter	JoinOperator	RightOuter	unnamed	JoinConstraint
+JoinOperator::FullOuter	JoinOperator	FullOuter	unnamed	JoinConstraint
+JoinConstraint::On	JoinConstraint	On	unnamed	Expr
+JoinConstraint::Using	JoinConstraint	Using	unnamed	Vec<Ident>
+Value::Number	Value	Number	unnamed	String
+Value::Number	Value	Number	unnamed	BigDecimal
+Value::SingleQuotedString	Value	SingleQuotedString	unnamed	String
+Value::NationalStringLiteral	Value	NationalStringLiteral	unnamed	String
+Value::HexStringLiteral	Value	HexStringLiteral	unnamed	String
+Value::Boolean	Value	Boolean	unnamed	bool
+Value::Date	Value	Date	unnamed	String
+Value::Time	Value	Time	unnamed	String
+Value::Timestamp	Value	Timestamp	unnamed	String
+Value::Interval	Value	Interval	value	String
+Value::Interval	Value	Interval	leading_field	DateTimeField
+Value::Interval	Value	Interval	leading_precision	Option<u64>
+Value::Interval	Value	Interval	last_field	Option<DateTimeField>
+Value::Interval	Value	Interval	fractional_seconds_precision	Option<u64>

--- a/util/ast-stats.js
+++ b/util/ast-stats.js
@@ -1,0 +1,103 @@
+// Getting this out of the source code is currently a manual process:
+// 1) Run `egrep -hv "//!" src/ast/*.rs > mods`
+//         this is required, because astexplorer's parser doesn't like the `//!` parent doc-comments
+// 2) Paste the results into https://astexplorer.net/ (select the Rust mode)
+// 3) Copy the AST data back to `const json =`
+// 4) Copy the source code to `srcText`,  escaping backslashes (`\` -> `\\`) and backticks ` -> \`
+// 5) Run:    node util/ast-stats.js > util/ast-fields.tsv
+
+const {srcText, json} = require("./real-data.js");
+// const {srcText, json} = require("./test-data.js");
+
+/** Walk the JSON object representing the AST depth-first, calling `visitor` on each "complex" node. */
+function walk(ast, path, visitor) {
+    ast.path = path;
+
+    if (!visitor(ast)) return;
+    const nodeName = (ast instanceof Array ? "Array" : ast["_type"]);
+    // console.log(`@${path}: ${nodeName} ${ast.toString().substring(1,20)}`)
+    for (var prop in ast) {
+        if (ast[prop] instanceof Object) {
+            walk(ast[prop], (path ? path + "/" : "") + nodeName, visitor);
+        }
+    }
+}
+
+/** Return all AST objects matching the predicate in an array.
+    Note: for nested objects only the top-most one is included in the results */
+function find(ast, filterFn) {
+    let rv = [];
+    walk(ast, "", node => {
+        if (filterFn(node)) {
+            rv.push(node);
+            return false;
+        }
+        return true;
+    });
+    return rv;
+}
+
+/** Return string in the given span of the text.
+ * A span is an `{start: LC, end: LC}` object, where
+ * LC is {line, column} sub-objects with 1-based positions, inclusive.
+ */
+function src(text, span) {
+    const lineLengths = text.split("\n").map(line => line.length);
+    function pos2idx(pos) {
+        let idx = 0;
+        for (let i = 0; i < pos.line-1; ++i) {
+            idx += lineLengths[i] + 1;
+        }
+        idx += pos.column;
+        //console.log(`pos2idx(${pos.line}, ${pos.column}) = ${idx}`)
+        return idx;
+    }
+    return text.substring(pos2idx(span.start), pos2idx(span.end))
+}
+
+// let spans = find(json, (node) => node._type == "Field").map(node => node.span);
+// console.log(src(srcText, spans[0]));
+
+/** A predicate to filter declarations preceded by a set of #[derive]s used for AST structs/enums */
+function filterAST(structOrEnum) {
+    const attrs = structOrEnum.attrs.map(attr => src(srcText, attr.span));
+    const isAST = attrs.some(a => a == "#[derive(Debug, Clone, PartialEq, Eq, Hash)]");
+    //console.log(structOrEnum.ident.to_string, isAST, isAST ? "" : attrs)
+    return isAST;
+}
+
+
+const structs = find(json, n => n._type == "ItemStruct").filter(filterAST);
+const enums = find(json, n => n._type == "ItemEnum").filter(filterAST);
+
+const enumVariants = enums.flatMap(enum_ => {
+    const enum_name = enum_.ident.to_string;
+    return find(enum_, n => n._type == "Variant").map(variant => ({
+        struct_name: `${enum_name}::${variant.ident.to_string}`,
+        enum_name: enum_name,
+        variant_name: variant.ident.to_string,
+        node: variant
+    }));
+});
+
+const structsAndEnumVariants = structs.map(struct => ({
+    struct_name: struct.ident.to_string,
+    enum_name: "", variant_name: "",
+    node: struct
+})).concat(enumVariants);
+
+let fields = structsAndEnumVariants.flatMap(item => {
+    return find(item, (n) => n._type == "Field").map(field => ({
+        struct_name: item.struct_name,
+        enum_name: item.enum_name, variant_name: item.variant_name,
+        field_name: field.ident ? field.ident.to_string : "unnamed",  // e.g. (Bar, Baz)
+        field_type: src(srcText, field.ty.span)
+    }));
+});
+
+const FIELDS = ["struct_name", "enum_name", "variant_name", "field_name", "field_type"];
+console.log(FIELDS.join("\t"));
+console.log(fields.map(row => FIELDS.map(col => row[col]).join("\t")).join("\n"));
+// console.log(fields);
+
+//console.log(src(srcText, {start:{line:1135, column:12}, end: {line:1135, column:17}}));

--- a/util/test-data.js
+++ b/util/test-data.js
@@ -1,0 +1,3068 @@
+const srcText = `#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Query {
+    /// WITH (common table expressions, or CTEs)
+    pub ctes: Vec<Cte>,
+    /// SELECT or UNION / EXCEPT / INTECEPT
+    pub body: SetExpr,
+    /// ORDER BY
+    pub order_by: Vec<OrderByExpr>,
+    /// \`LIMIT { <N> | ALL }\`
+    pub limit: Option<Expr>,
+    /// \`OFFSET <N> [ {ROW | ROWS} ]\`
+    pub offset: Option<Offset>,
+    /// \`FETCH {FIRST | NEXT} <N> [ PERCENT ] {ROW | ROWS} | {ONLY | WITH TIES }\`
+    pub fetch: Option<Fetch>,
+}`
+
+const json = {
+  "_type": "File",
+  "attrs": [],
+  "items": [
+    {
+      "_type": "ItemStruct",
+      "attrs": [
+        {
+          "_type": "Attribute",
+          "pound_token": {
+            "_type": "Pound",
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 1,
+                "column": 1
+              }
+            }
+          },
+          "style": {
+            "_type": "AttrStyle::Outer"
+          },
+          "path": {
+            "_type": "Path",
+            "segments": {
+              "0": {
+                "_type": "PathSegment",
+                "ident": {
+                  "_type": "Ident",
+                  "to_string": "derive",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 2
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 8
+                    }
+                  }
+                },
+                "arguments": {
+                  "_type": "PathArguments::None"
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 1,
+                    "column": 2
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 1,
+                    "column": 8
+                  }
+                }
+              },
+              "_type": "Punctuated",
+              "length": 1
+            },
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 1,
+                "column": 2
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 1,
+                "column": 8
+              }
+            }
+          },
+          "tts": {
+            "0": {
+              "_type": "Group",
+              "delimiter": {
+                "_type": "Delimiter::Parenthesis"
+              },
+              "stream": {
+                "0": {
+                  "_type": "Ident",
+                  "to_string": "Debug",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 9
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 14
+                    }
+                  }
+                },
+                "1": {
+                  "_type": "Punct",
+                  "as_char": ",",
+                  "spacing": {
+                    "_type": "Spacing::Alone"
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 14
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 15
+                    }
+                  }
+                },
+                "2": {
+                  "_type": "Ident",
+                  "to_string": "Clone",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 16
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 21
+                    }
+                  }
+                },
+                "3": {
+                  "_type": "Punct",
+                  "as_char": ",",
+                  "spacing": {
+                    "_type": "Spacing::Alone"
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 21
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 22
+                    }
+                  }
+                },
+                "4": {
+                  "_type": "Ident",
+                  "to_string": "PartialEq",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 23
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 32
+                    }
+                  }
+                },
+                "5": {
+                  "_type": "Punct",
+                  "as_char": ",",
+                  "spacing": {
+                    "_type": "Spacing::Alone"
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 32
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 33
+                    }
+                  }
+                },
+                "6": {
+                  "_type": "Ident",
+                  "to_string": "Eq",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 34
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 36
+                    }
+                  }
+                },
+                "7": {
+                  "_type": "Punct",
+                  "as_char": ",",
+                  "spacing": {
+                    "_type": "Spacing::Alone"
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 36
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 37
+                    }
+                  }
+                },
+                "8": {
+                  "_type": "Ident",
+                  "to_string": "Hash",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 38
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 42
+                    }
+                  }
+                },
+                "9": {
+                  "_type": "Punct",
+                  "as_char": ",",
+                  "spacing": {
+                    "_type": "Spacing::Alone"
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 42
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 43
+                    }
+                  }
+                },
+                "10": {
+                  "_type": "Ident",
+                  "to_string": "Serialize",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 44
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 53
+                    }
+                  }
+                },
+                "11": {
+                  "_type": "Punct",
+                  "as_char": ",",
+                  "spacing": {
+                    "_type": "Spacing::Alone"
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 53
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 54
+                    }
+                  }
+                },
+                "12": {
+                  "_type": "Ident",
+                  "to_string": "Deserialize",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 55
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 1,
+                      "column": 66
+                    }
+                  }
+                },
+                "_type": "TokenStream",
+                "length": 13
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 1,
+                  "column": 8
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 1,
+                  "column": 67
+                }
+              }
+            },
+            "_type": "TokenStream",
+            "length": 1
+          },
+          "bracket_token": {
+            "_type": "Bracket",
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 1,
+                "column": 68
+              }
+            }
+          },
+          "span": {
+            "_type": "Span",
+            "start": {
+              "_type": "LineColumn",
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "_type": "LineColumn",
+              "line": 1,
+              "column": 68
+            }
+          }
+        }
+      ],
+      "vis": {
+        "_type": "VisPublic",
+        "pub_token": {
+          "_type": "Pub",
+          "span": {
+            "_type": "Span",
+            "start": {
+              "_type": "LineColumn",
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "_type": "LineColumn",
+              "line": 2,
+              "column": 3
+            }
+          }
+        },
+        "span": {
+          "_type": "Span",
+          "start": {
+            "_type": "LineColumn",
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "_type": "LineColumn",
+            "line": 2,
+            "column": 3
+          }
+        }
+      },
+      "struct_token": {
+        "_type": "Struct",
+        "span": {
+          "_type": "Span",
+          "start": {
+            "_type": "LineColumn",
+            "line": 2,
+            "column": 4
+          },
+          "end": {
+            "_type": "LineColumn",
+            "line": 2,
+            "column": 10
+          }
+        }
+      },
+      "ident": {
+        "_type": "Ident",
+        "to_string": "Query",
+        "span": {
+          "_type": "Span",
+          "start": {
+            "_type": "LineColumn",
+            "line": 2,
+            "column": 11
+          },
+          "end": {
+            "_type": "LineColumn",
+            "line": 2,
+            "column": 16
+          }
+        }
+      },
+      "generics": {
+        "_type": "Generics",
+        "params": {
+          "_type": "Punctuated",
+          "length": 0
+        },
+        "span": {
+          "_type": "Span",
+          "start": {
+            "_type": "LineColumn",
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "_type": "LineColumn",
+            "line": 1,
+            "column": 0
+          }
+        }
+      },
+      "fields": {
+        "_type": "FieldsNamed",
+        "named": {
+          "0": {
+            "_type": "Field",
+            "attrs": [
+              {
+                "_type": "Attribute",
+                "pound_token": {
+                  "_type": "Pound",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 3,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 3,
+                      "column": 48
+                    }
+                  }
+                },
+                "style": {
+                  "_type": "AttrStyle::Outer"
+                },
+                "path": {
+                  "_type": "Path",
+                  "segments": {
+                    "0": {
+                      "_type": "PathSegment",
+                      "ident": {
+                        "_type": "Ident",
+                        "to_string": "doc",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 3,
+                            "column": 4
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 3,
+                            "column": 48
+                          }
+                        }
+                      },
+                      "arguments": {
+                        "_type": "PathArguments::None"
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 3,
+                          "column": 4
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 3,
+                          "column": 48
+                        }
+                      }
+                    },
+                    "_type": "Punctuated",
+                    "length": 1
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 3,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 3,
+                      "column": 48
+                    }
+                  }
+                },
+                "tts": {
+                  "0": {
+                    "_type": "Punct",
+                    "as_char": "=",
+                    "spacing": {
+                      "_type": "Spacing::Alone"
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 3,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 3,
+                        "column": 48
+                      }
+                    }
+                  },
+                  "1": {
+                    "_type": "Literal",
+                    "to_string": "\" WITH (common table expressions, or CTEs)\"",
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 3,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 3,
+                        "column": 48
+                      }
+                    }
+                  },
+                  "_type": "TokenStream",
+                  "length": 2
+                },
+                "bracket_token": {
+                  "_type": "Bracket",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 3,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 3,
+                      "column": 48
+                    }
+                  }
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 3,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 3,
+                    "column": 48
+                  }
+                }
+              }
+            ],
+            "vis": {
+              "_type": "VisPublic",
+              "pub_token": {
+                "_type": "Pub",
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 4,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 4,
+                    "column": 7
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 4,
+                  "column": 4
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 4,
+                  "column": 7
+                }
+              }
+            },
+            "ident": {
+              "_type": "Ident",
+              "to_string": "ctes",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 4,
+                  "column": 8
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 4,
+                  "column": 12
+                }
+              }
+            },
+            "colon_token": {
+              "_type": "Colon",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 4,
+                  "column": 12
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 4,
+                  "column": 13
+                }
+              }
+            },
+            "ty": {
+              "_type": "TypePath",
+              "path": {
+                "_type": "Path",
+                "segments": {
+                  "0": {
+                    "_type": "PathSegment",
+                    "ident": {
+                      "_type": "Ident",
+                      "to_string": "Vec",
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 4,
+                          "column": 14
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 4,
+                          "column": 17
+                        }
+                      }
+                    },
+                    "arguments": {
+                      "_type": "AngleBracketedGenericArguments",
+                      "lt_token": {
+                        "_type": "Lt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 4,
+                            "column": 17
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 4,
+                            "column": 18
+                          }
+                        }
+                      },
+                      "args": {
+                        "0": {
+                          "_type": "TypePath",
+                          "path": {
+                            "_type": "Path",
+                            "segments": {
+                              "0": {
+                                "_type": "PathSegment",
+                                "ident": {
+                                  "_type": "Ident",
+                                  "to_string": "Cte",
+                                  "span": {
+                                    "_type": "Span",
+                                    "start": {
+                                      "_type": "LineColumn",
+                                      "line": 4,
+                                      "column": 18
+                                    },
+                                    "end": {
+                                      "_type": "LineColumn",
+                                      "line": 4,
+                                      "column": 21
+                                    }
+                                  }
+                                },
+                                "arguments": {
+                                  "_type": "PathArguments::None"
+                                },
+                                "span": {
+                                  "_type": "Span",
+                                  "start": {
+                                    "_type": "LineColumn",
+                                    "line": 4,
+                                    "column": 18
+                                  },
+                                  "end": {
+                                    "_type": "LineColumn",
+                                    "line": 4,
+                                    "column": 21
+                                  }
+                                }
+                              },
+                              "_type": "Punctuated",
+                              "length": 1
+                            },
+                            "span": {
+                              "_type": "Span",
+                              "start": {
+                                "_type": "LineColumn",
+                                "line": 4,
+                                "column": 18
+                              },
+                              "end": {
+                                "_type": "LineColumn",
+                                "line": 4,
+                                "column": 21
+                              }
+                            }
+                          },
+                          "span": {
+                            "_type": "Span",
+                            "start": {
+                              "_type": "LineColumn",
+                              "line": 4,
+                              "column": 18
+                            },
+                            "end": {
+                              "_type": "LineColumn",
+                              "line": 4,
+                              "column": 21
+                            }
+                          }
+                        },
+                        "_type": "Punctuated",
+                        "length": 1
+                      },
+                      "gt_token": {
+                        "_type": "Gt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 4,
+                            "column": 21
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 4,
+                            "column": 22
+                          }
+                        }
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 4,
+                          "column": 17
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 4,
+                          "column": 22
+                        }
+                      }
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 4,
+                        "column": 14
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 4,
+                        "column": 22
+                      }
+                    }
+                  },
+                  "_type": "Punctuated",
+                  "length": 1
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 4,
+                    "column": 14
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 4,
+                    "column": 22
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 4,
+                  "column": 14
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 4,
+                  "column": 22
+                }
+              }
+            },
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 3,
+                "column": 4
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 4,
+                "column": 22
+              }
+            }
+          },
+          "1": {
+            "_type": "Comma",
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 4,
+                "column": 22
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 4,
+                "column": 23
+              }
+            }
+          },
+          "2": {
+            "_type": "Field",
+            "attrs": [
+              {
+                "_type": "Attribute",
+                "pound_token": {
+                  "_type": "Pound",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 5,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 5,
+                      "column": 43
+                    }
+                  }
+                },
+                "style": {
+                  "_type": "AttrStyle::Outer"
+                },
+                "path": {
+                  "_type": "Path",
+                  "segments": {
+                    "0": {
+                      "_type": "PathSegment",
+                      "ident": {
+                        "_type": "Ident",
+                        "to_string": "doc",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 5,
+                            "column": 4
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 5,
+                            "column": 43
+                          }
+                        }
+                      },
+                      "arguments": {
+                        "_type": "PathArguments::None"
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 5,
+                          "column": 4
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 5,
+                          "column": 43
+                        }
+                      }
+                    },
+                    "_type": "Punctuated",
+                    "length": 1
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 5,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 5,
+                      "column": 43
+                    }
+                  }
+                },
+                "tts": {
+                  "0": {
+                    "_type": "Punct",
+                    "as_char": "=",
+                    "spacing": {
+                      "_type": "Spacing::Alone"
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 5,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 5,
+                        "column": 43
+                      }
+                    }
+                  },
+                  "1": {
+                    "_type": "Literal",
+                    "to_string": "\" SELECT or UNION / EXCEPT / INTECEPT\"",
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 5,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 5,
+                        "column": 43
+                      }
+                    }
+                  },
+                  "_type": "TokenStream",
+                  "length": 2
+                },
+                "bracket_token": {
+                  "_type": "Bracket",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 5,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 5,
+                      "column": 43
+                    }
+                  }
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 5,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 5,
+                    "column": 43
+                  }
+                }
+              }
+            ],
+            "vis": {
+              "_type": "VisPublic",
+              "pub_token": {
+                "_type": "Pub",
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 6,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 6,
+                    "column": 7
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 6,
+                  "column": 4
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 6,
+                  "column": 7
+                }
+              }
+            },
+            "ident": {
+              "_type": "Ident",
+              "to_string": "body",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 6,
+                  "column": 8
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 6,
+                  "column": 12
+                }
+              }
+            },
+            "colon_token": {
+              "_type": "Colon",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 6,
+                  "column": 12
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 6,
+                  "column": 13
+                }
+              }
+            },
+            "ty": {
+              "_type": "TypePath",
+              "path": {
+                "_type": "Path",
+                "segments": {
+                  "0": {
+                    "_type": "PathSegment",
+                    "ident": {
+                      "_type": "Ident",
+                      "to_string": "SetExpr",
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 6,
+                          "column": 14
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 6,
+                          "column": 21
+                        }
+                      }
+                    },
+                    "arguments": {
+                      "_type": "PathArguments::None"
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 6,
+                        "column": 14
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 6,
+                        "column": 21
+                      }
+                    }
+                  },
+                  "_type": "Punctuated",
+                  "length": 1
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 6,
+                    "column": 14
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 6,
+                    "column": 21
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 6,
+                  "column": 14
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 6,
+                  "column": 21
+                }
+              }
+            },
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 5,
+                "column": 4
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 6,
+                "column": 21
+              }
+            }
+          },
+          "3": {
+            "_type": "Comma",
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 6,
+                "column": 21
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 6,
+                "column": 22
+              }
+            }
+          },
+          "4": {
+            "_type": "Field",
+            "attrs": [
+              {
+                "_type": "Attribute",
+                "pound_token": {
+                  "_type": "Pound",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 7,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 7,
+                      "column": 16
+                    }
+                  }
+                },
+                "style": {
+                  "_type": "AttrStyle::Outer"
+                },
+                "path": {
+                  "_type": "Path",
+                  "segments": {
+                    "0": {
+                      "_type": "PathSegment",
+                      "ident": {
+                        "_type": "Ident",
+                        "to_string": "doc",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 7,
+                            "column": 4
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 7,
+                            "column": 16
+                          }
+                        }
+                      },
+                      "arguments": {
+                        "_type": "PathArguments::None"
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 7,
+                          "column": 4
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 7,
+                          "column": 16
+                        }
+                      }
+                    },
+                    "_type": "Punctuated",
+                    "length": 1
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 7,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 7,
+                      "column": 16
+                    }
+                  }
+                },
+                "tts": {
+                  "0": {
+                    "_type": "Punct",
+                    "as_char": "=",
+                    "spacing": {
+                      "_type": "Spacing::Alone"
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 7,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 7,
+                        "column": 16
+                      }
+                    }
+                  },
+                  "1": {
+                    "_type": "Literal",
+                    "to_string": "\" ORDER BY\"",
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 7,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 7,
+                        "column": 16
+                      }
+                    }
+                  },
+                  "_type": "TokenStream",
+                  "length": 2
+                },
+                "bracket_token": {
+                  "_type": "Bracket",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 7,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 7,
+                      "column": 16
+                    }
+                  }
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 7,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 7,
+                    "column": 16
+                  }
+                }
+              }
+            ],
+            "vis": {
+              "_type": "VisPublic",
+              "pub_token": {
+                "_type": "Pub",
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 8,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 8,
+                    "column": 7
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 8,
+                  "column": 4
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 8,
+                  "column": 7
+                }
+              }
+            },
+            "ident": {
+              "_type": "Ident",
+              "to_string": "order_by",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 8,
+                  "column": 8
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 8,
+                  "column": 16
+                }
+              }
+            },
+            "colon_token": {
+              "_type": "Colon",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 8,
+                  "column": 16
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 8,
+                  "column": 17
+                }
+              }
+            },
+            "ty": {
+              "_type": "TypePath",
+              "path": {
+                "_type": "Path",
+                "segments": {
+                  "0": {
+                    "_type": "PathSegment",
+                    "ident": {
+                      "_type": "Ident",
+                      "to_string": "Vec",
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 8,
+                          "column": 18
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 8,
+                          "column": 21
+                        }
+                      }
+                    },
+                    "arguments": {
+                      "_type": "AngleBracketedGenericArguments",
+                      "lt_token": {
+                        "_type": "Lt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 8,
+                            "column": 21
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 8,
+                            "column": 22
+                          }
+                        }
+                      },
+                      "args": {
+                        "0": {
+                          "_type": "TypePath",
+                          "path": {
+                            "_type": "Path",
+                            "segments": {
+                              "0": {
+                                "_type": "PathSegment",
+                                "ident": {
+                                  "_type": "Ident",
+                                  "to_string": "OrderByExpr",
+                                  "span": {
+                                    "_type": "Span",
+                                    "start": {
+                                      "_type": "LineColumn",
+                                      "line": 8,
+                                      "column": 22
+                                    },
+                                    "end": {
+                                      "_type": "LineColumn",
+                                      "line": 8,
+                                      "column": 33
+                                    }
+                                  }
+                                },
+                                "arguments": {
+                                  "_type": "PathArguments::None"
+                                },
+                                "span": {
+                                  "_type": "Span",
+                                  "start": {
+                                    "_type": "LineColumn",
+                                    "line": 8,
+                                    "column": 22
+                                  },
+                                  "end": {
+                                    "_type": "LineColumn",
+                                    "line": 8,
+                                    "column": 33
+                                  }
+                                }
+                              },
+                              "_type": "Punctuated",
+                              "length": 1
+                            },
+                            "span": {
+                              "_type": "Span",
+                              "start": {
+                                "_type": "LineColumn",
+                                "line": 8,
+                                "column": 22
+                              },
+                              "end": {
+                                "_type": "LineColumn",
+                                "line": 8,
+                                "column": 33
+                              }
+                            }
+                          },
+                          "span": {
+                            "_type": "Span",
+                            "start": {
+                              "_type": "LineColumn",
+                              "line": 8,
+                              "column": 22
+                            },
+                            "end": {
+                              "_type": "LineColumn",
+                              "line": 8,
+                              "column": 33
+                            }
+                          }
+                        },
+                        "_type": "Punctuated",
+                        "length": 1
+                      },
+                      "gt_token": {
+                        "_type": "Gt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 8,
+                            "column": 33
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 8,
+                            "column": 34
+                          }
+                        }
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 8,
+                          "column": 21
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 8,
+                          "column": 34
+                        }
+                      }
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 8,
+                        "column": 18
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 8,
+                        "column": 34
+                      }
+                    }
+                  },
+                  "_type": "Punctuated",
+                  "length": 1
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 8,
+                    "column": 18
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 8,
+                    "column": 34
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 8,
+                  "column": 18
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 8,
+                  "column": 34
+                }
+              }
+            },
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 7,
+                "column": 4
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 8,
+                "column": 34
+              }
+            }
+          },
+          "5": {
+            "_type": "Comma",
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 8,
+                "column": 34
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 8,
+                "column": 35
+              }
+            }
+          },
+          "6": {
+            "_type": "Field",
+            "attrs": [
+              {
+                "_type": "Attribute",
+                "pound_token": {
+                  "_type": "Pound",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 9,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 9,
+                      "column": 29
+                    }
+                  }
+                },
+                "style": {
+                  "_type": "AttrStyle::Outer"
+                },
+                "path": {
+                  "_type": "Path",
+                  "segments": {
+                    "0": {
+                      "_type": "PathSegment",
+                      "ident": {
+                        "_type": "Ident",
+                        "to_string": "doc",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 9,
+                            "column": 4
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 9,
+                            "column": 29
+                          }
+                        }
+                      },
+                      "arguments": {
+                        "_type": "PathArguments::None"
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 9,
+                          "column": 4
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 9,
+                          "column": 29
+                        }
+                      }
+                    },
+                    "_type": "Punctuated",
+                    "length": 1
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 9,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 9,
+                      "column": 29
+                    }
+                  }
+                },
+                "tts": {
+                  "0": {
+                    "_type": "Punct",
+                    "as_char": "=",
+                    "spacing": {
+                      "_type": "Spacing::Alone"
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 9,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 9,
+                        "column": 29
+                      }
+                    }
+                  },
+                  "1": {
+                    "_type": "Literal",
+                    "to_string": "\" `LIMIT { <N> | ALL }`\"",
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 9,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 9,
+                        "column": 29
+                      }
+                    }
+                  },
+                  "_type": "TokenStream",
+                  "length": 2
+                },
+                "bracket_token": {
+                  "_type": "Bracket",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 9,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 9,
+                      "column": 29
+                    }
+                  }
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 9,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 9,
+                    "column": 29
+                  }
+                }
+              }
+            ],
+            "vis": {
+              "_type": "VisPublic",
+              "pub_token": {
+                "_type": "Pub",
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 10,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 10,
+                    "column": 7
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 10,
+                  "column": 4
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 10,
+                  "column": 7
+                }
+              }
+            },
+            "ident": {
+              "_type": "Ident",
+              "to_string": "limit",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 10,
+                  "column": 8
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 10,
+                  "column": 13
+                }
+              }
+            },
+            "colon_token": {
+              "_type": "Colon",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 10,
+                  "column": 13
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 10,
+                  "column": 14
+                }
+              }
+            },
+            "ty": {
+              "_type": "TypePath",
+              "path": {
+                "_type": "Path",
+                "segments": {
+                  "0": {
+                    "_type": "PathSegment",
+                    "ident": {
+                      "_type": "Ident",
+                      "to_string": "Option",
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 10,
+                          "column": 15
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 10,
+                          "column": 21
+                        }
+                      }
+                    },
+                    "arguments": {
+                      "_type": "AngleBracketedGenericArguments",
+                      "lt_token": {
+                        "_type": "Lt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 10,
+                            "column": 21
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 10,
+                            "column": 22
+                          }
+                        }
+                      },
+                      "args": {
+                        "0": {
+                          "_type": "TypePath",
+                          "path": {
+                            "_type": "Path",
+                            "segments": {
+                              "0": {
+                                "_type": "PathSegment",
+                                "ident": {
+                                  "_type": "Ident",
+                                  "to_string": "Expr",
+                                  "span": {
+                                    "_type": "Span",
+                                    "start": {
+                                      "_type": "LineColumn",
+                                      "line": 10,
+                                      "column": 22
+                                    },
+                                    "end": {
+                                      "_type": "LineColumn",
+                                      "line": 10,
+                                      "column": 26
+                                    }
+                                  }
+                                },
+                                "arguments": {
+                                  "_type": "PathArguments::None"
+                                },
+                                "span": {
+                                  "_type": "Span",
+                                  "start": {
+                                    "_type": "LineColumn",
+                                    "line": 10,
+                                    "column": 22
+                                  },
+                                  "end": {
+                                    "_type": "LineColumn",
+                                    "line": 10,
+                                    "column": 26
+                                  }
+                                }
+                              },
+                              "_type": "Punctuated",
+                              "length": 1
+                            },
+                            "span": {
+                              "_type": "Span",
+                              "start": {
+                                "_type": "LineColumn",
+                                "line": 10,
+                                "column": 22
+                              },
+                              "end": {
+                                "_type": "LineColumn",
+                                "line": 10,
+                                "column": 26
+                              }
+                            }
+                          },
+                          "span": {
+                            "_type": "Span",
+                            "start": {
+                              "_type": "LineColumn",
+                              "line": 10,
+                              "column": 22
+                            },
+                            "end": {
+                              "_type": "LineColumn",
+                              "line": 10,
+                              "column": 26
+                            }
+                          }
+                        },
+                        "_type": "Punctuated",
+                        "length": 1
+                      },
+                      "gt_token": {
+                        "_type": "Gt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 10,
+                            "column": 26
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 10,
+                            "column": 27
+                          }
+                        }
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 10,
+                          "column": 21
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 10,
+                          "column": 27
+                        }
+                      }
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 10,
+                        "column": 15
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 10,
+                        "column": 27
+                      }
+                    }
+                  },
+                  "_type": "Punctuated",
+                  "length": 1
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 10,
+                    "column": 15
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 10,
+                    "column": 27
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 10,
+                  "column": 15
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 10,
+                  "column": 27
+                }
+              }
+            },
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 9,
+                "column": 4
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 10,
+                "column": 27
+              }
+            }
+          },
+          "7": {
+            "_type": "Comma",
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 10,
+                "column": 27
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 10,
+                "column": 28
+              }
+            }
+          },
+          "8": {
+            "_type": "Field",
+            "attrs": [
+              {
+                "_type": "Attribute",
+                "pound_token": {
+                  "_type": "Pound",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 11,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 11,
+                      "column": 39
+                    }
+                  }
+                },
+                "style": {
+                  "_type": "AttrStyle::Outer"
+                },
+                "path": {
+                  "_type": "Path",
+                  "segments": {
+                    "0": {
+                      "_type": "PathSegment",
+                      "ident": {
+                        "_type": "Ident",
+                        "to_string": "doc",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 11,
+                            "column": 4
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 11,
+                            "column": 39
+                          }
+                        }
+                      },
+                      "arguments": {
+                        "_type": "PathArguments::None"
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 11,
+                          "column": 4
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 11,
+                          "column": 39
+                        }
+                      }
+                    },
+                    "_type": "Punctuated",
+                    "length": 1
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 11,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 11,
+                      "column": 39
+                    }
+                  }
+                },
+                "tts": {
+                  "0": {
+                    "_type": "Punct",
+                    "as_char": "=",
+                    "spacing": {
+                      "_type": "Spacing::Alone"
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 11,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 11,
+                        "column": 39
+                      }
+                    }
+                  },
+                  "1": {
+                    "_type": "Literal",
+                    "to_string": "\" `OFFSET <N> [ { ROW | ROWS } ]`\"",
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 11,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 11,
+                        "column": 39
+                      }
+                    }
+                  },
+                  "_type": "TokenStream",
+                  "length": 2
+                },
+                "bracket_token": {
+                  "_type": "Bracket",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 11,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 11,
+                      "column": 39
+                    }
+                  }
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 11,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 11,
+                    "column": 39
+                  }
+                }
+              }
+            ],
+            "vis": {
+              "_type": "VisPublic",
+              "pub_token": {
+                "_type": "Pub",
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 12,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 12,
+                    "column": 7
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 12,
+                  "column": 4
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 12,
+                  "column": 7
+                }
+              }
+            },
+            "ident": {
+              "_type": "Ident",
+              "to_string": "offset",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 12,
+                  "column": 8
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 12,
+                  "column": 14
+                }
+              }
+            },
+            "colon_token": {
+              "_type": "Colon",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 12,
+                  "column": 14
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 12,
+                  "column": 15
+                }
+              }
+            },
+            "ty": {
+              "_type": "TypePath",
+              "path": {
+                "_type": "Path",
+                "segments": {
+                  "0": {
+                    "_type": "PathSegment",
+                    "ident": {
+                      "_type": "Ident",
+                      "to_string": "Option",
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 12,
+                          "column": 16
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 12,
+                          "column": 22
+                        }
+                      }
+                    },
+                    "arguments": {
+                      "_type": "AngleBracketedGenericArguments",
+                      "lt_token": {
+                        "_type": "Lt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 12,
+                            "column": 22
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 12,
+                            "column": 23
+                          }
+                        }
+                      },
+                      "args": {
+                        "0": {
+                          "_type": "TypePath",
+                          "path": {
+                            "_type": "Path",
+                            "segments": {
+                              "0": {
+                                "_type": "PathSegment",
+                                "ident": {
+                                  "_type": "Ident",
+                                  "to_string": "Offset",
+                                  "span": {
+                                    "_type": "Span",
+                                    "start": {
+                                      "_type": "LineColumn",
+                                      "line": 12,
+                                      "column": 23
+                                    },
+                                    "end": {
+                                      "_type": "LineColumn",
+                                      "line": 12,
+                                      "column": 29
+                                    }
+                                  }
+                                },
+                                "arguments": {
+                                  "_type": "PathArguments::None"
+                                },
+                                "span": {
+                                  "_type": "Span",
+                                  "start": {
+                                    "_type": "LineColumn",
+                                    "line": 12,
+                                    "column": 23
+                                  },
+                                  "end": {
+                                    "_type": "LineColumn",
+                                    "line": 12,
+                                    "column": 29
+                                  }
+                                }
+                              },
+                              "_type": "Punctuated",
+                              "length": 1
+                            },
+                            "span": {
+                              "_type": "Span",
+                              "start": {
+                                "_type": "LineColumn",
+                                "line": 12,
+                                "column": 23
+                              },
+                              "end": {
+                                "_type": "LineColumn",
+                                "line": 12,
+                                "column": 29
+                              }
+                            }
+                          },
+                          "span": {
+                            "_type": "Span",
+                            "start": {
+                              "_type": "LineColumn",
+                              "line": 12,
+                              "column": 23
+                            },
+                            "end": {
+                              "_type": "LineColumn",
+                              "line": 12,
+                              "column": 29
+                            }
+                          }
+                        },
+                        "_type": "Punctuated",
+                        "length": 1
+                      },
+                      "gt_token": {
+                        "_type": "Gt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 12,
+                            "column": 29
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 12,
+                            "column": 30
+                          }
+                        }
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 12,
+                          "column": 22
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 12,
+                          "column": 30
+                        }
+                      }
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 12,
+                        "column": 16
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 12,
+                        "column": 30
+                      }
+                    }
+                  },
+                  "_type": "Punctuated",
+                  "length": 1
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 12,
+                    "column": 16
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 12,
+                    "column": 30
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 12,
+                  "column": 16
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 12,
+                  "column": 30
+                }
+              }
+            },
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 11,
+                "column": 4
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 12,
+                "column": 30
+              }
+            }
+          },
+          "9": {
+            "_type": "Comma",
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 12,
+                "column": 30
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 12,
+                "column": 31
+              }
+            }
+          },
+          "10": {
+            "_type": "Field",
+            "attrs": [
+              {
+                "_type": "Attribute",
+                "pound_token": {
+                  "_type": "Pound",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 13,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 13,
+                      "column": 86
+                    }
+                  }
+                },
+                "style": {
+                  "_type": "AttrStyle::Outer"
+                },
+                "path": {
+                  "_type": "Path",
+                  "segments": {
+                    "0": {
+                      "_type": "PathSegment",
+                      "ident": {
+                        "_type": "Ident",
+                        "to_string": "doc",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 13,
+                            "column": 4
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 13,
+                            "column": 86
+                          }
+                        }
+                      },
+                      "arguments": {
+                        "_type": "PathArguments::None"
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 13,
+                          "column": 4
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 13,
+                          "column": 86
+                        }
+                      }
+                    },
+                    "_type": "Punctuated",
+                    "length": 1
+                  },
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 13,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 13,
+                      "column": 86
+                    }
+                  }
+                },
+                "tts": {
+                  "0": {
+                    "_type": "Punct",
+                    "as_char": "=",
+                    "spacing": {
+                      "_type": "Spacing::Alone"
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 13,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 13,
+                        "column": 86
+                      }
+                    }
+                  },
+                  "1": {
+                    "_type": "Literal",
+                    "to_string": "\" `FETCH { FIRST | NEXT } <N> [ PERCENT ] { ROW | ROWS } | { ONLY | WITH TIES }`\"",
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 13,
+                        "column": 4
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 13,
+                        "column": 86
+                      }
+                    }
+                  },
+                  "_type": "TokenStream",
+                  "length": 2
+                },
+                "bracket_token": {
+                  "_type": "Bracket",
+                  "span": {
+                    "_type": "Span",
+                    "start": {
+                      "_type": "LineColumn",
+                      "line": 13,
+                      "column": 4
+                    },
+                    "end": {
+                      "_type": "LineColumn",
+                      "line": 13,
+                      "column": 86
+                    }
+                  }
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 13,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 13,
+                    "column": 86
+                  }
+                }
+              }
+            ],
+            "vis": {
+              "_type": "VisPublic",
+              "pub_token": {
+                "_type": "Pub",
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 14,
+                    "column": 4
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 14,
+                    "column": 7
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 14,
+                  "column": 4
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 14,
+                  "column": 7
+                }
+              }
+            },
+            "ident": {
+              "_type": "Ident",
+              "to_string": "fetch",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 14,
+                  "column": 8
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 14,
+                  "column": 13
+                }
+              }
+            },
+            "colon_token": {
+              "_type": "Colon",
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 14,
+                  "column": 13
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 14,
+                  "column": 14
+                }
+              }
+            },
+            "ty": {
+              "_type": "TypePath",
+              "path": {
+                "_type": "Path",
+                "segments": {
+                  "0": {
+                    "_type": "PathSegment",
+                    "ident": {
+                      "_type": "Ident",
+                      "to_string": "Option",
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 14,
+                          "column": 15
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 14,
+                          "column": 21
+                        }
+                      }
+                    },
+                    "arguments": {
+                      "_type": "AngleBracketedGenericArguments",
+                      "lt_token": {
+                        "_type": "Lt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 14,
+                            "column": 21
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 14,
+                            "column": 22
+                          }
+                        }
+                      },
+                      "args": {
+                        "0": {
+                          "_type": "TypePath",
+                          "path": {
+                            "_type": "Path",
+                            "segments": {
+                              "0": {
+                                "_type": "PathSegment",
+                                "ident": {
+                                  "_type": "Ident",
+                                  "to_string": "Fetch",
+                                  "span": {
+                                    "_type": "Span",
+                                    "start": {
+                                      "_type": "LineColumn",
+                                      "line": 14,
+                                      "column": 22
+                                    },
+                                    "end": {
+                                      "_type": "LineColumn",
+                                      "line": 14,
+                                      "column": 27
+                                    }
+                                  }
+                                },
+                                "arguments": {
+                                  "_type": "PathArguments::None"
+                                },
+                                "span": {
+                                  "_type": "Span",
+                                  "start": {
+                                    "_type": "LineColumn",
+                                    "line": 14,
+                                    "column": 22
+                                  },
+                                  "end": {
+                                    "_type": "LineColumn",
+                                    "line": 14,
+                                    "column": 27
+                                  }
+                                }
+                              },
+                              "_type": "Punctuated",
+                              "length": 1
+                            },
+                            "span": {
+                              "_type": "Span",
+                              "start": {
+                                "_type": "LineColumn",
+                                "line": 14,
+                                "column": 22
+                              },
+                              "end": {
+                                "_type": "LineColumn",
+                                "line": 14,
+                                "column": 27
+                              }
+                            }
+                          },
+                          "span": {
+                            "_type": "Span",
+                            "start": {
+                              "_type": "LineColumn",
+                              "line": 14,
+                              "column": 22
+                            },
+                            "end": {
+                              "_type": "LineColumn",
+                              "line": 14,
+                              "column": 27
+                            }
+                          }
+                        },
+                        "_type": "Punctuated",
+                        "length": 1
+                      },
+                      "gt_token": {
+                        "_type": "Gt",
+                        "span": {
+                          "_type": "Span",
+                          "start": {
+                            "_type": "LineColumn",
+                            "line": 14,
+                            "column": 27
+                          },
+                          "end": {
+                            "_type": "LineColumn",
+                            "line": 14,
+                            "column": 28
+                          }
+                        }
+                      },
+                      "span": {
+                        "_type": "Span",
+                        "start": {
+                          "_type": "LineColumn",
+                          "line": 14,
+                          "column": 21
+                        },
+                        "end": {
+                          "_type": "LineColumn",
+                          "line": 14,
+                          "column": 28
+                        }
+                      }
+                    },
+                    "span": {
+                      "_type": "Span",
+                      "start": {
+                        "_type": "LineColumn",
+                        "line": 14,
+                        "column": 15
+                      },
+                      "end": {
+                        "_type": "LineColumn",
+                        "line": 14,
+                        "column": 28
+                      }
+                    }
+                  },
+                  "_type": "Punctuated",
+                  "length": 1
+                },
+                "span": {
+                  "_type": "Span",
+                  "start": {
+                    "_type": "LineColumn",
+                    "line": 14,
+                    "column": 15
+                  },
+                  "end": {
+                    "_type": "LineColumn",
+                    "line": 14,
+                    "column": 28
+                  }
+                }
+              },
+              "span": {
+                "_type": "Span",
+                "start": {
+                  "_type": "LineColumn",
+                  "line": 14,
+                  "column": 15
+                },
+                "end": {
+                  "_type": "LineColumn",
+                  "line": 14,
+                  "column": 28
+                }
+              }
+            },
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 13,
+                "column": 4
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 14,
+                "column": 28
+              }
+            }
+          },
+          "11": {
+            "_type": "Comma",
+            "span": {
+              "_type": "Span",
+              "start": {
+                "_type": "LineColumn",
+                "line": 14,
+                "column": 28
+              },
+              "end": {
+                "_type": "LineColumn",
+                "line": 14,
+                "column": 29
+              }
+            }
+          },
+          "_type": "Punctuated",
+          "length": 12
+        },
+        "brace_token": {
+          "_type": "Brace",
+          "span": {
+            "_type": "Span",
+            "start": {
+              "_type": "LineColumn",
+              "line": 2,
+              "column": 17
+            },
+            "end": {
+              "_type": "LineColumn",
+              "line": 15,
+              "column": 1
+            }
+          }
+        },
+        "span": {
+          "_type": "Span",
+          "start": {
+            "_type": "LineColumn",
+            "line": 2,
+            "column": 17
+          },
+          "end": {
+            "_type": "LineColumn",
+            "line": 15,
+            "column": 1
+          }
+        }
+      },
+      "span": {
+        "_type": "Span",
+        "start": {
+          "_type": "LineColumn",
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "_type": "LineColumn",
+          "line": 15,
+          "column": 1
+        }
+      }
+    }
+  ],
+  "span": {
+    "_type": "Span",
+    "start": {
+      "_type": "LineColumn",
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "_type": "LineColumn",
+      "line": 15,
+      "column": 1
+    }
+  }
+};
+
+module.exports = {srcText: srcText, json:json};


### PR DESCRIPTION
I'm opening this draft PR to share the prototype I have at https://github.com/nickolay/sqlparser-rs/tree/wip-cst

**I hope that people, who contribute, already use, or want to use `sqlparser-rs`, react here** (if only via a GitHub reaction) so that we can judge if this is something worth pursuing as part of this library or if I'm completely off-track. There's a detailed write-up in the [branch's README](https://github.com/nickolay/sqlparser-rs/blob/wip-cst/README.md), but **the short version is that current AST is lossy** (w.r.t whitespace, comments, unimportant syntax, and source code locations) **and to fix that I propose an additional intermediate layer, which is lossless. Some changes to the AST will be necessary too**, but to what extent is up for discussion.

Apart from gauging the general mood and collecting feedback, I hope that documenting what I have so far will enable someone to beat me at coming up with the specific design for the CST/AST, as I have not been able to dedicate much time to this.

I'll include a quote from the motivational section of the README:

> Preserving full source code information (#161) would enable SQL rewriting/refactoring tools based on sqlparser-rs. For example:
>
> 1. **Error reporting**, both in the parser and in later stages of query processing, would benefit from knowing the source code location of SQL constructs (#179)
> 2. **SQL pretty-printing** requires comments to be preserved in AST (see #175, mentioning [forma](https://github.com/maxcountryman/forma))
> 3. **Refactoring via AST transformations** would also benefit from having full control over serialization, a possible solution for dialect-specific "writers" (#18)
> 4. Analyzing partially invalid code may be useful in the context of an IDE or other tooling.
>
> **I think that adopting [rust-analyzer's design][ra-syntax], that includes a lossless syntax tree, is the right direction for sqlparser-rs.** In addition to solving the use-cases described above, it helps in other ways:
>
> 5. We can omit syntax that does not affect semantics of the query (e.g. [`ROW` vs `ROWS`](https://github.com/andygrove/sqlparser-rs/blob/418b9631ce9c24cf9bb26cf7dd9e42edd29de985/src/ast/query.rs#L416)) from the typed AST by default, reducing the implementation effort.
> 6. Having a homogenous syntax tree also alleviates the need for a "visitor" (#114), also reducing the burden on implementors of new syntax

[ra-syntax]: https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md
