### PR TITLE
Add referential actions to TableConstraint foreign key

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -136,12 +136,17 @@ pub enum TableConstraint {
         is_primary: bool,
     },
     /// A referential integrity constraint (`[ CONSTRAINT <name> ] FOREIGN KEY (<columns>)
-    /// REFERENCES <foreign_table> (<referred_columns>)`)
+    /// REFERENCES <foreign_table> (<referred_columns>)
+    /// { [ON DELETE <referential_action>] [ON UPDATE <referential_action>] |
+    ///   [ON UPDATE <referential_action>] [ON DELETE <referential_action>]
+    /// }`).
     ForeignKey {
         name: Option<Ident>,
         columns: Vec<Ident>,
         foreign_table: ObjectName,
         referred_columns: Vec<Ident>,
+        on_delete: Option<ReferentialAction>,
+        on_update: Option<ReferentialAction>,
     },
     /// `[ CONSTRAINT <name> ] CHECK (<expr>)`
     Check {
@@ -169,14 +174,25 @@ impl fmt::Display for TableConstraint {
                 columns,
                 foreign_table,
                 referred_columns,
-            } => write!(
-                f,
-                "{}FOREIGN KEY ({}) REFERENCES {}({})",
-                display_constraint_name(name),
-                display_comma_separated(columns),
-                foreign_table,
-                display_comma_separated(referred_columns)
-            ),
+                on_delete,
+                on_update,
+            } => {
+                write!(
+                    f,
+                    "{}FOREIGN KEY ({}) REFERENCES {}({})",
+                    display_constraint_name(name),
+                    display_comma_separated(columns),
+                    foreign_table,
+                    display_comma_separated(referred_columns),
+                )?;
+                if let Some(action) = on_delete {
+                    write!(f, " ON DELETE {}", action)?;
+                }
+                if let Some(action) = on_update {
+                    write!(f, " ON UPDATE {}", action)?;
+                }
+                Ok(())
+            }
             TableConstraint::Check { name, expr } => {
                 write!(f, "{}CHECK ({})", display_constraint_name(name), expr)
             }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1162,7 +1162,9 @@ fn parse_create_table() {
                lng DOUBLE,
                constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0),
                ref INT REFERENCES othertable (a, b),\
-               ref2 INT references othertable2 on delete cascade on update no action\
+               ref2 INT references othertable2 on delete cascade on update no action,\
+               constraint fkey foreign key (lat) references othertable3 (lat) on delete restrict,\
+               FOREIGN KEY (lng) REFERENCES othertable4 (longitude) ON UPDATE SET NULL
                )";
     let ast = one_statement_parses_to(
         sql,
@@ -1172,7 +1174,9 @@ fn parse_create_table() {
          lng DOUBLE, \
          constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), \
          ref INT REFERENCES othertable (a, b), \
-         ref2 INT REFERENCES othertable2 ON DELETE CASCADE ON UPDATE NO ACTION)",
+         ref2 INT REFERENCES othertable2 ON DELETE CASCADE ON UPDATE NO ACTION, \
+         CONSTRAINT fkey FOREIGN KEY (lat) REFERENCES othertable3(lat) ON DELETE RESTRICT, \
+         FOREIGN KEY (lng) REFERENCES othertable4(longitude) ON UPDATE SET NULL)",
     );
     match ast {
         Statement::CreateTable {
@@ -1271,7 +1275,27 @@ fn parse_create_table() {
                     }
                 ]
             );
-            assert!(constraints.is_empty());
+            assert_eq!(
+                constraints,
+                vec![
+                    TableConstraint::ForeignKey {
+                        name: Some("fkey".into()),
+                        columns: vec!["lat".into()],
+                        foreign_table: ObjectName(vec!["othertable3".into()]),
+                        referred_columns: vec!["lat".into()],
+                        on_delete: Some(ReferentialAction::Restrict),
+                        on_update: None
+                    },
+                    TableConstraint::ForeignKey {
+                        name: None,
+                        columns: vec!["lng".into()],
+                        foreign_table: ObjectName(vec!["othertable4".into()]),
+                        referred_columns: vec!["longitude".into()],
+                        on_delete: None,
+                        on_update: Some(ReferentialAction::SetNull)
+                    },
+                ]
+            );
             assert_eq!(with_options, vec![]);
         }
         _ => unreachable!(),


### PR DESCRIPTION
This adds `ON UPDATE` and `ON DELETE` actions to `sqlparser::ast::TableConstraint::ForeignKey`, as described in [table constraint](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#table-constraint-definition) and [references specification](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#references-specification).