### PR TITLE
Add support for no_std + alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ path = "src/lib.rs"
 [features]
 # Enable JSON output in the `cli` example:
 json_example = ["serde_json", "serde"]
+std = []
+default = ["std"]
 
 [dependencies]
 bigdecimal = { version = "0.2", features = ["serde"], optional = true }

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -11,9 +11,11 @@
 // limitations under the License.
 
 use super::ObjectName;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+use core::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 /// SQL data types
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -15,9 +15,11 @@
 use super::{display_comma_separated, DataType, Expr, Ident, ObjectName};
 use crate::ast::display_separated;
 use crate::tokenizer::Token;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::ToString, vec::Vec};
+use core::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 /// An `ALTER TABLE` (`Statement::AlterTable`) operation
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -18,9 +18,15 @@ mod operator;
 mod query;
 mod value;
 
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 pub use self::data_type::DataType;
 pub use self::ddl::{

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -10,9 +10,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 /// Unary operators
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -10,11 +10,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 #[cfg(feature = "bigdecimal")]
 use bigdecimal::BigDecimal;
+use core::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 /// Primitive SQL values such as number and string
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -19,8 +19,8 @@ mod postgresql;
 mod snowflake;
 mod sqlite;
 
-use std::any::{Any, TypeId};
-use std::fmt::Debug;
+use core::any::{Any, TypeId};
+use core::fmt::Debug;
 
 pub use self::ansi::AnsiDialect;
 pub use self::generic::GenericDialect;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,9 @@
 //! println!("AST: {:?}", ast);
 //! ```
 #![warn(clippy::all)]
-
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+extern crate core;
 pub mod ast;
 #[macro_use]
 pub mod dialect;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,8 +18,17 @@ use super::ast::*;
 use super::dialect::keywords::Keyword;
 use super::dialect::*;
 use super::tokenizer::*;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+use core::fmt;
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParserError {
@@ -79,6 +88,7 @@ impl fmt::Display for ParserError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for ParserError {}
 
 pub struct Parser<'a> {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -10,13 +10,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 /// This module contains internal utilities used for testing the library.
 /// While technically public, the library's users are not supposed to rely
 /// on this module, as it will change without notice.
 //
 // Integration tests (i.e. everything under `tests/`) import this
 // via `tests/test_utils/mod.rs`.
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use super::ast::*;
 use super::dialect::*;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -16,15 +16,24 @@
 //!
 //! The tokens then form the input for the parser, which outputs an Abstract Syntax Tree (AST).
 
-use std::iter::Peekable;
-use std::str::Chars;
+use core::iter::Peekable;
+use core::str::Chars;
 
 use super::dialect::keywords::{Keyword, ALL_KEYWORDS, ALL_KEYWORDS_INDEX};
 use super::dialect::Dialect;
 use super::dialect::SnowflakeDialect;
+use core::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+    borrow::ToOwned,
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 
 /// SQL Token enumeration
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -831,6 +840,8 @@ mod tests {
         let dialect = GenericDialect {};
         let mut tokenizer = Tokenizer::new(&dialect, &sql);
         let tokens = tokenizer.tokenize().unwrap();
+
+        #[cfg(feature = "std")]
         println!("tokens: {:#?}", tokens);
         let expected = vec![
             Token::Whitespace(Whitespace::Newline),
@@ -878,6 +889,8 @@ mod tests {
         let dialect = GenericDialect {};
         let mut tokenizer = Tokenizer::new(&dialect, &sql);
         let tokens = tokenizer.tokenize().unwrap();
+
+        #[cfg(feature = "std")]
         println!("tokens: {:#?}", tokens);
         let expected = vec![
             Token::Whitespace(Whitespace::Newline),


### PR DESCRIPTION
I'm looking to use this in a no_std + alloc environment and so it would be really helpful to allow that. I've implemented this by having a `std` feature that is enabled by default, so it shouldn't affect existing users. The only thing the library uses that isn't available in core or alloc is the error trait, and a few `println!`s in tests.