### PR TITLE
add support for array expression and map index key as expression

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -245,7 +245,7 @@ pub enum Expr {
     },
     MapAccess {
         column: Box<Expr>,
-        keys: Vec<Value>,
+        keys: Vec<Expr>,
     },
     /// Scalar function call e.g. `LEFT(foo, 5)`
     Function(Function),
@@ -283,11 +283,7 @@ impl fmt::Display for Expr {
             Expr::MapAccess { column, keys } => {
                 write!(f, "{}", column)?;
                 for k in keys {
-                    match k {
-                        k @ Value::Number(_, _) => write!(f, "[{}]", k)?,
-                        Value::SingleQuotedString(s) => write!(f, "[\"{}\"]", s)?,
-                        _ => write!(f, "[{}]", k)?,
-                    }
+                    write!(f, "[{}]", k)?
                 }
                 Ok(())
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -274,6 +274,8 @@ pub enum Expr {
     Cube(Vec<Vec<Expr>>),
     /// The `ROLLUP` expr.
     Rollup(Vec<Vec<Expr>>),
+
+    Array(Vec<Expr>),
 }
 
 impl fmt::Display for Expr {
@@ -430,6 +432,9 @@ impl fmt::Display for Expr {
                 }
 
                 write!(f, ")")
+            }
+            Expr::Array(exprs) => {
+                write!(f, "ARRAY[{}]", display_comma_separated(exprs))
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -421,6 +421,12 @@ impl<'a> Parser<'a> {
                     op: UnaryOperator::Not,
                     expr: Box::new(self.parse_subexpr(Self::UNARY_NOT_PREC)?),
                 }),
+                Keyword::ARRAY => {
+                    self.expect_token(&Token::LBracket)?;
+                    let exprs = self.parse_comma_separated(Parser::parse_expr)?;
+                    self.expect_token(&Token::RBracket)?;
+                    Ok(Expr::Array(exprs))
+                }
                 // Here `w` is a word, check if it's a part of a multi-part
                 // identifier, a function call, or a simple identifier:
                 _ => match self.peek_token() {
@@ -1177,7 +1183,7 @@ impl<'a> Parser<'a> {
             Token::Mul | Token::Div | Token::Mod | Token::StringConcat => Ok(40),
             Token::DoubleColon => Ok(50),
             Token::ExclamationMark => Ok(50),
-            Token::LBracket | Token::RBracket => Ok(51),
+            Token::LBracket => Ok(51),
             _ => Ok(0),
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1068,7 +1068,7 @@ impl<'a> Parser<'a> {
             })
         } else if Token::LBracket == tok {
             self.parse_map_access(expr, precedence)
-        }else {
+        } else {
             // Can only happen if `get_next_precedence` got out of sync with this function
             parser_err!(format!("No infix parser for token {:?}", tok))
         }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -821,7 +821,7 @@ fn parse_map_access_expr() {
                         over: None,
                         distinct: false
                     })))),
-                    keys: vec![Expr::Value(Value::Number(zero.clone(), false))],
+                    keys: vec![Expr::Value(Value::Number(zero, false))],
                 }),
             }),
         })),
@@ -856,7 +856,7 @@ fn test_postgres_array() {
                 Expr::Value(Value::SingleQuotedString("No".to_string()),),
                 Expr::Value(Value::SingleQuotedString("Maybe".to_string()),)
             ])),
-            keys: vec![Expr::Value(Value::Number(zero.clone(), false))],
+            keys: vec![Expr::Value(Value::Number(zero, false))],
         }))),
         select.projection[0]
     );


### PR DESCRIPTION
This PR adds following support
-  Array expression eg: `select (array['Yes', 'No', 'Maybe'])`
-  `MapAccess` expression to have key expression  eg: `select (array['Yes', 'No', 'Maybe'])[floor(random() * 3 + 1)]`