### PR TITLE
Enable map access for numbers, multiple nesting levels

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -281,21 +281,15 @@ impl fmt::Display for Expr {
         match self {
             Expr::Identifier(s) => write!(f, "{}", s),
             Expr::MapAccess { column, keys } => {
-                write!(
-                    f,
-                    "{}{}",
-                    column,
-                    keys.iter()
-                        .map(|k| {
-                            match k {
-                                k @ Value::Number(_, _) => format!("[{}]", k),
-                                Value::SingleQuotedString(s) => format!("[\"{}\"]", s),
-                                _ => format!("[{}]", k),
-                            }
-                        })
-                        .collect::<Vec<String>>()
-                        .join("")
-                )
+                write!(f, "{}", column)?;
+                for k in keys {
+                    match k {
+                        k @ Value::Number(_, _) => write!(f, "[{}]", k)?,
+                        Value::SingleQuotedString(s) => write!(f, "[\"{}\"]", s)?,
+                        _ => write!(f, "[{}]", k)?
+                    }
+                }
+                Ok(())
             }
             Expr::Wildcard => f.write_str("*"),
             Expr::QualifiedWildcard(q) => write!(f, "{}.*", display_separated(q, ".")),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -286,7 +286,7 @@ impl fmt::Display for Expr {
                     match k {
                         k @ Value::Number(_, _) => write!(f, "[{}]", k)?,
                         Value::SingleQuotedString(s) => write!(f, "[\"{}\"]", s)?,
-                        _ => write!(f, "[{}]", k)?
+                        _ => write!(f, "[{}]", k)?,
                     }
                 }
                 Ok(())

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -251,7 +251,7 @@ pub enum Expr {
     },
     MapAccess {
         column: Box<Expr>,
-        key: String,
+        keys: Vec<Value>,
     },
     /// Scalar function call e.g. `LEFT(foo, 5)`
     Function(Function),
@@ -280,7 +280,15 @@ impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Expr::Identifier(s) => write!(f, "{}", s),
-            Expr::MapAccess { column, key } => write!(f, "{}[\"{}\"]", column, key),
+            Expr::MapAccess { column, keys } => {
+                write!(f, "{}{}", column, keys.into_iter().map(|k| {
+                    match k {
+                        k @ Value::Number(_, _) => format!("[{}]", k),
+                        _ => format!("[\"{}\"]", k)
+                    }
+
+                }).collect::<Vec<String>>().join(""))
+            },
             Expr::Wildcard => f.write_str("*"),
             Expr::QualifiedWildcard(q) => write!(f, "{}.*", display_separated(q, ".")),
             Expr::CompoundIdentifier(s) => write!(f, "{}", display_separated(s, ".")),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -285,7 +285,7 @@ impl fmt::Display for Expr {
                     f,
                     "{}{}",
                     column,
-                    keys.into_iter()
+                    keys.iter()
                         .map(|k| {
                             match k {
                                 k @ Value::Number(_, _) => format!("[{}]", k),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -281,15 +281,22 @@ impl fmt::Display for Expr {
         match self {
             Expr::Identifier(s) => write!(f, "{}", s),
             Expr::MapAccess { column, keys } => {
-                write!(f, "{}{}", column, keys.into_iter().map(|k| {
-                    match k {
-                        k @ Value::Number(_, _) => format!("[{}]", k),
-                        Value::SingleQuotedString(s) => format!("[\"{}\"]", s),
-                        _ => format!("[{}]", k)
-                    }
-
-                }).collect::<Vec<String>>().join(""))
-            },
+                write!(
+                    f,
+                    "{}{}",
+                    column,
+                    keys.into_iter()
+                        .map(|k| {
+                            match k {
+                                k @ Value::Number(_, _) => format!("[{}]", k),
+                                Value::SingleQuotedString(s) => format!("[\"{}\"]", s),
+                                _ => format!("[{}]", k),
+                            }
+                        })
+                        .collect::<Vec<String>>()
+                        .join("")
+                )
+            }
             Expr::Wildcard => f.write_str("*"),
             Expr::QualifiedWildcard(q) => write!(f, "{}.*", display_separated(q, ".")),
             Expr::CompoundIdentifier(s) => write!(f, "{}", display_separated(s, ".")),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -284,6 +284,7 @@ impl fmt::Display for Expr {
                 write!(f, "{}{}", column, keys.into_iter().map(|k| {
                     match k {
                         k @ Value::Number(_, _) => format!("[{}]", k),
+                        Value::SingleQuotedString(s) => format!("[\"{}\"]", s),
                         _ => format!("[{}]", k)
                     }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -284,7 +284,7 @@ impl fmt::Display for Expr {
                 write!(f, "{}{}", column, keys.into_iter().map(|k| {
                     match k {
                         k @ Value::Number(_, _) => format!("[{}]", k),
-                        _ => format!("[\"{}\"]", k)
+                        _ => format!("[{}]", k)
                     }
 
                 }).collect::<Vec<String>>().join(""))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2005,7 +2005,9 @@ impl<'a> Parser<'a> {
     /// Parse a map key string
     pub fn parse_map_key(&mut self) -> Result<Value, ParserError> {
         match self.next_token() {
-            Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => Ok(Value::SingleQuotedString(value)),
+            Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => {
+                Ok(Value::SingleQuotedString(value))
+            }
             Token::SingleQuotedString(s) => Ok(Value::SingleQuotedString(s)),
             #[cfg(not(feature = "bigdecimal"))]
             Token::Number(s, _) => Ok(Value::Number(s, false)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -951,7 +951,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_map_access(&mut self, expr: Expr) -> Result<Expr, ParserError> {
-        let key = self.parse_literal_string()?;
+        let key = self.parse_map_key_string()?;
         let tok = self.consume_token(&Token::RBracket);
         debug!("Tok: {}", tok);
         match expr {
@@ -1992,6 +1992,16 @@ impl<'a> Parser<'a> {
             Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => Ok(value),
             Token::SingleQuotedString(s) => Ok(s),
             unexpected => self.expected("literal string", unexpected),
+        }
+    }
+
+    /// Parse a map key string
+    pub fn parse_map_key_string(&mut self) -> Result<String, ParserError> {
+        match self.next_token() {
+            Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => Ok(value),
+            Token::SingleQuotedString(s) => Ok(s),
+            Token::Number(s, _) => Ok(s),
+            unexpected => self.expected("literal string or number", unexpected),
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -951,13 +951,20 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_map_access(&mut self, expr: Expr) -> Result<Expr, ParserError> {
-        let key = self.parse_map_key_string()?;
+        let key = self.parse_map_key()?;
         let tok = self.consume_token(&Token::RBracket);
         debug!("Tok: {}", tok);
+        let mut key_parts: Vec<Value> = vec![key];
+        while self.consume_token(&Token::LBracket) {
+            let key = self.parse_map_key()?;
+            let tok = self.consume_token(&Token::RBracket);
+            debug!("Tok: {}", tok);
+            key_parts.push(key);
+        }
         match expr {
             e @ Expr::Identifier(_) | e @ Expr::CompoundIdentifier(_) => Ok(Expr::MapAccess {
                 column: Box::new(e),
-                key,
+                keys: key_parts,
             }),
             _ => Ok(expr),
         }
@@ -1996,11 +2003,14 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a map key string
-    pub fn parse_map_key_string(&mut self) -> Result<String, ParserError> {
+    pub fn parse_map_key(&mut self) -> Result<Value, ParserError> {
         match self.next_token() {
-            Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => Ok(value),
-            Token::SingleQuotedString(s) => Ok(s),
-            Token::Number(s, _) => Ok(s),
+            Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => Ok(Value::SingleQuotedString(value)),
+            Token::SingleQuotedString(s) => Ok(Value::SingleQuotedString(s)),
+            #[cfg(not(feature = "bigdecimal"))]
+            Token::Number(s, _) => Ok(Value::Number(s, false)),
+            #[cfg(feature = "bigdecimal")]
+            Token::Number(s, _) => Ok(Value::Number(s.parse().unwrap(), false)),
             unexpected => self.expected("literal string or number", unexpected),
         }
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -26,6 +26,7 @@ use matches::assert_matches;
 use sqlparser::ast::*;
 use sqlparser::dialect::{keywords::ALL_KEYWORDS, GenericDialect, SQLiteDialect};
 use sqlparser::parser::{Parser, ParserError};
+use sqlparser::ast::Expr::Identifier;
 
 #[test]
 fn parse_insert_values() {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -26,7 +26,6 @@ use matches::assert_matches;
 use sqlparser::ast::*;
 use sqlparser::dialect::{keywords::ALL_KEYWORDS, GenericDialect, SQLiteDialect};
 use sqlparser::parser::{Parser, ParserError};
-use sqlparser::ast::Expr::Identifier;
 
 #[test]
 fn parse_insert_values() {

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -194,7 +194,7 @@ fn rename_table() {
 
 #[test]
 fn map_access() {
-    let rename = "SELECT a.b[\"asdf\"] FROM db.table WHERE a = 2";
+    let rename = r#"SELECT a.b["asdf"] FROM db.table WHERE a = 2"#;
     hive().verified_stmt(rename);
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -674,7 +674,6 @@ fn parse_pg_regex_match_ops() {
 
 #[test]
 fn parse_map_access_expr() {
-    //let sql = "SELECT foo[0] as foozero, bar[\"baz\"] as barbaz FROM foos";
     let sql = "SELECT foo[0] FROM foos";
     let select = pg_and_generic().verified_only_select(sql);
     #[cfg(not(feature = "bigdecimal"))]
@@ -687,6 +686,13 @@ fn parse_map_access_expr() {
     #[cfg(not(feature = "bigdecimal"))]
     assert_eq!(
         &MapAccess { column: Box::new(Identifier(Ident { value: "foo".to_string(), quote_style: None })), keys: vec![Value::Number("0".to_string(), false), Value::Number("0".to_string(), false)] },
+        expr_from_projection(only(&select.projection)),
+    );
+    let sql = r#"SELECT bar[0]['baz']['fooz'] FROM foos"#;
+    let select = pg_and_generic().verified_only_select(sql);
+    #[cfg(not(feature = "bigdecimal"))]
+    assert_eq!(
+        &MapAccess { column: Box::new(Identifier(Ident { value: "bar".to_string(), quote_style: None })), keys: vec![Value::Number("0".to_string(), false), Value::SingleQuotedString("baz".to_string()), Value::SingleQuotedString("fooz".to_string())] },
         expr_from_projection(only(&select.projection)),
     );
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -674,29 +674,29 @@ fn parse_pg_regex_match_ops() {
 
 #[test]
 fn parse_map_access_expr() {
+    #[cfg(not(feature = "bigdecimal"))]
+    let zero = "0".to_string();
+    #[cfg(feature = "bigdecimal")]
+    let zero = BigDecimal::parse_bytes(b"0", 10).unwrap();
     let sql = "SELECT foo[0] FROM foos";
     let select = pg_and_generic().verified_only_select(sql);
-    #[cfg(not(feature = "bigdecimal"))]
     assert_eq!(
-        &MapAccess { column: Box::new(Identifier(Ident { value: "foo".to_string(), quote_style: None })), keys: vec![Value::Number("0".to_string(), false)] },
+        &MapAccess { column: Box::new(Identifier(Ident { value: "foo".to_string(), quote_style: None })), keys: vec![Value::Number(zero.clone(), false)] },
         expr_from_projection(only(&select.projection)),
     );
     let sql = "SELECT foo[0][0] FROM foos";
     let select = pg_and_generic().verified_only_select(sql);
-    #[cfg(not(feature = "bigdecimal"))]
     assert_eq!(
-        &MapAccess { column: Box::new(Identifier(Ident { value: "foo".to_string(), quote_style: None })), keys: vec![Value::Number("0".to_string(), false), Value::Number("0".to_string(), false)] },
+        &MapAccess { column: Box::new(Identifier(Ident { value: "foo".to_string(), quote_style: None })), keys: vec![Value::Number(zero.clone(), false), Value::Number(zero.clone(), false)] },
         expr_from_projection(only(&select.projection)),
     );
-    let sql = r#"SELECT bar[0]['baz']['fooz'] FROM foos"#;
+    let sql = r#"SELECT bar[0]["baz"]["fooz"] FROM foos"#;
     let select = pg_and_generic().verified_only_select(sql);
-    #[cfg(not(feature = "bigdecimal"))]
     assert_eq!(
-        &MapAccess { column: Box::new(Identifier(Ident { value: "bar".to_string(), quote_style: None })), keys: vec![Value::Number("0".to_string(), false), Value::SingleQuotedString("baz".to_string()), Value::SingleQuotedString("fooz".to_string())] },
+        &MapAccess { column: Box::new(Identifier(Ident { value: "bar".to_string(), quote_style: None })), keys: vec![Value::Number(zero, false), Value::SingleQuotedString("baz".to_string()), Value::SingleQuotedString("fooz".to_string())] },
         expr_from_projection(only(&select.projection)),
     );
 }
-
 
 fn pg() -> TestedDialects {
     TestedDialects {
@@ -709,3 +709,4 @@ fn pg_and_generic() -> TestedDialects {
         dialects: vec![Box::new(PostgreSqlDialect {}), Box::new(GenericDialect {})],
     }
 }
+

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -18,12 +18,12 @@
 mod test_utils;
 use test_utils::*;
 
+#[cfg(feature = "bigdecimal")]
+use bigdecimal::BigDecimal;
+use sqlparser::ast::Expr::{Identifier, MapAccess};
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, PostgreSqlDialect};
 use sqlparser::parser::ParserError;
-use sqlparser::ast::Expr::{Identifier, MapAccess};
-#[cfg(feature = "bigdecimal")]
-use bigdecimal::BigDecimal;
 
 #[test]
 fn parse_create_table_with_defaults() {
@@ -681,19 +681,44 @@ fn parse_map_access_expr() {
     let sql = "SELECT foo[0] FROM foos";
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
-        &MapAccess { column: Box::new(Identifier(Ident { value: "foo".to_string(), quote_style: None })), keys: vec![Value::Number(zero.clone(), false)] },
+        &MapAccess {
+            column: Box::new(Identifier(Ident {
+                value: "foo".to_string(),
+                quote_style: None
+            })),
+            keys: vec![Value::Number(zero.clone(), false)]
+        },
         expr_from_projection(only(&select.projection)),
     );
     let sql = "SELECT foo[0][0] FROM foos";
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
-        &MapAccess { column: Box::new(Identifier(Ident { value: "foo".to_string(), quote_style: None })), keys: vec![Value::Number(zero.clone(), false), Value::Number(zero.clone(), false)] },
+        &MapAccess {
+            column: Box::new(Identifier(Ident {
+                value: "foo".to_string(),
+                quote_style: None
+            })),
+            keys: vec![
+                Value::Number(zero.clone(), false),
+                Value::Number(zero.clone(), false)
+            ]
+        },
         expr_from_projection(only(&select.projection)),
     );
     let sql = r#"SELECT bar[0]["baz"]["fooz"] FROM foos"#;
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
-        &MapAccess { column: Box::new(Identifier(Ident { value: "bar".to_string(), quote_style: None })), keys: vec![Value::Number(zero, false), Value::SingleQuotedString("baz".to_string()), Value::SingleQuotedString("fooz".to_string())] },
+        &MapAccess {
+            column: Box::new(Identifier(Ident {
+                value: "bar".to_string(),
+                quote_style: None
+            })),
+            keys: vec![
+                Value::Number(zero, false),
+                Value::SingleQuotedString("baz".to_string()),
+                Value::SingleQuotedString("fooz".to_string())
+            ]
+        },
         expr_from_projection(only(&select.projection)),
     );
 }
@@ -709,4 +734,3 @@ fn pg_and_generic() -> TestedDialects {
         dialects: vec![Box::new(PostgreSqlDialect {}), Box::new(GenericDialect {})],
     }
 }
-


### PR DESCRIPTION
This enables number based map access in the AST. I am unsure if this required a new type rather than just patching MapAccess but here goes.