### PR TITLE
Implement parsing of Postgres regex match operators

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -80,6 +80,10 @@ pub enum BinaryOperator {
     PGBitwiseXor,
     PGBitwiseShiftLeft,
     PGBitwiseShiftRight,
+    PGRegexMatch,
+    PGRegexIMatch,
+    PGRegexNotMatch,
+    PGRegexNotIMatch,
 }
 
 impl fmt::Display for BinaryOperator {
@@ -110,6 +114,10 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::PGBitwiseXor => "#",
             BinaryOperator::PGBitwiseShiftLeft => "<<",
             BinaryOperator::PGBitwiseShiftRight => ">>",
+            BinaryOperator::PGRegexMatch => "~",
+            BinaryOperator::PGRegexIMatch => "~*",
+            BinaryOperator::PGRegexNotMatch => "!~",
+            BinaryOperator::PGRegexNotIMatch => "!~*",
         })
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -835,6 +835,18 @@ impl<'a> Parser<'a> {
             Token::Sharp if dialect_of!(self is PostgreSqlDialect) => {
                 Some(BinaryOperator::PGBitwiseXor)
             }
+            Token::Tilde if dialect_of!(self is PostgreSqlDialect) => {
+                Some(BinaryOperator::PGRegexMatch)
+            }
+            Token::TildeAsterisk if dialect_of!(self is PostgreSqlDialect) => {
+                Some(BinaryOperator::PGRegexIMatch)
+            }
+            Token::ExclamationMarkTilde if dialect_of!(self is PostgreSqlDialect) => {
+                Some(BinaryOperator::PGRegexNotMatch)
+            }
+            Token::ExclamationMarkTildeAsterisk if dialect_of!(self is PostgreSqlDialect) => {
+                Some(BinaryOperator::PGRegexNotIMatch)
+            }
             Token::Word(w) => match w.keyword {
                 Keyword::AND => Some(BinaryOperator::And),
                 Keyword::OR => Some(BinaryOperator::Or),
@@ -1002,6 +1014,10 @@ impl<'a> Parser<'a> {
             Token::DoubleColon => Ok(50),
             Token::ExclamationMark => Ok(50),
             Token::LBracket | Token::RBracket => Ok(10),
+            Token::Tilde
+            | Token::TildeAsterisk
+            | Token::ExclamationMarkTilde
+            | Token::ExclamationMarkTildeAsterisk => Ok(19),
             _ => Ok(0),
         }
     }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -647,6 +647,28 @@ fn parse_pg_postfix_factorial() {
     }
 }
 
+#[test]
+fn parse_pg_regex_binary_ops() {
+    let regex_ops = &[
+        ("~", BinaryOperator::PGRegexMatch),
+        ("!~", BinaryOperator::PGRegexNotMatch),
+        ("~*", BinaryOperator::PGRegexIMatch),
+        ("!~*", BinaryOperator::PGRegexNotIMatch),
+    ];
+
+    for (str_op, op) in regex_ops {
+        let select = pg().verified_only_select(&format!("SELECT a {} b", &str_op));
+        assert_eq!(
+            SelectItem::UnnamedExpr(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("a"))),
+                op: op.clone(),
+                right: Box::new(Expr::Identifier(Ident::new("b"))),
+            }),
+            select.projection[0]
+        );
+    }
+}
+
 fn pg() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(PostgreSqlDialect {})],


### PR DESCRIPTION
Hey all,

This PR adds support for parsing Postgres' [POSIX regex matching operators](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-POSIX-REGEXP). These are similar in nature to `LIKE` et al but with full support for regex patterns rather than being restricted to wildcards, so you can use `select * from my_table where name ~ '^pattern$'`.

I've restricted the parsing to only run when using the Postgres dialect, but I've not given lexing the same treatment as that doesn't _seem_ to be the done thing (e.g. `PGBitwiseXor` is lexed unconditionally). If this is actually desired, please let me know!

I'm not entirely happy with the token names, but given the overlap (e.g. `~` is both a unary and bitwise op now) I didn't want to attach names that were overly specific either.