### PR TITLE
add SUPER keyword

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -437,6 +437,7 @@ define_keywords!(
     SUBSTRING_REGEX,
     SUCCEEDS,
     SUM,
+    SUPER,
     SYMMETRIC,
     SYNC,
     SYSTEM,


### PR DESCRIPTION
the `SUPER` keyword exists in the MySQL dialect which indicates a privilege on some system admin commands like kill queries, set global variables etc.

i'm not sure whether the keywords set is accepting the keywords of all the dialects or not. thank you for advices in advance!