### PR TITLE
Support minimum display width for integer data types

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -42,13 +42,13 @@ pub enum DataType {
     /// Floating point with optional precision e.g. FLOAT(8)
     Float(Option<u64>),
     /// Tiny integer
-    TinyInt,
+    TinyInt(Option<u64>),
     /// Small integer
-    SmallInt,
+    SmallInt(Option<u64>),
     /// Integer
-    Int,
+    Int(Option<u64>),
     /// Big integer
-    BigInt,
+    BigInt(Option<u64>),
     /// Floating point e.g. REAL
     Real,
     /// Double e.g. DOUBLE PRECISION
@@ -97,10 +97,12 @@ impl fmt::Display for DataType {
                 }
             }
             DataType::Float(size) => format_type_with_optional_length(f, "FLOAT", size),
-            DataType::TinyInt => write!(f, "TINYINT"),
-            DataType::SmallInt => write!(f, "SMALLINT"),
-            DataType::Int => write!(f, "INT"),
-            DataType::BigInt => write!(f, "BIGINT"),
+            DataType::TinyInt(zerofill) => format_type_with_optional_length(f, "TINYINT", zerofill),
+            DataType::SmallInt(zerofill) => {
+                format_type_with_optional_length(f, "SMALLINT", zerofill)
+            }
+            DataType::Int(zerofill) => format_type_with_optional_length(f, "INT", zerofill),
+            DataType::BigInt(zerofill) => format_type_with_optional_length(f, "BIGINT", zerofill),
             DataType::Real => write!(f, "REAL"),
             DataType::Double => write!(f, "DOUBLE"),
             DataType::Boolean => write!(f, "BOOLEAN"),

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -41,13 +41,13 @@ pub enum DataType {
     Decimal(Option<u64>, Option<u64>),
     /// Floating point with optional precision e.g. FLOAT(8)
     Float(Option<u64>),
-    /// Tiny integer
+    /// Tiny integer with optional display width e.g. TINYINT or TINYINT(3)
     TinyInt(Option<u64>),
-    /// Small integer
+    /// Small integer with optional display width e.g. SMALLINT or SMALLINT(5)
     SmallInt(Option<u64>),
-    /// Integer
+    /// Integer with optional display width e.g. INT or INT(11)
     Int(Option<u64>),
-    /// Big integer
+    /// Big integer with optional display width e.g. BIGINT or BIGINT(20)
     BigInt(Option<u64>),
     /// Floating point e.g. REAL
     Real,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1995,7 +1995,9 @@ impl<'a> Parser<'a> {
                 }
                 Keyword::TINYINT => Ok(DataType::TinyInt(self.parse_optional_precision()?)),
                 Keyword::SMALLINT => Ok(DataType::SmallInt(self.parse_optional_precision()?)),
-                Keyword::INT | Keyword::INTEGER => Ok(DataType::Int(self.parse_optional_precision()?)),
+                Keyword::INT | Keyword::INTEGER => {
+                    Ok(DataType::Int(self.parse_optional_precision()?))
+                }
                 Keyword::BIGINT => Ok(DataType::BigInt(self.parse_optional_precision()?)),
                 Keyword::VARCHAR => Ok(DataType::Varchar(self.parse_optional_precision()?)),
                 Keyword::CHAR | Keyword::CHARACTER => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1993,10 +1993,10 @@ impl<'a> Parser<'a> {
                     let _ = self.parse_keyword(Keyword::PRECISION);
                     Ok(DataType::Double)
                 }
-                Keyword::TINYINT => Ok(DataType::TinyInt),
-                Keyword::SMALLINT => Ok(DataType::SmallInt),
-                Keyword::INT | Keyword::INTEGER => Ok(DataType::Int),
-                Keyword::BIGINT => Ok(DataType::BigInt),
+                Keyword::TINYINT => Ok(DataType::TinyInt(self.parse_optional_precision()?)),
+                Keyword::SMALLINT => Ok(DataType::SmallInt(self.parse_optional_precision()?)),
+                Keyword::INT | Keyword::INTEGER => Ok(DataType::Int(self.parse_optional_precision()?)),
+                Keyword::BIGINT => Ok(DataType::BigInt(self.parse_optional_precision()?)),
                 Keyword::VARCHAR => Ok(DataType::Varchar(self.parse_optional_precision()?)),
                 Keyword::CHAR | Keyword::CHARACTER => {
                     if self.parse_keyword(Keyword::VARYING) {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1013,7 +1013,7 @@ fn parse_cast() {
     assert_eq!(
         &Expr::Cast {
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
-            data_type: DataType::BigInt
+            data_type: DataType::BigInt(None)
         },
         expr_from_projection(only(&select.projection))
     );
@@ -1023,7 +1023,7 @@ fn parse_cast() {
     assert_eq!(
         &Expr::Cast {
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
-            data_type: DataType::TinyInt
+            data_type: DataType::TinyInt(None)
         },
         expr_from_projection(only(&select.projection))
     );
@@ -1053,7 +1053,7 @@ fn parse_try_cast() {
     assert_eq!(
         &Expr::TryCast {
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
-            data_type: DataType::BigInt
+            data_type: DataType::BigInt(None)
         },
         expr_from_projection(only(&select.projection))
     );
@@ -1216,7 +1216,7 @@ fn parse_create_table() {
                     },
                     ColumnDef {
                         name: "constrained".into(),
-                        data_type: DataType::Int,
+                        data_type: DataType::Int(None),
                         collation: None,
                         options: vec![
                             ColumnOptionDef {
@@ -1243,7 +1243,7 @@ fn parse_create_table() {
                     },
                     ColumnDef {
                         name: "ref".into(),
-                        data_type: DataType::Int,
+                        data_type: DataType::Int(None),
                         collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
@@ -1257,7 +1257,7 @@ fn parse_create_table() {
                     },
                     ColumnDef {
                         name: "ref2".into(),
-                        data_type: DataType::Int,
+                        data_type: DataType::Int(None),
                         collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -16,6 +16,7 @@
 
 #[macro_use]
 mod test_utils;
+
 use test_utils::*;
 
 use sqlparser::ast::*;
@@ -109,19 +110,19 @@ fn parse_create_table_auto_increment() {
             assert_eq!(
                 vec![ColumnDef {
                     name: Ident::new("bar"),
-                    data_type: DataType::Int,
+                    data_type: DataType::Int(None),
                     collation: None,
                     options: vec![
                         ColumnOptionDef {
                             name: None,
-                            option: ColumnOption::Unique { is_primary: true }
+                            option: ColumnOption::Unique { is_primary: true },
                         },
                         ColumnOptionDef {
                             name: None,
                             option: ColumnOption::DialectSpecific(vec![Token::make_keyword(
                                 "AUTO_INCREMENT"
-                            )])
-                        }
+                            )]),
+                        },
                     ],
                 }],
                 columns
@@ -140,13 +141,53 @@ fn parse_quote_identifiers() {
             assert_eq!(
                 vec![ColumnDef {
                     name: Ident::with_quote('`', "BEGIN"),
-                    data_type: DataType::Int,
+                    data_type: DataType::Int(None),
                     collation: None,
                     options: vec![ColumnOptionDef {
                         name: None,
-                        option: ColumnOption::Unique { is_primary: true }
+                        option: ColumnOption::Unique { is_primary: true },
                     }],
                 }],
+                columns
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_table_with_minimum_display_width() {
+    let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3), bar_smallint SMALLINT(5), bar_int INT(11), bar_bigint BIGINT(20))";
+    match mysql().verified_stmt(sql) {
+        Statement::CreateTable { name, columns, .. } => {
+            assert_eq!(name.to_string(), "foo");
+            assert_eq!(
+                vec![
+                    ColumnDef {
+                        name: Ident::new("bar_tinyint"),
+                        data_type: DataType::TinyInt(Some(3)),
+                        collation: None,
+                        options: vec![],
+                    },
+                    ColumnDef {
+                        name: Ident::new("bar_smallint"),
+                        data_type: DataType::SmallInt(Some(5)),
+                        collation: None,
+                        options: vec![],
+                    },
+                    ColumnDef {
+                        name: Ident::new("bar_int"),
+                        data_type: DataType::Int(Some(11)),
+                        collation: None,
+                        options: vec![],
+                    },
+                    ColumnDef {
+                        name: Ident::new("bar_bigint"),
+                        data_type: DataType::BigInt(Some(20)),
+                        collation: None,
+                        options: vec![],
+                    }
+                ],
                 columns
             );
         }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -54,7 +54,7 @@ fn parse_create_table_with_defaults() {
                 vec![
                     ColumnDef {
                         name: "customer_id".into(),
-                        data_type: DataType::Int,
+                        data_type: DataType::Int(None),
                         collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
@@ -65,7 +65,7 @@ fn parse_create_table_with_defaults() {
                     },
                     ColumnDef {
                         name: "store_id".into(),
-                        data_type: DataType::SmallInt,
+                        data_type: DataType::SmallInt(None),
                         collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
@@ -98,7 +98,7 @@ fn parse_create_table_with_defaults() {
                     },
                     ColumnDef {
                         name: "address_id".into(),
-                        data_type: DataType::SmallInt,
+                        data_type: DataType::SmallInt(None),
                         collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
@@ -154,7 +154,7 @@ fn parse_create_table_with_defaults() {
                     },
                     ColumnDef {
                         name: "active".into(),
-                        data_type: DataType::Int,
+                        data_type: DataType::Int(None),
                         collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
@@ -574,7 +574,7 @@ fn parse_prepare() {
             ..
         } => {
             assert_eq!(name, "a".into());
-            assert_eq!(data_types, vec![DataType::Int, DataType::Text]);
+            assert_eq!(data_types, vec![DataType::Int(None), DataType::Text]);
 
             statement
         }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -68,7 +68,7 @@ fn parse_create_table_auto_increment() {
             assert_eq!(
                 vec![ColumnDef {
                     name: "bar".into(),
-                    data_type: DataType::Int,
+                    data_type: DataType::Int(None),
                     collation: None,
                     options: vec![
                         ColumnOptionDef {
@@ -100,13 +100,13 @@ fn parse_create_sqlite_quote() {
                 vec![
                     ColumnDef {
                         name: Ident::with_quote('"', "KEY"),
-                        data_type: DataType::Int,
+                        data_type: DataType::Int(None),
                         collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::with_quote('[', "INDEX"),
-                        data_type: DataType::Int,
+                        data_type: DataType::Int(None),
                         collation: None,
                         options: vec![],
                     },


### PR DESCRIPTION
This PR address the #279 issue as MySQL supports the [minimum display width](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html) for integer data types.