### PR TITLE
Fix performance of very nested SQL files, add example to benchmark

### DIFF
--- a/sqlparser_bench/benches/sqlparser_bench.rs
+++ b/sqlparser_bench/benches/sqlparser_bench.rs
@@ -37,6 +37,19 @@ fn basic_queries(c: &mut Criterion) {
     group.bench_function("sqlparser::with_select", |b| {
         b.iter(|| Parser::parse_sql(&dialect, with_query));
     });
+
+    let nested_query = "
+    SELECT
+@ FROM((((((((((SELECT
+@ FROM((((((SELECT
+@ FROM((((((((((SELECT
+@ FROM(((((((((((((SELECT
+I FROM(((((((SELECT
+I FROM
+";
+group.bench_function("sqlparser::nested_query", |b| {
+    b.iter(|| Parser::parse_sql(&dialect, nested_query));
+});
 }
 
 criterion_group!(benches, basic_queries);

--- a/sqlparser_bench/benches/sqlparser_bench.rs
+++ b/sqlparser_bench/benches/sqlparser_bench.rs
@@ -47,9 +47,9 @@ fn basic_queries(c: &mut Criterion) {
 I FROM(((((((SELECT
 I FROM
 ";
-group.bench_function("sqlparser::nested_query", |b| {
-    b.iter(|| Parser::parse_sql(&dialect, nested_query));
-});
+    group.bench_function("sqlparser::nested_query", |b| {
+        b.iter(|| Parser::parse_sql(&dialect, nested_query));
+    });
 }
 
 criterion_group!(benches, basic_queries);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2060,7 +2060,10 @@ impl Parser {
             // If the recently consumed '(' starts a derived table, the call to
             // `parse_derived_table_factor` below will return success after parsing the
             // subquery, followed by the closing ')', and the alias of the derived table.
-            // In the example above this is case (3).const
+            // In the example above this is case (3).
+
+            // We will only try to parse `parse_derived_table_factor` if it wasn't tried in a
+            // previous attempt for the same index
             if !self
                 .memoize_parse_derived_table_factor
                 .contains(&self.index)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,9 +19,9 @@ use super::dialect::keywords;
 use super::dialect::keywords::Keyword;
 use super::dialect::Dialect;
 use super::tokenizer::*;
+use std::collections::HashSet;
 use std::error::Error;
 use std::fmt;
-use std::collections::HashSet;
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParserError {
     TokenizerError(String),
@@ -94,7 +94,11 @@ pub struct Parser {
 impl Parser {
     /// Parse the specified tokens
     pub fn new(tokens: Vec<Token>) -> Self {
-        Parser { tokens, index: 0, memoize_parse_derived_table_factor: HashSet::new() }
+        Parser {
+            tokens,
+            index: 0,
+            memoize_parse_derived_table_factor: HashSet::new(),
+        }
     }
 
     /// Parse a SQL statement and produce an Abstract Syntax Tree (AST)
@@ -2057,7 +2061,10 @@ impl Parser {
             // `parse_derived_table_factor` below will return success after parsing the
             // subquery, followed by the closing ')', and the alias of the derived table.
             // In the example above this is case (3).const
-            if !self.memoize_parse_derived_table_factor.contains(&self.index) {
+            if !self
+                .memoize_parse_derived_table_factor
+                .contains(&self.index)
+            {
                 return_ok_if_some!(
                     self.maybe_parse(|parser| parser.parse_derived_table_factor(NotLateral))
                 );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2071,8 +2071,8 @@ impl Parser {
                 return_ok_if_some!(
                     self.maybe_parse(|parser| parser.parse_derived_table_factor(NotLateral))
                 );
+                self.memoize_parse_derived_table_factor.insert(self.index);
             }
-            self.memoize_parse_derived_table_factor.insert(self.index);
 
             // A parsing error from `parse_derived_table_factor` indicates that the '(' we've
             // recently consumed does not start a derived table (cases 1, 2, or 4).

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,7 +21,7 @@ use super::dialect::Dialect;
 use super::tokenizer::*;
 use std::error::Error;
 use std::fmt;
-
+use std::collections::HashSet;
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParserError {
     TokenizerError(String),
@@ -87,12 +87,14 @@ pub struct Parser {
     tokens: Vec<Token>,
     /// The index of the first unprocessed token in `self.tokens`
     index: usize,
+    /// Memoizes unsuccesful `parse_derived_table_factor` results
+    memoize_parse_derived_table_factor: HashSet<usize>,
 }
 
 impl Parser {
     /// Parse the specified tokens
     pub fn new(tokens: Vec<Token>) -> Self {
-        Parser { tokens, index: 0 }
+        Parser { tokens, index: 0, memoize_parse_derived_table_factor: HashSet::new() }
     }
 
     /// Parse a SQL statement and produce an Abstract Syntax Tree (AST)
@@ -2054,10 +2056,14 @@ impl Parser {
             // If the recently consumed '(' starts a derived table, the call to
             // `parse_derived_table_factor` below will return success after parsing the
             // subquery, followed by the closing ')', and the alias of the derived table.
-            // In the example above this is case (3).
-            return_ok_if_some!(
-                self.maybe_parse(|parser| parser.parse_derived_table_factor(NotLateral))
-            );
+            // In the example above this is case (3).const
+            if !self.memoize_parse_derived_table_factor.contains(&self.index) {
+                return_ok_if_some!(
+                    self.maybe_parse(|parser| parser.parse_derived_table_factor(NotLateral))
+                );
+            }
+            self.memoize_parse_derived_table_factor.insert(self.index);
+
             // A parsing error from `parse_derived_table_factor` indicates that the '(' we've
             // recently consumed does not start a derived table (cases 1, 2, or 4).
             // `maybe_parse` will ignore such an error and rewind to be after the opening '('.


### PR DESCRIPTION
This adds one of the inputs found during fuzzing as benchmarking input.

https://github.com/ballista-compute/sqlparser-rs/issues/216

According to benchmark,the query takes 75.814 ms on average. That is much more than the other benchmarks, which are more than 1000x as fast (3 / 17 microseconds).

I included a fix which memoizes the unsuccesful usage of parse_derived_table_factor.

This brings down the benchmark to 109.24 microseconds (687 times speedup for this extreme example).