### PR TITLE
Rname `Token::Mult` to `Token::Mul`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -382,7 +382,7 @@ impl<'a> Parser<'a> {
                         while self.consume_token(&Token::Period) {
                             match self.next_token() {
                                 Token::Word(w) => id_parts.push(w.to_ident()),
-                                Token::Mult => {
+                                Token::Mul => {
                                     ends_with_wildcard = true;
                                     break;
                                 }
@@ -404,7 +404,7 @@ impl<'a> Parser<'a> {
                     _ => Ok(Expr::Identifier(w.to_ident())),
                 },
             }, // End of Token::Word
-            Token::Mult => Ok(Expr::Wildcard),
+            Token::Mul => Ok(Expr::Wildcard),
             tok @ Token::Minus | tok @ Token::Plus => {
                 let op = if tok == Token::Plus {
                     UnaryOperator::Plus
@@ -867,7 +867,7 @@ impl<'a> Parser<'a> {
             Token::LtEq => Some(BinaryOperator::LtEq),
             Token::Plus => Some(BinaryOperator::Plus),
             Token::Minus => Some(BinaryOperator::Minus),
-            Token::Mult => Some(BinaryOperator::Multiply),
+            Token::Mul => Some(BinaryOperator::Multiply),
             Token::Mod => Some(BinaryOperator::Modulo),
             Token::StringConcat => Some(BinaryOperator::StringConcat),
             Token::Pipe => Some(BinaryOperator::BitwiseOr),
@@ -1054,7 +1054,7 @@ impl<'a> Parser<'a> {
             Token::Caret | Token::Sharp | Token::ShiftRight | Token::ShiftLeft => Ok(22),
             Token::Ampersand => Ok(23),
             Token::Plus | Token::Minus => Ok(Self::PLUS_MINUS_PREC),
-            Token::Mult | Token::Div | Token::Mod | Token::StringConcat => Ok(40),
+            Token::Mul | Token::Div | Token::Mod | Token::StringConcat => Ok(40),
             Token::DoubleColon => Ok(50),
             Token::ExclamationMark => Ok(50),
             Token::LBracket | Token::RBracket => Ok(10),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -78,7 +78,7 @@ pub enum Token {
     /// Minus operator `-`
     Minus,
     /// Multiplication operator `*`
-    Mult,
+    Mul,
     /// Division operator `/`
     Div,
     /// Modulo Operator `%`
@@ -163,7 +163,7 @@ impl fmt::Display for Token {
             Token::GtEq => f.write_str(">="),
             Token::Plus => f.write_str("+"),
             Token::Minus => f.write_str("-"),
-            Token::Mult => f.write_str("*"),
+            Token::Mul => f.write_str("*"),
             Token::Div => f.write_str("/"),
             Token::StringConcat => f.write_str("||"),
             Token::Mod => f.write_str("%"),
@@ -488,7 +488,7 @@ impl<'a> Tokenizer<'a> {
                     }
                 }
                 '+' => self.consume_and_return(chars, Token::Plus),
-                '*' => self.consume_and_return(chars, Token::Mult),
+                '*' => self.consume_and_return(chars, Token::Mul),
                 '%' => self.consume_and_return(chars, Token::Mod),
                 '|' => {
                     chars.next(); // consume the '|'
@@ -811,7 +811,7 @@ mod tests {
         let expected = vec![
             Token::make_keyword("SELECT"),
             Token::Whitespace(Whitespace::Space),
-            Token::Mult,
+            Token::Mul,
             Token::Whitespace(Whitespace::Space),
             Token::make_keyword("FROM"),
             Token::Whitespace(Whitespace::Space),
@@ -845,7 +845,7 @@ mod tests {
             Token::Whitespace(Whitespace::Space),
             Token::make_keyword("SELECT"),
             Token::Whitespace(Whitespace::Space),
-            Token::Mult,
+            Token::Mul,
             Token::Whitespace(Whitespace::Space),
             Token::make_keyword("FROM"),
             Token::Whitespace(Whitespace::Space),
@@ -877,7 +877,7 @@ mod tests {
             Token::Whitespace(Whitespace::Space),
             Token::make_keyword("SELECT"),
             Token::Whitespace(Whitespace::Space),
-            Token::Mult,
+            Token::Mul,
             Token::Whitespace(Whitespace::Space),
             Token::make_keyword("FROM"),
             Token::Whitespace(Whitespace::Space),
@@ -905,7 +905,7 @@ mod tests {
         let expected = vec![
             Token::make_keyword("SELECT"),
             Token::Whitespace(Whitespace::Space),
-            Token::Mult,
+            Token::Mul,
             Token::Whitespace(Whitespace::Space),
             Token::make_keyword("FROM"),
             Token::Whitespace(Whitespace::Space),
@@ -983,7 +983,7 @@ mod tests {
             Token::Whitespace(Whitespace::Newline),
             Token::make_keyword("SELECT"),
             Token::Whitespace(Whitespace::Space),
-            Token::Mult,
+            Token::Mul,
             Token::Whitespace(Whitespace::Space),
             Token::make_keyword("FROM"),
             Token::Whitespace(Whitespace::Space),


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

I think rust developers will be more inclined to use the abbr `Mul` for multiplication operator.