### PR TITLE
Add fuzzer based on cargo-fuzz

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -1,0 +1,9 @@
+# Fuzzing
+
+sqlparser uses the tool `cargo-fuzz`.  This tool can be installed using: `cargo install cargo-fuzz`.
+Cargo-fuzz also requires nightly to be installed: `rustup install nightly`
+
+Running the fuzzer is as easy as running in the `fuzz` directory:
+
+`cargo +nightly fuzz run parse_sql`
+

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -5,5 +5,5 @@ Cargo-fuzz also requires nightly to be installed: `rustup install nightly`
 
 Running the fuzzer is as easy as running in the `fuzz` directory:
 
-`cargo +nightly fuzz run parse_sql -- -max_len=64`
+`cargo +nightly fuzz run parse_sql -- -max_len=64 -jobs=16 -timeout=1`
 

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -5,5 +5,5 @@ Cargo-fuzz also requires nightly to be installed: `rustup install nightly`
 
 Running the fuzzer is as easy as running in the `fuzz` directory:
 
-`cargo +nightly fuzz run parse_sql`
+`cargo +nightly fuzz run parse_sql -- -max_len=64`
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "sqlparser-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.sqlparser]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parse_sql"
+path = "fuzz_targets/parse_sql.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/parse_sql.rs
+++ b/fuzz/fuzz_targets/parse_sql.rs
@@ -3,10 +3,8 @@ use libfuzzer_sys::fuzz_target;
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
-fuzz_target!(|data: &[u8]| {
+fuzz_target!(|data: String| {
     let dialect = GenericDialect {};
 
-    if let Ok(s) = std::str::from_utf8(data) {
-        let _ = Parser::parse_sql(&dialect, s);
-    }
+    let _ = Parser::parse_sql(&dialect, &data);
 });

--- a/fuzz/fuzz_targets/parse_sql.rs
+++ b/fuzz/fuzz_targets/parse_sql.rs
@@ -1,0 +1,12 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+fuzz_target!(|data: &[u8]| {
+    let dialect = GenericDialect {};
+
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = Parser::parse_sql(&dialect, s);
+    }
+});


### PR DESCRIPTION
Currently it returns (after fuzzing):

`Error: Fuzz target exited with signal: 11` 

That looks like a problem in the nightly compiler (LLVM?)