### PR TITLE
Implement some MySQL specific syntax and extend the UPDATE statement

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -40,6 +40,7 @@ $ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
         "--ansi" => Box::new(AnsiDialect {}),
         "--postgres" => Box::new(PostgreSqlDialect {}),
         "--ms" => Box::new(MsSqlDialect {}),
+        "--mysql" => Box::new(MySqlDialect {}),
         "--snowflake" => Box::new(SnowflakeDialect {}),
         "--hive" => Box::new(HiveDialect {}),
         "--generic" | "" => Box::new(GenericDialect {}),

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -60,6 +60,13 @@ pub enum AlterTableOperation {
     },
     /// `RENAME TO <table_name>`
     RenameTable { table_name: ObjectName },
+    // CHANGE [ COLUMN ] <old_name> <new_name> <data_type> [ <options> ]
+    ChangeColumn {
+        old_name: Ident,
+        new_name: Ident,
+        data_type: DataType,
+        options: Vec<ColumnOption>,
+    },
 }
 
 impl fmt::Display for AlterTableOperation {
@@ -118,6 +125,14 @@ impl fmt::Display for AlterTableOperation {
             ),
             AlterTableOperation::RenameTable { table_name } => {
                 write!(f, "RENAME TO {}", table_name)
+            }
+            AlterTableOperation::ChangeColumn {old_name, new_name, data_type, options} => {
+                write!(f, "CHANGE COLUMN {} {} {}", old_name, new_name, data_type)?;
+                if options.is_empty() {
+                    Ok(())
+                }else {
+                    write!(f, " {}", display_separated(options, " "))
+                }
             }
         }
     }

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -126,11 +126,16 @@ impl fmt::Display for AlterTableOperation {
             AlterTableOperation::RenameTable { table_name } => {
                 write!(f, "RENAME TO {}", table_name)
             }
-            AlterTableOperation::ChangeColumn {old_name, new_name, data_type, options} => {
+            AlterTableOperation::ChangeColumn {
+                old_name,
+                new_name,
+                data_type,
+                options,
+            } => {
                 write!(f, "CHANGE COLUMN {} {} {}", old_name, new_name, data_type)?;
                 if options.is_empty() {
                     Ok(())
-                }else {
+                } else {
                     write!(f, " {}", display_separated(options, " "))
                 }
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1373,7 +1373,7 @@ impl fmt::Display for Statement {
 #[non_exhaustive]
 pub enum OnInsert {
     /// ON DUPLICATE KEY UPDATE (MySQL when the key already exists, then execute an update instead)
-    DuplicateKeyUpdate(Vec<Expr>),
+    DuplicateKeyUpdate(Vec<Assignment>),
 }
 
 impl fmt::Display for OnInsert {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -497,7 +497,6 @@ impl fmt::Display for WindowFrameUnits {
     }
 }
 
-
 /// Specifies [WindowFrame]'s `start_bound` and `end_bound`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -629,7 +628,7 @@ pub enum Statement {
     /// UPDATE
     Update {
         /// TABLE
-        table_name: ObjectName,
+        table: TableWithJoins,
         /// Column assignments
         assignments: Vec<Assignment>,
         /// WHERE
@@ -992,11 +991,11 @@ impl fmt::Display for Statement {
                 write!(f, "\n\\.")
             }
             Statement::Update {
-                table_name,
+                table,
                 assignments,
                 selection,
             } => {
-                write!(f, "UPDATE {}", table_name)?;
+                write!(f, "UPDATE {}", table)?;
                 if !assignments.is_empty() {
                     write!(f, " SET {}", display_comma_separated(assignments))?;
                 }
@@ -1379,7 +1378,11 @@ pub enum OnInsert {
 impl fmt::Display for OnInsert {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            OnInsert::DuplicateKeyUpdate(expr) => write!(f, " ON DUPLICATE KEY UPDATE {}", display_comma_separated(expr)),
+            Self::DuplicateKeyUpdate(expr) => write!(
+                f,
+                " ON DUPLICATE KEY UPDATE {}",
+                display_comma_separated(expr)
+            ),
         }
     }
 }
@@ -1388,13 +1391,13 @@ impl fmt::Display for OnInsert {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Assignment {
-    pub id: Ident,
+    pub id: Vec<Ident>,
     pub value: Expr,
 }
 
 impl fmt::Display for Assignment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} = {}", self.id, self.value)
+        write!(f, "{} = {}", display_separated(&self.id, "."), self.value)
     }
 }
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -535,6 +535,7 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::DISTRIBUTE,
     // for MSSQL-specific OUTER APPLY (seems reserved in most dialects)
     Keyword::OUTER,
+    Keyword::SET,
 ];
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -114,6 +114,7 @@ define_keywords!(
     CEIL,
     CEILING,
     CHAIN,
+    CHANGE,
     CHAR,
     CHARACTER,
     CHARACTER_LENGTH,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -181,6 +181,7 @@ define_keywords!(
     DISTRIBUTE,
     DOUBLE,
     DROP,
+    DUPLICATE,
     DYNAMIC,
     EACH,
     ELEMENT,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2939,10 +2939,10 @@ impl<'a> Parser<'a> {
             let after_columns = self.parse_parenthesized_column_list(Optional)?;
 
             let source = Box::new(self.parse_query()?);
-            let on = if dialect_of!(self is MySqlDialect) && self.parse_keyword(Keyword::ON) {
-                self.expect_keyword(Keyword::DUPLICATE);
-                self.expect_keyword(Keyword::KEY);
-                self.expect_keyword(Keyword::UPDATE);
+            let on = if self.parse_keyword(Keyword::ON) {
+                self.expect_keyword(Keyword::DUPLICATE)?;
+                self.expect_keyword(Keyword::KEY)?;
+                self.expect_keyword(Keyword::UPDATE)?;
                 let l = self.parse_comma_separated(Parser::parse_expr)?;
 
                 Some(OnInsert::DuplicateKeyUpdate(l))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1914,7 +1914,7 @@ impl<'a> Parser<'a> {
                 data_type,
                 options,
             }
-        }else {
+        } else {
             return self.expected(
                 "ADD, RENAME, PARTITION or DROP after ALTER TABLE",
                 self.peek_token(),
@@ -2191,7 +2191,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse identifiers strictly i.e. don't parse keywords
-    pub fn parse_identifiers_strict(&mut self) -> Result<Vec<Ident>, ParserError> {
+    pub fn parse_identifiers_non_keywords(&mut self) -> Result<Vec<Ident>, ParserError> {
         let mut idents = vec![];
         loop {
             match self.peek_token() {
@@ -3027,7 +3027,7 @@ impl<'a> Parser<'a> {
 
     /// Parse a `var = expr` assignment, used in an UPDATE statement
     pub fn parse_assignment(&mut self) -> Result<Assignment, ParserError> {
-        let id = self.parse_identifiers_strict()?;
+        let id = self.parse_identifiers_non_keywords()?;
         self.expect_token(&Token::Eq)?;
         let value = self.parse_expr()?;
         Ok(Assignment { id, value })

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2322,6 +2322,7 @@ impl<'a> Parser<'a> {
             })
         } else {
             let insert = self.parse_insert()?;
+
             Ok(Query {
                 with,
                 body: SetExpr::Insert(insert),
@@ -2938,6 +2939,17 @@ impl<'a> Parser<'a> {
             let after_columns = self.parse_parenthesized_column_list(Optional)?;
 
             let source = Box::new(self.parse_query()?);
+            let on = if dialect_of!(self is MySqlDialect) && self.parse_keyword(Keyword::ON) {
+                self.expect_keyword(Keyword::DUPLICATE);
+                self.expect_keyword(Keyword::KEY);
+                self.expect_keyword(Keyword::UPDATE);
+                let l = self.parse_comma_separated(Parser::parse_expr)?;
+
+                Some(OnInsert::DuplicateKeyUpdate(l))
+            } else {
+                None
+            };
+
             Ok(Statement::Insert {
                 or,
                 table_name,
@@ -2947,6 +2959,7 @@ impl<'a> Parser<'a> {
                 after_columns,
                 source,
                 table,
+                on,
             })
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -637,25 +637,15 @@ impl<'a> Parser<'a> {
         // PARSE SUBSTRING (EXPR [FROM 1] [FOR 3])
         self.expect_token(&Token::LParen)?;
         let expr = self.parse_expr()?;
-        let from_expr = if self.parse_keyword(Keyword::FROM) {
-            Some(self.parse_expr()?)
-        } else {
-            if self.consume_token(&Token::Comma) {
-                Some(self.parse_expr()?)
-            } else {
-                None
-            }
-        };
+        let mut from_expr = None;
+        if self.parse_keyword(Keyword::FROM) || self.consume_token(&Token::Comma) {
+            from_expr = Some(self.parse_expr()?);
+        }
 
-        let to_expr = if self.parse_keyword(Keyword::FOR) {
-            Some(self.parse_expr()?)
-        } else {
-            if self.consume_token(&Token::Comma) {
-                Some(self.parse_expr()?)
-            } else {
-                None
-            }
-        };
+        let mut to_expr = None;
+        if self.parse_keyword(Keyword::FOR) || self.consume_token(&Token::Comma) {
+            to_expr = Some(self.parse_expr()?);
+        }
         self.expect_token(&Token::RParen)?;
 
         Ok(Expr::Substring {
@@ -1911,12 +1901,8 @@ impl<'a> Parser<'a> {
             let new_name = self.parse_identifier()?;
             let data_type = self.parse_data_type()?;
             let mut options = vec![];
-            loop {
-                if let Some(option) = self.parse_optional_column_option()? {
-                    options.push(option);
-                } else {
-                    break;
-                }
+            while let Some(option) = self.parse_optional_column_option()? {
+                options.push(option);
             }
 
             AlterTableOperation::ChangeColumn {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2943,7 +2943,7 @@ impl<'a> Parser<'a> {
                 self.expect_keyword(Keyword::DUPLICATE)?;
                 self.expect_keyword(Keyword::KEY)?;
                 self.expect_keyword(Keyword::UPDATE)?;
-                let l = self.parse_comma_separated(Parser::parse_expr)?;
+                let l = self.parse_comma_separated(Parser::parse_assignment)?;
 
                 Some(OnInsert::DuplicateKeyUpdate(l))
             } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -637,14 +637,25 @@ impl<'a> Parser<'a> {
         // PARSE SUBSTRING (EXPR [FROM 1] [FOR 3])
         self.expect_token(&Token::LParen)?;
         let expr = self.parse_expr()?;
-        let mut from_expr = None;
-        let mut to_expr = None;
-        if self.parse_keyword(Keyword::FROM) {
-            from_expr = Some(self.parse_expr()?);
-        }
-        if self.parse_keyword(Keyword::FOR) {
-            to_expr = Some(self.parse_expr()?);
-        }
+        let from_expr = if self.parse_keyword(Keyword::FROM) {
+            Some(self.parse_expr()?)
+        } else {
+            if self.consume_token(&Token::Comma) {
+                Some(self.parse_expr()?)
+            } else {
+                None
+            }
+        };
+
+        let to_expr = if self.parse_keyword(Keyword::FOR) {
+            Some(self.parse_expr()?)
+        } else {
+            if self.consume_token(&Token::Comma) {
+                Some(self.parse_expr()?)
+            } else {
+                None
+            }
+        };
         self.expect_token(&Token::RParen)?;
 
         Ok(Expr::Substring {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1894,7 +1894,27 @@ impl<'a> Parser<'a> {
                 old_partitions: before,
                 new_partitions: renames,
             }
-        } else {
+        } else if self.parse_keyword(Keyword::CHANGE) {
+            let _ = self.parse_keyword(Keyword::COLUMN);
+            let old_name = self.parse_identifier()?;
+            let new_name = self.parse_identifier()?;
+            let data_type = self.parse_data_type()?;
+            let mut options = vec![];
+            loop {
+                if let Some(option) = self.parse_optional_column_option()? {
+                    options.push(option);
+                } else {
+                    break;
+                }
+            }
+
+            AlterTableOperation::ChangeColumn {
+                old_name,
+                new_name,
+                data_type,
+                options,
+            }
+        }else {
             return self.expected(
                 "ADD, RENAME, PARTITION or DROP after ALTER TABLE",
                 self.peek_token(),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -140,25 +140,25 @@ fn parse_update() {
     let sql = "UPDATE t SET a = 1, b = 2, c = 3 WHERE d";
     match verified_stmt(sql) {
         Statement::Update {
-            table_name,
+            table,
             assignments,
             selection,
             ..
         } => {
-            assert_eq!(table_name.to_string(), "t".to_string());
+            assert_eq!(table.to_string(), "t".to_string());
             assert_eq!(
                 assignments,
                 vec![
                     Assignment {
-                        id: "a".into(),
+                        id: vec!["a".into()],
                         value: Expr::Value(number("1")),
                     },
                     Assignment {
-                        id: "b".into(),
+                        id: vec!["b".into()],
                         value: Expr::Value(number("2")),
                     },
                     Assignment {
-                        id: "c".into(),
+                        id: vec!["c".into()],
                         value: Expr::Value(number("3")),
                     },
                 ]
@@ -183,6 +183,55 @@ fn parse_update() {
         ParserError::ParserError("Expected end of statement, found: extrabadstuff".to_string()),
         res.unwrap_err()
     );
+}
+
+#[test]
+fn parse_update_with_table_alias() {
+    let sql = "UPDATE users AS u SET u.username = 'new_user' WHERE u.username = 'old_user'";
+    match verified_stmt(sql) {
+        Statement::Update {
+            table,
+            assignments,
+            selection,
+        } => {
+            assert_eq!(
+                TableWithJoins {
+                    relation: TableFactor::Table {
+                        name: ObjectName(vec![Ident::new("users")]),
+                        alias: Some(TableAlias {
+                            name: Ident::new("u"),
+                            columns: vec![]
+                        }),
+                        args: vec![],
+                        with_hints: vec![],
+                    },
+                    joins: vec![]
+                },
+                table
+            );
+            assert_eq!(
+                vec![Assignment {
+                    id: vec![Ident::new("u"), Ident::new("username")],
+                    value: Expr::Value(Value::SingleQuotedString("new_user".to_string()))
+                }],
+                assignments
+            );
+            assert_eq!(
+                Some(Expr::BinaryOp {
+                    left: Box::new(Expr::CompoundIdentifier(vec![
+                        Ident::new("u"),
+                        Ident::new("username")
+                    ])),
+                    op: BinaryOperator::Eq,
+                    right: Box::new(Expr::Value(Value::SingleQuotedString(
+                        "old_user".to_string()
+                    )))
+                }),
+                selection
+            );
+        }
+        _ => unreachable!(),
+    }
 }
 
 #[test]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -310,66 +310,61 @@ fn insert_with_on_duplicate_update() {
             );
             assert_eq!(
                 Some(OnInsert::DuplicateKeyUpdate(vec![
-                    Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident::new("description".to_string()))),
-                        op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Function(Function {
+                    Assignment {
+                        id: Ident::new("description".to_string()),
+                        value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(Expr::Identifier(Ident::new(
                                 "description"
                             )))],
                             over: None,
                             distinct: false
-                        }))
+                        })
                     },
-                    Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident::new("perm_create".to_string()))),
-                        op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Function(Function {
+                    Assignment {
+                        id: Ident::new("perm_create".to_string()),
+                        value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(Expr::Identifier(Ident::new(
                                 "perm_create"
                             )))],
                             over: None,
                             distinct: false
-                        }))
+                        })
                     },
-                    Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident::new("perm_read".to_string()))),
-                        op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Function(Function {
+                    Assignment {
+                        id: Ident::new("perm_read".to_string()),
+                        value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(Expr::Identifier(Ident::new(
                                 "perm_read"
                             )))],
                             over: None,
                             distinct: false
-                        }))
+                        })
                     },
-                    Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident::new("perm_update".to_string()))),
-                        op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Function(Function {
+                    Assignment {
+                        id: Ident::new("perm_update".to_string()),
+                        value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(Expr::Identifier(Ident::new(
                                 "perm_update"
                             )))],
                             over: None,
                             distinct: false
-                        }))
+                        })
                     },
-                    Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident::new("perm_delete".to_string()))),
-                        op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Function(Function {
+                    Assignment {
+                        id: Ident::new("perm_delete".to_string()),
+                        value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(Expr::Identifier(Ident::new(
                                 "perm_delete"
                             )))],
                             over: None,
                             distinct: false
-                        }))
-                    }
+                        })
+                    },
                 ])),
                 on
             );

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -470,6 +470,67 @@ fn parse_alter_table_change_column() {
     }
 }
 
+#[test]
+#[cfg(not(feature = "bigdecimal"))]
+fn parse_substring_in_select() {
+    let sql = "SELECT DISTINCT SUBSTRING(description, 0, 1) FROM test";
+    match mysql().one_statement_parses_to(
+        sql,
+        "SELECT DISTINCT SUBSTRING(description FROM 0 FOR 1) FROM test",
+    ) {
+        Statement::Query(query) => {
+            assert_eq!(
+                Box::new(Query {
+                    with: None,
+                    body: SetExpr::Select(Box::new(Select {
+                        distinct: true,
+                        top: None,
+                        projection: vec![SelectItem::UnnamedExpr(Expr::Substring {
+                            expr: Box::new(Expr::Identifier(Ident {
+                                value: "description".to_string(),
+                                quote_style: None
+                            })),
+                            substring_from: Some(Box::new(Expr::Value(Value::Number(
+                                "0".to_string(),
+                                false
+                            )))),
+                            substring_for: Some(Box::new(Expr::Value(Value::Number(
+                                "1".to_string(),
+                                false
+                            ))))
+                        })],
+                        from: vec![TableWithJoins {
+                            relation: TableFactor::Table {
+                                name: ObjectName(vec![Ident {
+                                    value: "test".to_string(),
+                                    quote_style: None
+                                }]),
+                                alias: None,
+                                args: vec![],
+                                with_hints: vec![]
+                            },
+                            joins: vec![]
+                        }],
+                        lateral_views: vec![],
+                        selection: None,
+                        group_by: vec![],
+                        cluster_by: vec![],
+                        distribute_by: vec![],
+                        sort_by: vec![],
+                        having: None,
+                    })),
+                    order_by: vec![],
+                    limit: None,
+                    offset: None,
+                    fetch: None
+                }),
+                query
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
 fn mysql() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],


### PR DESCRIPTION
Implement the `ON DUPLICATE KEY UPDATE` syntax on an `INSERT` statement which is MySQL specific as well as the ability to use joins in an `UPDATE` statement.

Besides that a breaking change was introduced on the UPDATE statement to support table aliases (which is also defined in the 2016 SQL spec).