### PR TITLE
 add map access for nested expr

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1077,10 +1077,12 @@ impl<'a> Parser<'a> {
             key_parts.push(key);
         }
         match expr {
-            e @ Expr::Identifier(_) | e @ Expr::CompoundIdentifier(_)| e @ Expr::Nested(_) => Ok(Expr::MapAccess {
-                column: Box::new(e),
-                keys: key_parts,
-            }),
+            e @ Expr::Identifier(_) | e @ Expr::CompoundIdentifier(_) | e @ Expr::Nested(_) => {
+                Ok(Expr::MapAccess {
+                    column: Box::new(e),
+                    keys: key_parts,
+                })
+            }
             _ => Ok(expr),
         }
     }
@@ -1177,7 +1179,7 @@ impl<'a> Parser<'a> {
             Token::Mul | Token::Div | Token::Mod | Token::StringConcat => Ok(40),
             Token::DoubleColon => Ok(50),
             Token::ExclamationMark => Ok(50),
-            Token::LBracket | Token::RBracket => Ok(10),
+            Token::LBracket | Token::RBracket => Ok(51),
             _ => Ok(0),
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1077,7 +1077,7 @@ impl<'a> Parser<'a> {
             key_parts.push(key);
         }
         match expr {
-            e @ Expr::Identifier(_) | e @ Expr::CompoundIdentifier(_) => Ok(Expr::MapAccess {
+            e @ Expr::Identifier(_) | e @ Expr::CompoundIdentifier(_)| e @ Expr::Nested(_) => Ok(Expr::MapAccess {
                 column: Box::new(e),
                 keys: key_parts,
             }),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -771,7 +771,7 @@ fn parse_map_access_expr() {
                         over: None,
                         distinct: false
                     })))),
-                    keys: vec![Value::Number(zero.clone(), false)],
+                    keys: vec![Value::Number(zero, false)],
                 }),
             }),
         })),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -714,14 +714,14 @@ fn parse_map_access_expr() {
                 quote_style: None
             })),
             keys: vec![
-                Value::Number(zero, false),
+                Value::Number(zero.clone(), false),
                 Value::SingleQuotedString("baz".to_string()),
                 Value::SingleQuotedString("fooz".to_string())
             ]
         },
         expr_from_projection(only(&select.projection)),
     );
-    let sql = "SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname = ((pg_catalog.current_schemas(true))[1])";
+    let sql = "SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname = ((pg_catalog.current_schemas(true))[0])";
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
         Expr::BinaryOp {
@@ -739,7 +739,7 @@ fn parse_map_access_expr() {
                     over: None,
                     distinct: false
                 })))),
-                keys: vec![Value::Number("1".to_string(), false)],
+                keys: vec![Value::Number(zero, false)],
             }))),
         },
         select.selection.unwrap()

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -739,9 +739,42 @@ fn parse_map_access_expr() {
                     over: None,
                     distinct: false
                 })))),
-                keys: vec![Value::Number(zero, false)],
+                keys: vec![Value::Number(zero.clone(), false)],
             }))),
         },
+        select.selection.unwrap()
+    );
+    let sql ="SELECT nspname WHERE (nspname !~ '^pg_temp_' OR nspname = (pg_catalog.current_schemas(true))[0])";
+    let select = pg_and_generic().verified_only_select(sql);
+    assert_eq!(
+        Expr::Nested(Box::new(Expr::BinaryOp {
+            left: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("nspname"))),
+                op: BinaryOperator::PGRegexNotMatch,
+                right: Box::new(Expr::Value(Value::SingleQuotedString(
+                    "^pg_temp_".to_string()
+                ))),
+            }),
+            op: BinaryOperator::Or,
+            right: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("nspname"))),
+                op: BinaryOperator::Eq,
+                right: Box::new(MapAccess {
+                    column: Box::new(Expr::Nested(Box::new(Expr::Function(Function {
+                        name: ObjectName(vec![
+                            Ident::new("pg_catalog"),
+                            Ident::new("current_schemas")
+                        ]),
+                        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                            Value::Boolean(true)
+                        )))],
+                        over: None,
+                        distinct: false
+                    })))),
+                    keys: vec![Value::Number(zero.clone(), false)],
+                }),
+            }),
+        })),
         select.selection.unwrap()
     );
 }


### PR DESCRIPTION
```
SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname = ((pg_catalog.current_schemas(true))[1])
```
is valid postgres statement. 

added support for using nested expr in map access. 

Signed-off-by: poonai <rbalajis25@gmail.com>