### PR TITLE
Fix one last clippy warning

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1564,6 +1564,7 @@ pub enum HiveRowFormat {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::large_enum_variant)]
 pub enum HiveIOFormat {
     IOF {
         input_format: Expr,


### PR DESCRIPTION
There is still one clippy failure on main with the latest rust: https://github.com/sqlparser-rs/sqlparser-rs/runs/4454072819?check_suite_focus=true

