### PR TITLE
Add Tokenizer::tokenize_with_location() API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlparser"
 description = "Extensible SQL Lexer and Parser with support for ANSI SQL:2011"
-version = "0.7.1-alpha.0"
+version = "0.7.1"
 authors = ["Andy Grove <andygrove73@gmail.com>"]
 homepage = "https://github.com/ballista-compute/sqlparser-rs"
 documentation = "https://docs.rs/sqlparser/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlparser"
 description = "Extensible SQL Lexer and Parser with support for ANSI SQL:2011"
-version = "0.7.1"
+version = "0.7.1-alpha.0"
 authors = ["Andy Grove <andygrove73@gmail.com>"]
 homepage = "https://github.com/ballista-compute/sqlparser-rs"
 documentation = "https://docs.rs/sqlparser/"

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -254,14 +254,16 @@ impl fmt::Display for Whitespace {
 }
 
 /// Location in input string
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Location {
+    /// Line number, starting from 1
     pub line: u64,
+    /// Line column, starting from 1
     pub column: u64,
 }
 
 /// A [Token] with [Location] attached to it
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct TokenWithLocation {
     pub token: Token,
     pub location: Location,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -344,7 +344,7 @@ impl<'a> Tokenizer<'a> {
         Ok(tokens)
     }
 
-    /// Tokenize the statement and produce a vector of tokens
+    /// Tokenize the statement and produce a vector of tokens with location information
     pub fn tokenize_with_location(&mut self) -> Result<Vec<TokenWithLocation>, TokenizerError> {
         let mut state = State {
             peekable: self.query.chars().peekable(),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -323,16 +323,13 @@ impl<'a> State<'a> {
 /// SQL Tokenizer
 pub struct Tokenizer<'a> {
     dialect: &'a dyn Dialect,
-    pub query: String,
+    pub query: &'a str,
 }
 
 impl<'a> Tokenizer<'a> {
     /// Create a new SQL tokenizer for the specified SQL statement
-    pub fn new(dialect: &'a dyn Dialect, query: &str) -> Self {
-        Self {
-            dialect,
-            query: query.to_string(),
-        }
+    pub fn new(dialect: &'a dyn Dialect, query: &'a str) -> Self {
+        Self { dialect, query }
     }
 
     /// Tokenize the statement and produce a vector of tokens

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -253,6 +253,20 @@ impl fmt::Display for Whitespace {
     }
 }
 
+/// Location in input string
+#[derive(Debug, PartialEq)]
+pub struct Location {
+    pub line: usize,
+    pub position: usize,
+}
+
+/// A [Token] with [Location] attached to it
+#[derive(Debug, PartialEq)]
+pub struct TokenWithLocation {
+    pub token: Token,
+    pub location: Location,
+}
+
 /// Tokenizer error
 #[derive(Debug, PartialEq)]
 pub struct TokenizerError {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -357,7 +357,7 @@ impl<'a> Tokenizer<'a> {
         let mut location = state.location();
         while let Some(token) = self.next_token(&mut state)? {
             tokens.push(TokenWithLocation {
-                token: token,
+                token,
                 location: location.clone(),
             });
 


### PR DESCRIPTION
* add TokenWithLocation to track Token location
* implement Tokenizer::tokenize_with_location() -> ``Result<Vec<TokenWithLocation>, ..>``
* refactor line/column tracking to alter current position along with peekable.next() (the old approach with duplicate position tracking was error-prone and contained a bug in multiline word parsing, see the test)
* eliminate String copying for Tokenizer, use ``&'a str`` instead
* minor TokenizerError column fixes, now it shows the missing symbol position and not the expected token start location