### PR TITLE
RFC Source spans

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod ast;
 pub mod dialect;
 pub mod keywords;
 pub mod parser;
+pub mod span;
 pub mod tokenizer;
 
 #[doc(hidden)]

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,0 +1,142 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// A byte span within the parsed string
+#[derive(Debug, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Span {
+    Unset,
+    Set { start: usize, end: usize },
+}
+
+/// All spans are equal
+impl PartialEq for Span {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+/// All spans hash to the same value
+impl core::hash::Hash for Span {
+    fn hash<H: core::hash::Hasher>(&self, _: &mut H) {}
+}
+
+impl Span {
+    pub fn new() -> Self {
+        Span::Unset
+    }
+
+    pub fn expanded(&self, item: &impl Spanned) -> Span {
+        match self {
+            Span::Unset => item.span(),
+            Span::Set { start: s1, end: e1 } => match item.span() {
+                Span::Unset => *self,
+                Span::Set { start: s2, end: e2 } => {
+                    (usize::min(*s1, s2)..usize::max(*e1, e2)).into()
+                }
+            },
+        }
+    }
+
+    pub fn expand(&mut self, item: &impl Spanned) {
+        *self = self.expanded(item);
+    }
+
+    pub fn start(&self) -> Option<usize> {
+        match self {
+            Span::Unset => None,
+            Span::Set { start, .. } => Some(*start),
+        }
+    }
+
+    pub fn end(&self) -> Option<usize> {
+        match self {
+            Span::Unset => None,
+            Span::Set { end, .. } => Some(*end),
+        }
+    }
+
+    pub fn range(&self) -> Option<core::ops::Range<usize>> {
+        match self {
+            Span::Unset => None,
+            Span::Set { start, end } => Some(*start..*end),
+        }
+    }
+}
+
+impl Default for Span {
+    fn default() -> Self {
+        Span::Unset
+    }
+}
+
+impl core::convert::From<core::ops::Range<usize>> for Span {
+    fn from(r: core::ops::Range<usize>) -> Self {
+        Self::Set {
+            start: r.start,
+            end: r.end,
+        }
+    }
+}
+
+pub struct UnsetSpanError;
+
+impl core::convert::TryInto<core::ops::Range<usize>> for Span {
+    type Error = UnsetSpanError;
+
+    fn try_into(self) -> Result<core::ops::Range<usize>, Self::Error> {
+        match self {
+            Span::Unset => Err(UnsetSpanError),
+            Span::Set { start, end } => Ok(start..end),
+        }
+    }
+}
+
+pub trait Spanned {
+    fn span(&self) -> Span;
+}
+
+impl Spanned for Span {
+    fn span(&self) -> Span {
+        *self
+    }
+}
+
+impl<T: Spanned> Spanned for Option<T> {
+    fn span(&self) -> Span {
+        match self {
+            Some(v) => v.span(),
+            None => Default::default(),
+        }
+    }
+}
+
+impl<T: Spanned> Spanned for Vec<T> {
+    fn span(&self) -> Span {
+        let mut ans = Span::new();
+        for v in self {
+            ans.expand(v);
+        }
+        ans
+    }
+}
+
+impl<T: Spanned> Spanned for Box<T> {
+    fn span(&self) -> Span {
+        self.as_ref().span()
+    }
+}

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -24,176 +24,244 @@ use alloc::{
     vec,
     vec::Vec,
 };
+
 use core::fmt;
 use core::iter::Peekable;
-use core::str::Chars;
+use core::str::CharIndices;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::dialect::SnowflakeDialect;
-use crate::dialect::{Dialect, MySqlDialect};
 use crate::keywords::{Keyword, ALL_KEYWORDS, ALL_KEYWORDS_INDEX};
+use crate::{dialect::Dialect, dialect::MySqlDialect, span::Spanned};
+
+use crate::span::Span;
 
 /// SQL Token enumeration
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Token {
     /// An end-of-file marker, not a real token
-    EOF,
+    EOF { span: Span },
     /// A keyword (like SELECT) or an optionally quoted SQL identifier
-    Word(Word),
+    Word { value: Word, span: Span },
     /// An unsigned numeric literal
-    Number(String, bool),
+    Number {
+        value: String,
+        long: bool,
+        span: Span,
+    },
     /// A character that could not be tokenized
-    Char(char),
+    Char { value: char, span: Span },
     /// Single quoted string: i.e: 'string'
-    SingleQuotedString(String),
+    SingleQuotedString { value: String, span: Span },
     /// "National" string literal: i.e: N'string'
-    NationalStringLiteral(String),
+    NationalStringLiteral { value: String, span: Span },
     /// Hexadecimal string literal: i.e.: X'deadbeef'
-    HexStringLiteral(String),
+    HexStringLiteral { value: String, span: Span },
     /// Comma
-    Comma,
+    Comma { span: Span },
     /// Whitespace (space, tab, etc)
-    Whitespace(Whitespace),
+    Whitespace { value: Whitespace, span: Span },
     /// Double equals sign `==`
-    DoubleEq,
+    DoubleEq { span: Span },
     /// Equality operator `=`
-    Eq,
+    Eq { span: Span },
     /// Not Equals operator `<>` (or `!=` in some dialects)
-    Neq,
+    Neq { span: Span },
     /// Less Than operator `<`
-    Lt,
+    Lt { span: Span },
     /// Greater Than operator `>`
-    Gt,
+    Gt { span: Span },
     /// Less Than Or Equals operator `<=`
-    LtEq,
+    LtEq { span: Span },
     /// Greater Than Or Equals operator `>=`
-    GtEq,
+    GtEq { span: Span },
     /// Spaceship operator <=>
-    Spaceship,
+    Spaceship { span: Span },
     /// Plus operator `+`
-    Plus,
+    Plus { span: Span },
     /// Minus operator `-`
-    Minus,
+    Minus { span: Span },
     /// Multiplication operator `*`
-    Mul,
+    Mul { span: Span },
     /// Division operator `/`
-    Div,
+    Div { span: Span },
     /// Modulo Operator `%`
-    Mod,
+    Mod { span: Span },
     /// String concatenation `||`
-    StringConcat,
+    StringConcat { span: Span },
     /// Left parenthesis `(`
-    LParen,
+    LParen { span: Span },
     /// Right parenthesis `)`
-    RParen,
+    RParen { span: Span },
     /// Period (used for compound identifiers or projections into nested types)
-    Period,
+    Period { span: Span },
     /// Colon `:`
-    Colon,
+    Colon { span: Span },
     /// DoubleColon `::` (used for casting in postgresql)
-    DoubleColon,
+    DoubleColon { span: Span },
     /// SemiColon `;` used as separator for COPY and payload
-    SemiColon,
+    SemiColon { span: Span },
     /// Backslash `\` used in terminating the COPY payload with `\.`
-    Backslash,
+    Backslash { span: Span },
     /// Left bracket `[`
-    LBracket,
+    LBracket { span: Span },
     /// Right bracket `]`
-    RBracket,
+    RBracket { span: Span },
     /// Ampersand `&`
-    Ampersand,
+    Ampersand { span: Span },
     /// Pipe `|`
-    Pipe,
+    Pipe { span: Span },
     /// Caret `^`
-    Caret,
+    Caret { span: Span },
     /// Left brace `{`
-    LBrace,
+    LBrace { span: Span },
     /// Right brace `}`
-    RBrace,
+    RBrace { span: Span },
     /// Right Arrow `=>`
-    RArrow,
+    RArrow { span: Span },
     /// Sharp `#` used for PostgreSQL Bitwise XOR operator
-    Sharp,
+    Sharp { span: Span },
     /// Tilde `~` used for PostgreSQL Bitwise NOT operator or case sensitive match regular expression operator
-    Tilde,
+    Tilde { span: Span },
     /// `~*` , a case insensitive match regular expression operator in PostgreSQL
-    TildeAsterisk,
+    TildeAsterisk { span: Span },
     /// `!~` , a case sensitive not match regular expression operator in PostgreSQL
-    ExclamationMarkTilde,
+    ExclamationMarkTilde { span: Span },
     /// `!~*` , a case insensitive not match regular expression operator in PostgreSQL
-    ExclamationMarkTildeAsterisk,
+    ExclamationMarkTildeAsterisk { span: Span },
     /// `<<`, a bitwise shift left operator in PostgreSQL
-    ShiftLeft,
+    ShiftLeft { span: Span },
     /// `>>`, a bitwise shift right operator in PostgreSQL
-    ShiftRight,
+    ShiftRight { span: Span },
     /// Exclamation Mark `!` used for PostgreSQL factorial operator
-    ExclamationMark,
+    ExclamationMark { span: Span },
     /// Double Exclamation Mark `!!` used for PostgreSQL prefix factorial operator
-    DoubleExclamationMark,
+    DoubleExclamationMark { span: Span },
     /// AtSign `@` used for PostgreSQL abs operator
-    AtSign,
+    AtSign { span: Span },
     /// `|/`, a square root math operator in PostgreSQL
-    PGSquareRoot,
+    PGSquareRoot { span: Span },
     /// `||/` , a cube root math operator in PostgreSQL
-    PGCubeRoot,
+    PGCubeRoot { span: Span },
+}
+
+impl Spanned for Token {
+    fn span(&self) -> Span {
+        match self {
+            Token::EOF { span, .. } => *span,
+            Token::Word { span, .. } => *span,
+            Token::Number { span, .. } => *span,
+            Token::Char { span, .. } => *span,
+            Token::SingleQuotedString { span, .. } => *span,
+            Token::NationalStringLiteral { span, .. } => *span,
+            Token::HexStringLiteral { span, .. } => *span,
+            Token::Comma { span, .. } => *span,
+            Token::Whitespace { span, .. } => *span,
+            Token::DoubleEq { span, .. } => *span,
+            Token::Eq { span, .. } => *span,
+            Token::Neq { span, .. } => *span,
+            Token::Lt { span, .. } => *span,
+            Token::Gt { span, .. } => *span,
+            Token::LtEq { span, .. } => *span,
+            Token::GtEq { span, .. } => *span,
+            Token::Spaceship { span, .. } => *span,
+            Token::Plus { span, .. } => *span,
+            Token::Minus { span, .. } => *span,
+            Token::Mul { span, .. } => *span,
+            Token::Div { span, .. } => *span,
+            Token::Mod { span, .. } => *span,
+            Token::StringConcat { span, .. } => *span,
+            Token::LParen { span, .. } => *span,
+            Token::RParen { span, .. } => *span,
+            Token::Period { span, .. } => *span,
+            Token::Colon { span, .. } => *span,
+            Token::DoubleColon { span, .. } => *span,
+            Token::SemiColon { span, .. } => *span,
+            Token::Backslash { span, .. } => *span,
+            Token::LBracket { span, .. } => *span,
+            Token::RBracket { span, .. } => *span,
+            Token::Ampersand { span, .. } => *span,
+            Token::Pipe { span, .. } => *span,
+            Token::Caret { span, .. } => *span,
+            Token::LBrace { span, .. } => *span,
+            Token::RBrace { span, .. } => *span,
+            Token::RArrow { span, .. } => *span,
+            Token::Sharp { span, .. } => *span,
+            Token::Tilde { span, .. } => *span,
+            Token::TildeAsterisk { span, .. } => *span,
+            Token::ExclamationMarkTilde { span, .. } => *span,
+            Token::ExclamationMarkTildeAsterisk { span, .. } => *span,
+            Token::ShiftLeft { span, .. } => *span,
+            Token::ShiftRight { span, .. } => *span,
+            Token::ExclamationMark { span, .. } => *span,
+            Token::DoubleExclamationMark { span, .. } => *span,
+            Token::AtSign { span, .. } => *span,
+            Token::PGSquareRoot { span, .. } => *span,
+            Token::PGCubeRoot { span, .. } => *span,
+        }
+    }
 }
 
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Token::EOF => f.write_str("EOF"),
-            Token::Word(ref w) => write!(f, "{}", w),
-            Token::Number(ref n, l) => write!(f, "{}{long}", n, long = if *l { "L" } else { "" }),
-            Token::Char(ref c) => write!(f, "{}", c),
-            Token::SingleQuotedString(ref s) => write!(f, "'{}'", s),
-            Token::NationalStringLiteral(ref s) => write!(f, "N'{}'", s),
-            Token::HexStringLiteral(ref s) => write!(f, "X'{}'", s),
-            Token::Comma => f.write_str(","),
-            Token::Whitespace(ws) => write!(f, "{}", ws),
-            Token::DoubleEq => f.write_str("=="),
-            Token::Spaceship => f.write_str("<=>"),
-            Token::Eq => f.write_str("="),
-            Token::Neq => f.write_str("<>"),
-            Token::Lt => f.write_str("<"),
-            Token::Gt => f.write_str(">"),
-            Token::LtEq => f.write_str("<="),
-            Token::GtEq => f.write_str(">="),
-            Token::Plus => f.write_str("+"),
-            Token::Minus => f.write_str("-"),
-            Token::Mul => f.write_str("*"),
-            Token::Div => f.write_str("/"),
-            Token::StringConcat => f.write_str("||"),
-            Token::Mod => f.write_str("%"),
-            Token::LParen => f.write_str("("),
-            Token::RParen => f.write_str(")"),
-            Token::Period => f.write_str("."),
-            Token::Colon => f.write_str(":"),
-            Token::DoubleColon => f.write_str("::"),
-            Token::SemiColon => f.write_str(";"),
-            Token::Backslash => f.write_str("\\"),
-            Token::LBracket => f.write_str("["),
-            Token::RBracket => f.write_str("]"),
-            Token::Ampersand => f.write_str("&"),
-            Token::Caret => f.write_str("^"),
-            Token::Pipe => f.write_str("|"),
-            Token::LBrace => f.write_str("{"),
-            Token::RBrace => f.write_str("}"),
-            Token::RArrow => f.write_str("=>"),
-            Token::Sharp => f.write_str("#"),
-            Token::ExclamationMark => f.write_str("!"),
-            Token::DoubleExclamationMark => f.write_str("!!"),
-            Token::Tilde => f.write_str("~"),
-            Token::TildeAsterisk => f.write_str("~*"),
-            Token::ExclamationMarkTilde => f.write_str("!~"),
-            Token::ExclamationMarkTildeAsterisk => f.write_str("!~*"),
-            Token::AtSign => f.write_str("@"),
-            Token::ShiftLeft => f.write_str("<<"),
-            Token::ShiftRight => f.write_str(">>"),
-            Token::PGSquareRoot => f.write_str("|/"),
-            Token::PGCubeRoot => f.write_str("||/"),
+            Token::EOF { .. } => f.write_str("EOF"),
+            Token::Word { ref value, .. } => write!(f, "{}", value),
+            Token::Number {
+                ref value,
+                ref long,
+                ..
+            } => write!(f, "{}{long}", value, long = if *long { "L" } else { "" }),
+            Token::Char { ref value, .. } => write!(f, "{}", value),
+            Token::SingleQuotedString { ref value, .. } => write!(f, "'{}'", value),
+            Token::NationalStringLiteral { ref value, .. } => write!(f, "N'{}'", value),
+            Token::HexStringLiteral { ref value, .. } => write!(f, "X'{}'", value),
+            Token::Comma { .. } => f.write_str(","),
+            Token::Whitespace { value, .. } => write!(f, "{}", value),
+            Token::DoubleEq { .. } => f.write_str("=="),
+            Token::Spaceship { .. } => f.write_str("<=>"),
+            Token::Eq { .. } => f.write_str("="),
+            Token::Neq { .. } => f.write_str("<>"),
+            Token::Lt { .. } => f.write_str("<"),
+            Token::Gt { .. } => f.write_str(">"),
+            Token::LtEq { .. } => f.write_str("<="),
+            Token::GtEq { .. } => f.write_str(">="),
+            Token::Plus { .. } => f.write_str("+"),
+            Token::Minus { .. } => f.write_str("-"),
+            Token::Mul { .. } => f.write_str("*"),
+            Token::Div { .. } => f.write_str("/"),
+            Token::StringConcat { .. } => f.write_str("||"),
+            Token::Mod { .. } => f.write_str("%"),
+            Token::LParen { .. } => f.write_str("("),
+            Token::RParen { .. } => f.write_str(")"),
+            Token::Period { .. } => f.write_str("."),
+            Token::Colon { .. } => f.write_str(":"),
+            Token::DoubleColon { .. } => f.write_str("::"),
+            Token::SemiColon { .. } => f.write_str(";"),
+            Token::Backslash { .. } => f.write_str("\\"),
+            Token::LBracket { .. } => f.write_str("["),
+            Token::RBracket { .. } => f.write_str("]"),
+            Token::Ampersand { .. } => f.write_str("&"),
+            Token::Caret { .. } => f.write_str("^"),
+            Token::Pipe { .. } => f.write_str("|"),
+            Token::LBrace { .. } => f.write_str("{"),
+            Token::RBrace { .. } => f.write_str("}"),
+            Token::RArrow { .. } => f.write_str("=>"),
+            Token::Sharp { .. } => f.write_str("#"),
+            Token::ExclamationMark { .. } => f.write_str("!"),
+            Token::DoubleExclamationMark { .. } => f.write_str("!!"),
+            Token::Tilde { .. } => f.write_str("~"),
+            Token::TildeAsterisk { .. } => f.write_str("~*"),
+            Token::ExclamationMarkTilde { .. } => f.write_str("!~"),
+            Token::ExclamationMarkTildeAsterisk { .. } => f.write_str("!~*"),
+            Token::AtSign { .. } => f.write_str("@"),
+            Token::ShiftLeft { .. } => f.write_str("<<"),
+            Token::ShiftRight { .. } => f.write_str(">>"),
+            Token::PGSquareRoot { .. } => f.write_str("|/"),
+            Token::PGCubeRoot { .. } => f.write_str("||/"),
         }
     }
 }
@@ -205,16 +273,19 @@ impl Token {
 
     pub fn make_word(word: &str, quote_style: Option<char>) -> Self {
         let word_uppercase = word.to_uppercase();
-        Token::Word(Word {
-            value: word.to_string(),
-            quote_style,
-            keyword: if quote_style == None {
-                let keyword = ALL_KEYWORDS.binary_search(&word_uppercase.as_str());
-                keyword.map_or(Keyword::NoKeyword, |x| ALL_KEYWORDS_INDEX[x])
-            } else {
-                Keyword::NoKeyword
+        Token::Word {
+            value: Word {
+                value: word.to_string(),
+                quote_style,
+                keyword: if quote_style == None {
+                    let keyword = ALL_KEYWORDS.binary_search(&word_uppercase.as_str());
+                    keyword.map_or(Keyword::NoKeyword, |x| ALL_KEYWORDS_INDEX[x])
+                } else {
+                    Keyword::NoKeyword
+                },
             },
-        })
+            span: Default::default(),
+        }
     }
 }
 
@@ -285,6 +356,7 @@ pub struct TokenizerError {
     pub message: String,
     pub line: u64,
     pub col: u64,
+    pub span: Span,
 }
 
 impl fmt::Display for TokenizerError {
@@ -306,6 +378,7 @@ pub struct Tokenizer<'a> {
     query: &'a str,
     line: u64,
     col: u64,
+    start: usize,
 }
 
 impl<'a> Tokenizer<'a> {
@@ -316,58 +389,259 @@ impl<'a> Tokenizer<'a> {
             query,
             line: 1,
             col: 1,
+            start: 0,
         }
     }
 
     /// Tokenize the statement and produce a vector of tokens
     pub fn tokenize(&mut self) -> Result<Vec<Token>, TokenizerError> {
-        let mut peekable = self.query.chars().peekable();
+        let mut peekable = self.query.char_indices().peekable();
 
-        let mut tokens: Vec<Token> = vec![];
+        let mut tokens = vec![];
 
-        while let Some(token) = self.next_token(&mut peekable)? {
+        self.start = peekable
+            .peek()
+            .map(|(start, _)| *start)
+            .unwrap_or(self.query.len());
+        loop {
+            let mut token = match self.next_token(&mut peekable)? {
+                None => break,
+                Some(token) => token,
+            };
+            let end = peekable
+                .peek()
+                .map(|(start, _)| *start)
+                .unwrap_or(self.query.len());
+            let s: Span = (self.start..end).into();
+            match &mut token {
+                Token::EOF { span } => {
+                    *span = s;
+                }
+                Token::Word { span, .. } => {
+                    *span = s;
+                }
+                Token::Number { span, .. } => {
+                    *span = s;
+                }
+                Token::Char { span, .. } => {
+                    *span = s;
+                }
+                Token::SingleQuotedString { span, .. } => {
+                    *span = s;
+                }
+                Token::NationalStringLiteral { span, .. } => {
+                    *span = s;
+                }
+                Token::HexStringLiteral { span, .. } => {
+                    *span = s;
+                }
+                Token::Comma { span } => {
+                    *span = s;
+                }
+                Token::Whitespace { span, .. } => {
+                    *span = s;
+                }
+                Token::DoubleEq { span } => {
+                    *span = s;
+                }
+                Token::Eq { span } => {
+                    *span = s;
+                }
+                Token::Neq { span } => {
+                    *span = s;
+                }
+                Token::Lt { span } => {
+                    *span = s;
+                }
+                Token::Gt { span } => {
+                    *span = s;
+                }
+                Token::LtEq { span } => {
+                    *span = s;
+                }
+                Token::GtEq { span } => {
+                    *span = s;
+                }
+                Token::Spaceship { span } => {
+                    *span = s;
+                }
+                Token::Plus { span } => {
+                    *span = s;
+                }
+                Token::Minus { span } => {
+                    *span = s;
+                }
+                Token::Mul { span } => {
+                    *span = s;
+                }
+                Token::Div { span } => {
+                    *span = s;
+                }
+                Token::Mod { span } => {
+                    *span = s;
+                }
+                Token::StringConcat { span } => {
+                    *span = s;
+                }
+                Token::LParen { span } => {
+                    *span = s;
+                }
+                Token::RParen { span } => {
+                    *span = s;
+                }
+                Token::Period { span } => {
+                    *span = s;
+                }
+                Token::Colon { span } => {
+                    *span = s;
+                }
+                Token::DoubleColon { span } => {
+                    *span = s;
+                }
+                Token::SemiColon { span } => {
+                    *span = s;
+                }
+                Token::Backslash { span } => {
+                    *span = s;
+                }
+                Token::LBracket { span } => {
+                    *span = s;
+                }
+                Token::RBracket { span } => {
+                    *span = s;
+                }
+                Token::Ampersand { span } => {
+                    *span = s;
+                }
+                Token::Pipe { span } => {
+                    *span = s;
+                }
+                Token::Caret { span } => {
+                    *span = s;
+                }
+                Token::LBrace { span } => {
+                    *span = s;
+                }
+                Token::RBrace { span } => {
+                    *span = s;
+                }
+                Token::RArrow { span } => {
+                    *span = s;
+                }
+                Token::Sharp { span } => {
+                    *span = s;
+                }
+                Token::Tilde { span } => {
+                    *span = s;
+                }
+                Token::TildeAsterisk { span } => {
+                    *span = s;
+                }
+                Token::ExclamationMarkTilde { span } => {
+                    *span = s;
+                }
+                Token::ExclamationMarkTildeAsterisk { span } => {
+                    *span = s;
+                }
+                Token::ShiftLeft { span } => {
+                    *span = s;
+                }
+                Token::ShiftRight { span } => {
+                    *span = s;
+                }
+                Token::ExclamationMark { span } => {
+                    *span = s;
+                }
+                Token::DoubleExclamationMark { span } => {
+                    *span = s;
+                }
+                Token::AtSign { span } => {
+                    *span = s;
+                }
+                Token::PGSquareRoot { span } => {
+                    *span = s;
+                }
+                Token::PGCubeRoot { span } => {
+                    *span = s;
+                }
+            }
             match &token {
-                Token::Whitespace(Whitespace::Newline) => {
+                Token::Whitespace {
+                    value: Whitespace::Newline,
+                    ..
+                } => {
                     self.line += 1;
                     self.col = 1;
                 }
-
-                Token::Whitespace(Whitespace::Tab) => self.col += 4,
-                Token::Word(w) if w.quote_style == None => self.col += w.value.len() as u64,
-                Token::Word(w) if w.quote_style != None => self.col += w.value.len() as u64 + 2,
-                Token::Number(s, _) => self.col += s.len() as u64,
-                Token::SingleQuotedString(s) => self.col += s.len() as u64,
+                Token::Whitespace {
+                    value: Whitespace::Tab,
+                    ..
+                } => self.col += 4,
+                Token::Word { value, .. } if value.quote_style == None => {
+                    self.col += value.value.len() as u64
+                }
+                Token::Word { value, .. } if value.quote_style != None => {
+                    self.col += value.value.len() as u64 + 2
+                }
+                Token::Number { value, .. } => self.col += value.len() as u64,
+                Token::SingleQuotedString { value, .. } => self.col += value.len() as u64,
                 _ => self.col += 1,
             }
 
             tokens.push(token);
+            self.start = end;
         }
         Ok(tokens)
     }
 
     /// Get the next token or return None
-    fn next_token(&self, chars: &mut Peekable<Chars<'_>>) -> Result<Option<Token>, TokenizerError> {
+    fn next_token(
+        &self,
+        chars: &mut Peekable<CharIndices<'_>>,
+    ) -> Result<Option<Token>, TokenizerError> {
         //println!("next_token: {:?}", chars.peek());
+        let span = Span::new();
         match chars.peek() {
-            Some(&ch) => match ch {
-                ' ' => self.consume_and_return(chars, Token::Whitespace(Whitespace::Space)),
-                '\t' => self.consume_and_return(chars, Token::Whitespace(Whitespace::Tab)),
-                '\n' => self.consume_and_return(chars, Token::Whitespace(Whitespace::Newline)),
+            Some(&ch) => match ch.1 {
+                ' ' => self.consume_and_return(
+                    chars,
+                    Token::Whitespace {
+                        value: Whitespace::Space,
+                        span,
+                    },
+                ),
+                '\t' => self.consume_and_return(
+                    chars,
+                    Token::Whitespace {
+                        value: Whitespace::Tab,
+                        span,
+                    },
+                ),
+                '\n' => self.consume_and_return(
+                    chars,
+                    Token::Whitespace {
+                        value: Whitespace::Newline,
+                        span,
+                    },
+                ),
                 '\r' => {
                     // Emit a single Whitespace::Newline token for \r and \r\n
                     chars.next();
-                    if let Some('\n') = chars.peek() {
+                    if let Some((_, '\n')) = chars.peek() {
                         chars.next();
                     }
-                    Ok(Some(Token::Whitespace(Whitespace::Newline)))
+                    Ok(Some(Token::Whitespace {
+                        value: Whitespace::Newline,
+                        span,
+                    }))
                 }
                 'N' => {
                     chars.next(); // consume, to check the next char
                     match chars.peek() {
-                        Some('\'') => {
+                        Some((_, '\'')) => {
                             // N'...' - a <national character string literal>
-                            let s = self.tokenize_single_quoted_string(chars)?;
-                            Ok(Some(Token::NationalStringLiteral(s)))
+                            let value = self.tokenize_single_quoted_string(chars)?;
+                            Ok(Some(Token::NationalStringLiteral { value, span }))
                         }
                         _ => {
                             // regular identifier starting with an "N"
@@ -381,10 +655,10 @@ impl<'a> Tokenizer<'a> {
                 x @ 'x' | x @ 'X' => {
                     chars.next(); // consume, to check the next char
                     match chars.peek() {
-                        Some('\'') => {
+                        Some((_, '\'')) => {
                             // X'...' - a <binary string literal>
-                            let s = self.tokenize_single_quoted_string(chars)?;
-                            Ok(Some(Token::HexStringLiteral(s)))
+                            let value = self.tokenize_single_quoted_string(chars)?;
+                            Ok(Some(Token::HexStringLiteral { value, span }))
                         }
                         _ => {
                             // regular identifier starting with an "X"
@@ -399,222 +673,256 @@ impl<'a> Tokenizer<'a> {
                     let s = self.tokenize_word(ch, chars);
 
                     if s.chars().all(|x| ('0'..='9').contains(&x) || x == '.') {
-                        let mut s = peeking_take_while(&mut s.chars().peekable(), |ch| {
-                            matches!(ch, '0'..='9' | '.')
-                        });
+                        let mut value =
+                            peeking_take_while(&mut s.char_indices().peekable(), |ch| {
+                                matches!(ch, '0'..='9' | '.')
+                            });
                         let s2 = peeking_take_while(chars, |ch| matches!(ch, '0'..='9' | '.'));
-                        s += s2.as_str();
-                        return Ok(Some(Token::Number(s, false)));
+                        value += s2.as_str();
+                        return Ok(Some(Token::Number {
+                            value,
+                            long: false,
+                            span,
+                        }));
                     }
                     Ok(Some(Token::make_word(&s, None)))
                 }
                 // string
                 '\'' => {
-                    let s = self.tokenize_single_quoted_string(chars)?;
-
-                    Ok(Some(Token::SingleQuotedString(s)))
+                    let value = self.tokenize_single_quoted_string(chars)?;
+                    Ok(Some(Token::SingleQuotedString { value, span }))
                 }
                 // delimited (quoted) identifier
                 quote_start if self.dialect.is_delimited_identifier_start(quote_start) => {
                     chars.next(); // consume the opening quote
                     let quote_end = Word::matching_end_quote(quote_start);
                     let s = peeking_take_while(chars, |ch| ch != quote_end);
-                    if chars.next() == Some(quote_end) {
+                    if chars.next().map(|(_, c)| c) == Some(quote_end) {
                         Ok(Some(Token::make_word(&s, Some(quote_start))))
                     } else {
-                        self.tokenizer_error(format!(
-                            "Expected close delimiter '{}' before EOF.",
-                            quote_end
-                        ))
+                        self.tokenizer_error(
+                            self.start..self.query.len(),
+                            format!("Expected close delimiter '{}' before EOF.", quote_end),
+                        )
                     }
                 }
                 // numbers and period
                 '0'..='9' | '.' => {
-                    let mut s = peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
+                    let mut value = peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
 
                     // match binary literal that starts with 0x
-                    if s == "0" && chars.peek() == Some(&'x') {
+                    if value == "0" && chars.peek().map(|(_, c)| c) == Some(&'x') {
                         chars.next();
-                        let s2 = peeking_take_while(
+                        let value = peeking_take_while(
                             chars,
                             |ch| matches!(ch, '0'..='9' | 'A'..='F' | 'a'..='f'),
                         );
-                        return Ok(Some(Token::HexStringLiteral(s2)));
+                        return Ok(Some(Token::HexStringLiteral { value, span }));
                     }
 
                     // match one period
-                    if let Some('.') = chars.peek() {
-                        s.push('.');
+                    if let Some((_, '.')) = chars.peek() {
+                        value.push('.');
                         chars.next();
                     }
-                    s += &peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
+                    value += &peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
 
                     // No number -> Token::Period
-                    if s == "." {
-                        return Ok(Some(Token::Period));
+                    if value == "." {
+                        return Ok(Some(Token::Period { span }));
                     }
 
-                    let long = if chars.peek() == Some(&'L') {
+                    let long = if let Some((_, 'L')) = chars.peek() {
                         chars.next();
                         true
                     } else {
                         false
                     };
-                    Ok(Some(Token::Number(s, long)))
+                    Ok(Some(Token::Number { value, long, span }))
                 }
                 // punctuation
-                '(' => self.consume_and_return(chars, Token::LParen),
-                ')' => self.consume_and_return(chars, Token::RParen),
-                ',' => self.consume_and_return(chars, Token::Comma),
+                '(' => self.consume_and_return(chars, Token::LParen { span }),
+                ')' => self.consume_and_return(chars, Token::RParen { span }),
+                ',' => self.consume_and_return(chars, Token::Comma { span }),
                 // operators
                 '-' => {
                     chars.next(); // consume the '-'
                     match chars.peek() {
-                        Some('-') => {
+                        Some((_, '-')) => {
                             chars.next(); // consume the second '-', starting a single-line comment
                             let comment = self.tokenize_single_line_comment(chars);
-                            Ok(Some(Token::Whitespace(Whitespace::SingleLineComment {
-                                prefix: "--".to_owned(),
-                                comment,
-                            })))
+                            Ok(Some(Token::Whitespace {
+                                value: Whitespace::SingleLineComment {
+                                    prefix: "--".to_owned(),
+                                    comment,
+                                },
+                                span,
+                            }))
                         }
                         // a regular '-' operator
-                        _ => Ok(Some(Token::Minus)),
+                        _ => Ok(Some(Token::Minus { span })),
                     }
                 }
                 '/' => {
                     chars.next(); // consume the '/'
                     match chars.peek() {
-                        Some('*') => {
+                        Some((_, '*')) => {
                             chars.next(); // consume the '*', starting a multi-line comment
                             self.tokenize_multiline_comment(chars)
                         }
-                        Some('/') if dialect_of!(self is SnowflakeDialect) => {
+                        Some((_, '/')) if dialect_of!(self is SnowflakeDialect) => {
                             chars.next(); // consume the second '/', starting a snowflake single-line comment
                             let comment = self.tokenize_single_line_comment(chars);
-                            Ok(Some(Token::Whitespace(Whitespace::SingleLineComment {
-                                prefix: "//".to_owned(),
-                                comment,
-                            })))
+                            Ok(Some(Token::Whitespace {
+                                value: Whitespace::SingleLineComment {
+                                    prefix: "//".to_owned(),
+                                    comment,
+                                },
+                                span,
+                            }))
                         }
                         // a regular '/' operator
-                        _ => Ok(Some(Token::Div)),
+                        _ => Ok(Some(Token::Div { span })),
                     }
                 }
-                '+' => self.consume_and_return(chars, Token::Plus),
-                '*' => self.consume_and_return(chars, Token::Mul),
-                '%' => self.consume_and_return(chars, Token::Mod),
+                '+' => self.consume_and_return(chars, Token::Plus { span }),
+                '*' => self.consume_and_return(chars, Token::Mul { span }),
+                '%' => self.consume_and_return(chars, Token::Mod { span }),
                 '|' => {
                     chars.next(); // consume the '|'
                     match chars.peek() {
-                        Some('/') => self.consume_and_return(chars, Token::PGSquareRoot),
-                        Some('|') => {
+                        Some((_, '/')) => {
+                            self.consume_and_return(chars, Token::PGSquareRoot { span })
+                        }
+                        Some((_, '|')) => {
                             chars.next(); // consume the second '|'
                             match chars.peek() {
-                                Some('/') => self.consume_and_return(chars, Token::PGCubeRoot),
-                                _ => Ok(Some(Token::StringConcat)),
+                                Some((_, '/')) => {
+                                    self.consume_and_return(chars, Token::PGCubeRoot { span })
+                                }
+                                _ => Ok(Some(Token::StringConcat { span })),
                             }
                         }
                         // Bitshift '|' operator
-                        _ => Ok(Some(Token::Pipe)),
+                        _ => Ok(Some(Token::Pipe { span })),
                     }
                 }
                 '=' => {
                     chars.next(); // consume
                     match chars.peek() {
-                        Some('>') => self.consume_and_return(chars, Token::RArrow),
-                        _ => Ok(Some(Token::Eq)),
+                        Some((_, '>')) => self.consume_and_return(chars, Token::RArrow { span }),
+                        _ => Ok(Some(Token::Eq { span })),
                     }
                 }
                 '!' => {
                     chars.next(); // consume
                     match chars.peek() {
-                        Some('=') => self.consume_and_return(chars, Token::Neq),
-                        Some('!') => self.consume_and_return(chars, Token::DoubleExclamationMark),
-                        Some('~') => {
+                        Some((_, '=')) => self.consume_and_return(chars, Token::Neq { span }),
+                        Some((_, '!')) => {
+                            self.consume_and_return(chars, Token::DoubleExclamationMark { span })
+                        }
+                        Some((_, '~')) => {
                             chars.next();
                             match chars.peek() {
-                                Some('*') => self
-                                    .consume_and_return(chars, Token::ExclamationMarkTildeAsterisk),
-                                _ => Ok(Some(Token::ExclamationMarkTilde)),
+                                Some((_, '*')) => self.consume_and_return(
+                                    chars,
+                                    Token::ExclamationMarkTildeAsterisk { span },
+                                ),
+                                _ => Ok(Some(Token::ExclamationMarkTilde { span })),
                             }
                         }
-                        _ => Ok(Some(Token::ExclamationMark)),
+                        _ => Ok(Some(Token::ExclamationMark { span })),
                     }
                 }
                 '<' => {
                     chars.next(); // consume
                     match chars.peek() {
-                        Some('=') => {
+                        Some((_, '=')) => {
                             chars.next();
                             match chars.peek() {
-                                Some('>') => self.consume_and_return(chars, Token::Spaceship),
-                                _ => Ok(Some(Token::LtEq)),
+                                Some((_, '>')) => {
+                                    self.consume_and_return(chars, Token::Spaceship { span })
+                                }
+                                _ => Ok(Some(Token::LtEq { span })),
                             }
                         }
-                        Some('>') => self.consume_and_return(chars, Token::Neq),
-                        Some('<') => self.consume_and_return(chars, Token::ShiftLeft),
-                        _ => Ok(Some(Token::Lt)),
+                        Some((_, '>')) => self.consume_and_return(chars, Token::Neq { span }),
+                        Some((_, '<')) => self.consume_and_return(chars, Token::ShiftLeft { span }),
+                        _ => Ok(Some(Token::Lt { span })),
                     }
                 }
                 '>' => {
                     chars.next(); // consume
                     match chars.peek() {
-                        Some('=') => self.consume_and_return(chars, Token::GtEq),
-                        Some('>') => self.consume_and_return(chars, Token::ShiftRight),
-                        _ => Ok(Some(Token::Gt)),
+                        Some((_, '=')) => self.consume_and_return(chars, Token::GtEq { span }),
+                        Some((_, '>')) => {
+                            self.consume_and_return(chars, Token::ShiftRight { span })
+                        }
+                        _ => Ok(Some(Token::Gt { span })),
                     }
                 }
                 ':' => {
                     chars.next();
                     match chars.peek() {
-                        Some(':') => self.consume_and_return(chars, Token::DoubleColon),
-                        _ => Ok(Some(Token::Colon)),
+                        Some((_, ':')) => {
+                            self.consume_and_return(chars, Token::DoubleColon { span })
+                        }
+                        _ => Ok(Some(Token::Colon { span })),
                     }
                 }
-                ';' => self.consume_and_return(chars, Token::SemiColon),
-                '\\' => self.consume_and_return(chars, Token::Backslash),
-                '[' => self.consume_and_return(chars, Token::LBracket),
-                ']' => self.consume_and_return(chars, Token::RBracket),
-                '&' => self.consume_and_return(chars, Token::Ampersand),
-                '^' => self.consume_and_return(chars, Token::Caret),
-                '{' => self.consume_and_return(chars, Token::LBrace),
-                '}' => self.consume_and_return(chars, Token::RBrace),
+                ';' => self.consume_and_return(chars, Token::SemiColon { span }),
+                '\\' => self.consume_and_return(chars, Token::Backslash { span }),
+                '[' => self.consume_and_return(chars, Token::LBracket { span }),
+                ']' => self.consume_and_return(chars, Token::RBracket { span }),
+                '&' => self.consume_and_return(chars, Token::Ampersand { span }),
+                '^' => self.consume_and_return(chars, Token::Caret { span }),
+                '{' => self.consume_and_return(chars, Token::LBrace { span }),
+                '}' => self.consume_and_return(chars, Token::RBrace { span }),
                 '#' if dialect_of!(self is SnowflakeDialect) => {
                     chars.next(); // consume the '#', starting a snowflake single-line comment
                     let comment = self.tokenize_single_line_comment(chars);
-                    Ok(Some(Token::Whitespace(Whitespace::SingleLineComment {
-                        prefix: "#".to_owned(),
-                        comment,
-                    })))
+                    Ok(Some(Token::Whitespace {
+                        value: Whitespace::SingleLineComment {
+                            prefix: "#".to_owned(),
+                            comment,
+                        },
+                        span,
+                    }))
                 }
                 '~' => {
                     chars.next(); // consume
                     match chars.peek() {
-                        Some('*') => self.consume_and_return(chars, Token::TildeAsterisk),
-                        _ => Ok(Some(Token::Tilde)),
+                        Some((_, '*')) => {
+                            self.consume_and_return(chars, Token::TildeAsterisk { span })
+                        }
+                        _ => Ok(Some(Token::Tilde { span })),
                     }
                 }
-                '#' => self.consume_and_return(chars, Token::Sharp),
-                '@' => self.consume_and_return(chars, Token::AtSign),
-                other => self.consume_and_return(chars, Token::Char(other)),
+                '#' => self.consume_and_return(chars, Token::Sharp { span }),
+                '@' => self.consume_and_return(chars, Token::AtSign { span }),
+                other => self.consume_and_return(chars, Token::Char { value: other, span }),
             },
             None => Ok(None),
         }
     }
 
-    fn tokenizer_error<R>(&self, message: impl Into<String>) -> Result<R, TokenizerError> {
+    fn tokenizer_error<R>(
+        &self,
+        span: impl Into<Span>,
+        message: impl Into<String>,
+    ) -> Result<R, TokenizerError> {
         Err(TokenizerError {
             message: message.into(),
+            span: span.into(),
             col: self.col,
             line: self.line,
         })
     }
 
     // Consume characters until newline
-    fn tokenize_single_line_comment(&self, chars: &mut Peekable<Chars<'_>>) -> String {
+    fn tokenize_single_line_comment(&self, chars: &mut Peekable<CharIndices<'_>>) -> String {
         let mut comment = peeking_take_while(chars, |ch| ch != '\n');
-        if let Some(ch) = chars.next() {
+        if let Some((_, ch)) = chars.next() {
             assert_eq!(ch, '\n');
             comment.push(ch);
         }
@@ -622,7 +930,7 @@ impl<'a> Tokenizer<'a> {
     }
 
     /// Tokenize an identifier or keyword, after the first char is already consumed.
-    fn tokenize_word(&self, first_char: char, chars: &mut Peekable<Chars<'_>>) -> String {
+    fn tokenize_word(&self, first_char: char, chars: &mut Peekable<CharIndices<'_>>) -> String {
         let mut s = first_char.to_string();
         s.push_str(&peeking_take_while(chars, |ch| {
             self.dialect.is_identifier_part(ch)
@@ -633,7 +941,7 @@ impl<'a> Tokenizer<'a> {
     /// Read a single quoted string, starting with the opening quote.
     fn tokenize_single_quoted_string(
         &self,
-        chars: &mut Peekable<Chars<'_>>,
+        chars: &mut Peekable<CharIndices<'_>>,
     ) -> Result<String, TokenizerError> {
         let mut s = String::new();
         chars.next(); // consume the opening quote
@@ -642,48 +950,52 @@ impl<'a> Tokenizer<'a> {
         let mut is_escaped = false;
         while let Some(&ch) = chars.peek() {
             match ch {
-                '\'' => {
+                (_, '\'') => {
                     chars.next(); // consume
                     if is_escaped {
-                        s.push(ch);
+                        s.push('\'');
                         is_escaped = false;
-                    } else if chars.peek().map(|c| *c == '\'').unwrap_or(false) {
-                        s.push(ch);
+                    } else if chars.peek().map(|c| c.1 == '\'').unwrap_or(false) {
+                        s.push('\'');
                         chars.next();
                     } else {
                         return Ok(s);
                     }
                 }
-                '\\' => {
+                (_, '\\') => {
                     if dialect_of!(self is MySqlDialect) {
                         is_escaped = !is_escaped;
                     } else {
-                        s.push(ch);
+                        s.push('\\');
                     }
                     chars.next();
                 }
-                _ => {
+                (_, ch) => {
                     chars.next(); // consume
                     s.push(ch);
                 }
             }
         }
-        self.tokenizer_error("Unterminated string literal")
+        let end = chars.peek().map(|(i, _)| *i).unwrap_or(self.query.len());
+        self.tokenizer_error(self.start..end, "Unterminated string literal")
     }
 
     fn tokenize_multiline_comment(
         &self,
-        chars: &mut Peekable<Chars<'_>>,
+        chars: &mut Peekable<CharIndices<'_>>,
     ) -> Result<Option<Token>, TokenizerError> {
         let mut s = String::new();
         let mut maybe_closing_comment = false;
         // TODO: deal with nested comments
         loop {
             match chars.next() {
-                Some(ch) => {
+                Some((_, ch)) => {
                     if maybe_closing_comment {
                         if ch == '/' {
-                            break Ok(Some(Token::Whitespace(Whitespace::MultiLineComment(s))));
+                            break Ok(Some(Token::Whitespace {
+                                value: Whitespace::MultiLineComment(s),
+                                span: Span::default(),
+                            }));
                         } else {
                             s.push('*');
                         }
@@ -693,7 +1005,12 @@ impl<'a> Tokenizer<'a> {
                         s.push(ch);
                     }
                 }
-                None => break self.tokenizer_error("Unexpected EOF while in a multi-line comment"),
+                None => {
+                    break self.tokenizer_error(
+                        self.start..self.query.len(),
+                        "Unexpected EOF while in a multi-line comment",
+                    )
+                }
             }
         }
     }
@@ -701,7 +1018,7 @@ impl<'a> Tokenizer<'a> {
     #[allow(clippy::unnecessary_wraps)]
     fn consume_and_return(
         &self,
-        chars: &mut Peekable<Chars<'_>>,
+        chars: &mut Peekable<CharIndices<'_>>,
         t: Token,
     ) -> Result<Option<Token>, TokenizerError> {
         chars.next();
@@ -713,11 +1030,11 @@ impl<'a> Tokenizer<'a> {
 /// Return the characters read as String, and keep the first non-matching
 /// char available as `chars.next()`.
 fn peeking_take_while(
-    chars: &mut Peekable<Chars<'_>>,
+    chars: &mut Peekable<CharIndices<'_>>,
     mut predicate: impl FnMut(char) -> bool,
 ) -> String {
     let mut s = String::new();
-    while let Some(&ch) = chars.peek() {
+    while let Some(ch) = chars.peek().map(|(_, ch)| *ch) {
         if predicate(ch) {
             chars.next(); // consume
             s.push(ch);
@@ -739,6 +1056,7 @@ mod tests {
             message: "test".into(),
             line: 1,
             col: 1,
+            span: Span::new(),
         };
         #[cfg(feature = "std")]
         {
@@ -757,8 +1075,15 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Number(String::from("1"), false),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Number {
+                value: String::from("1"),
+                long: false,
+                span: Span::new(),
+            },
         ];
 
         compare(expected, tokens);
@@ -773,8 +1098,15 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Number(String::from(".1"), false),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Number {
+                value: String::from(".1"),
+                long: false,
+                span: Span::new(),
+            },
         ];
 
         compare(expected, tokens);
@@ -789,11 +1121,18 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("sqrt", None),
-            Token::LParen,
-            Token::Number(String::from("1"), false),
-            Token::RParen,
+            Token::LParen { span: Span::new() },
+            Token::Number {
+                value: String::from("1"),
+                long: false,
+                span: Span::new(),
+            },
+            Token::RParen { span: Span::new() },
         ];
 
         compare(expected, tokens);
@@ -808,12 +1147,27 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::SingleQuotedString(String::from("a")),
-            Token::Whitespace(Whitespace::Space),
-            Token::StringConcat,
-            Token::Whitespace(Whitespace::Space),
-            Token::SingleQuotedString(String::from("b")),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::SingleQuotedString {
+                value: String::from("a"),
+                span: Span::new(),
+            },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::StringConcat { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::SingleQuotedString {
+                value: String::from("b"),
+                span: Span::new(),
+            },
         ];
 
         compare(expected, tokens);
@@ -827,15 +1181,30 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("one", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::Pipe,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Pipe { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("two", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::Caret,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Caret { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("three", None),
         ];
         compare(expected, tokens);
@@ -851,32 +1220,68 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("true"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("XOR"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("true"),
-            Token::Comma,
-            Token::Whitespace(Whitespace::Space),
+            Token::Comma { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("false"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("XOR"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("false"),
-            Token::Comma,
-            Token::Whitespace(Whitespace::Space),
+            Token::Comma { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("true"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("XOR"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("false"),
-            Token::Comma,
-            Token::Whitespace(Whitespace::Space),
+            Token::Comma { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("false"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("XOR"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("true"),
         ];
         compare(expected, tokens);
@@ -891,24 +1296,59 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Mul,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Mul { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("FROM"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("customer", None),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("WHERE"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("id", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::Eq,
-            Token::Whitespace(Whitespace::Space),
-            Token::Number(String::from("1"), false),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Eq { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Number {
+                value: String::from("1"),
+                long: false,
+                span: Span::new(),
+            },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("LIMIT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Number(String::from("5"), false),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Number {
+                value: String::from("5"),
+                long: false,
+                span: Span::new(),
+            },
         ];
 
         compare(expected, tokens);
@@ -923,22 +1363,50 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("EXPLAIN"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Mul,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Mul { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("FROM"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("customer", None),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("WHERE"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("id", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::Eq,
-            Token::Whitespace(Whitespace::Space),
-            Token::Number(String::from("1"), false),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Eq { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Number {
+                value: String::from("1"),
+                long: false,
+                span: Span::new(),
+            },
         ];
 
         compare(expected, tokens);
@@ -953,24 +1421,55 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("EXPLAIN"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("ANALYZE"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Mul,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Mul { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("FROM"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("customer", None),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("WHERE"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("id", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::Eq,
-            Token::Whitespace(Whitespace::Space),
-            Token::Number(String::from("1"), false),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Eq { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Number {
+                value: String::from("1"),
+                long: false,
+                span: Span::new(),
+            },
         ];
 
         compare(expected, tokens);
@@ -985,20 +1484,44 @@ mod tests {
 
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Mul,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Mul { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("FROM"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("customer", None),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("WHERE"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("salary", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::Neq,
-            Token::Whitespace(Whitespace::Space),
-            Token::SingleQuotedString(String::from("Not Provided")),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Neq { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::SingleQuotedString {
+                value: String::from("Not Provided"),
+                span: Span::new(),
+            },
         ];
 
         compare(expected, tokens);
@@ -1013,12 +1536,30 @@ mod tests {
         let tokens = tokenizer.tokenize().unwrap();
         // println!("tokens: {:#?}", tokens);
         let expected = vec![
-            Token::Whitespace(Whitespace::Newline),
-            Token::Char('م'),
-            Token::Char('ص'),
-            Token::Char('ط'),
-            Token::Char('ف'),
-            Token::Char('ى'),
+            Token::Whitespace {
+                value: Whitespace::Newline,
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'م',
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'ص',
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'ط',
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'ف',
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'ى',
+                span: Span::new(),
+            },
             Token::make_word("h", None),
         ];
         compare(expected, tokens);
@@ -1031,7 +1572,10 @@ mod tests {
         let dialect = GenericDialect {};
         let mut tokenizer = Tokenizer::new(&dialect, &sql);
         let tokens = tokenizer.tokenize().unwrap();
-        let expected = vec![Token::SingleQuotedString("foo\r\nbar\nbaz".to_string())];
+        let expected = vec![Token::SingleQuotedString {
+            value: "foo\r\nbar\nbaz".to_string(),
+            span: Span::new(),
+        }];
         compare(expected, tokens);
     }
 
@@ -1046,7 +1590,8 @@ mod tests {
             Err(TokenizerError {
                 message: "Unterminated string literal".to_string(),
                 line: 1,
-                col: 8
+                col: 8,
+                span: (7..11).into()
             })
         );
     }
@@ -1060,21 +1605,54 @@ mod tests {
         let tokens = tokenizer.tokenize().unwrap();
         // println!("tokens: {:#?}", tokens);
         let expected = vec![
-            Token::Whitespace(Whitespace::Newline),
-            Token::Whitespace(Whitespace::Newline),
+            Token::Whitespace {
+                value: Whitespace::Newline,
+                span: Span::new(),
+            },
+            Token::Whitespace {
+                value: Whitespace::Newline,
+                span: Span::new(),
+            },
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Mul,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Mul { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("FROM"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("table"),
-            Token::Whitespace(Whitespace::Tab),
-            Token::Char('م'),
-            Token::Char('ص'),
-            Token::Char('ط'),
-            Token::Char('ف'),
-            Token::Char('ى'),
+            Token::Whitespace {
+                value: Whitespace::Tab,
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'م',
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'ص',
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'ط',
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'ف',
+                span: Span::new(),
+            },
+            Token::Char {
+                value: 'ى',
+                span: Span::new(),
+            },
             Token::make_word("h", None),
         ];
         compare(expected, tokens);
@@ -1088,11 +1666,11 @@ mod tests {
         let tokens = tokenizer.tokenize().unwrap();
         let expected = vec![
             Token::make_word("FUNCTION", None),
-            Token::LParen,
+            Token::LParen { span: Span::new() },
             Token::make_word("key", None),
-            Token::RArrow,
+            Token::RArrow { span: Span::new() },
             Token::make_word("value", None),
-            Token::RParen,
+            Token::RParen { span: Span::new() },
         ];
         compare(expected, tokens);
     }
@@ -1106,9 +1684,15 @@ mod tests {
 
         let expected = vec![
             Token::make_word("a", None),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("IS"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("NULL"),
         ];
 
@@ -1123,12 +1707,23 @@ mod tests {
         let mut tokenizer = Tokenizer::new(&dialect, &sql);
         let tokens = tokenizer.tokenize().unwrap();
         let expected = vec![
-            Token::Number("0".to_string(), false),
-            Token::Whitespace(Whitespace::SingleLineComment {
-                prefix: "--".to_string(),
-                comment: "this is a comment\n".to_string(),
-            }),
-            Token::Number("1".to_string(), false),
+            Token::Number {
+                value: "0".to_string(),
+                long: false,
+                span: Span::new(),
+            },
+            Token::Whitespace {
+                value: Whitespace::SingleLineComment {
+                    prefix: "--".to_string(),
+                    comment: "this is a comment\n".to_string(),
+                },
+                span: Span::new(),
+            },
+            Token::Number {
+                value: "1".to_string(),
+                long: false,
+                span: Span::new(),
+            },
         ];
         compare(expected, tokens);
     }
@@ -1140,10 +1735,13 @@ mod tests {
         let dialect = GenericDialect {};
         let mut tokenizer = Tokenizer::new(&dialect, &sql);
         let tokens = tokenizer.tokenize().unwrap();
-        let expected = vec![Token::Whitespace(Whitespace::SingleLineComment {
-            prefix: "--".to_string(),
-            comment: "this is a comment".to_string(),
-        })];
+        let expected = vec![Token::Whitespace {
+            value: Whitespace::SingleLineComment {
+                prefix: "--".to_string(),
+                comment: "this is a comment".to_string(),
+            },
+            span: Span::new(),
+        }];
         compare(expected, tokens);
     }
 
@@ -1155,11 +1753,20 @@ mod tests {
         let mut tokenizer = Tokenizer::new(&dialect, &sql);
         let tokens = tokenizer.tokenize().unwrap();
         let expected = vec![
-            Token::Number("0".to_string(), false),
-            Token::Whitespace(Whitespace::MultiLineComment(
-                "multi-line\n* /comment".to_string(),
-            )),
-            Token::Number("1".to_string(), false),
+            Token::Number {
+                value: "0".to_string(),
+                long: false,
+                span: Span::new(),
+            },
+            Token::Whitespace {
+                value: Whitespace::MultiLineComment("multi-line\n* /comment".to_string()),
+                span: Span::new(),
+            },
+            Token::Number {
+                value: "1".to_string(),
+                long: false,
+                span: Span::new(),
+            },
         ];
         compare(expected, tokens);
     }
@@ -1172,9 +1779,18 @@ mod tests {
         let mut tokenizer = Tokenizer::new(&dialect, &sql);
         let tokens = tokenizer.tokenize().unwrap();
         let expected = vec![
-            Token::Whitespace(Whitespace::Newline),
-            Token::Whitespace(Whitespace::MultiLineComment("* Comment *".to_string())),
-            Token::Whitespace(Whitespace::Newline),
+            Token::Whitespace {
+                value: Whitespace::Newline,
+                span: Span::new(),
+            },
+            Token::Whitespace {
+                value: Whitespace::MultiLineComment("* Comment *".to_string()),
+                span: Span::new(),
+            },
+            Token::Whitespace {
+                value: Whitespace::Newline,
+                span: Span::new(),
+            },
         ];
         compare(expected, tokens);
     }
@@ -1190,7 +1806,8 @@ mod tests {
             Err(TokenizerError {
                 message: "Expected close delimiter '\"' before EOF.".to_string(),
                 line: 1,
-                col: 1
+                col: 1,
+                span: (0..4).into(),
             })
         );
     }
@@ -1204,13 +1821,25 @@ mod tests {
         let tokens = tokenizer.tokenize().unwrap();
         let expected = vec![
             Token::make_word("line1", None),
-            Token::Whitespace(Whitespace::Newline),
+            Token::Whitespace {
+                value: Whitespace::Newline,
+                span: Span::new(),
+            },
             Token::make_word("line2", None),
-            Token::Whitespace(Whitespace::Newline),
+            Token::Whitespace {
+                value: Whitespace::Newline,
+                span: Span::new(),
+            },
             Token::make_word("line3", None),
-            Token::Whitespace(Whitespace::Newline),
+            Token::Whitespace {
+                value: Whitespace::Newline,
+                span: Span::new(),
+            },
             Token::make_word("line4", None),
-            Token::Whitespace(Whitespace::Newline),
+            Token::Whitespace {
+                value: Whitespace::Newline,
+                span: Span::new(),
+            },
         ];
         compare(expected, tokens);
     }
@@ -1223,15 +1852,34 @@ mod tests {
         let tokens = tokenizer.tokenize().unwrap();
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("TOP"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Number(String::from("5"), false),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Number {
+                value: String::from("5"),
+                long: false,
+                span: Span::new(),
+            },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("bar", Some('[')),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_keyword("FROM"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("foo", None),
         ];
         compare(expected, tokens);
@@ -1245,33 +1893,81 @@ mod tests {
         let tokens = tokenizer.tokenize().unwrap();
         let expected = vec![
             Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("col", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::Tilde,
-            Token::Whitespace(Whitespace::Space),
-            Token::SingleQuotedString("^a".into()),
-            Token::Comma,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::Tilde { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::SingleQuotedString {
+                value: "^a".into(),
+                span: Span::new(),
+            },
+            Token::Comma { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("col", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::TildeAsterisk,
-            Token::Whitespace(Whitespace::Space),
-            Token::SingleQuotedString("^a".into()),
-            Token::Comma,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::TildeAsterisk { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::SingleQuotedString {
+                value: "^a".into(),
+                span: Span::new(),
+            },
+            Token::Comma { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("col", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::ExclamationMarkTilde,
-            Token::Whitespace(Whitespace::Space),
-            Token::SingleQuotedString("^a".into()),
-            Token::Comma,
-            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::ExclamationMarkTilde { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::SingleQuotedString {
+                value: "^a".into(),
+                span: Span::new(),
+            },
+            Token::Comma { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
             Token::make_word("col", None),
-            Token::Whitespace(Whitespace::Space),
-            Token::ExclamationMarkTildeAsterisk,
-            Token::Whitespace(Whitespace::Space),
-            Token::SingleQuotedString("^a".into()),
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::ExclamationMarkTildeAsterisk { span: Span::new() },
+            Token::Whitespace {
+                value: Whitespace::Space,
+                span: Span::new(),
+            },
+            Token::SingleQuotedString {
+                value: "^a".into(),
+                span: Span::new(),
+            },
         ];
         compare(expected, tokens);
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -422,7 +422,7 @@ fn test_eof_after_as() {
 fn test_no_infix_error() {
     let res = Parser::parse_sql(&GenericDialect {}, "ASSERT-URA<<");
     assert_eq!(
-        ParserError::ParserError("No infix parser for token ShiftLeft".to_string()),
+        ParserError::ParserError("No infix parser for token '<<'".to_string()),
         res.unwrap_err()
     );
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -16,6 +16,7 @@
 
 #[macro_use]
 mod test_utils;
+use sqlparser::span::Span;
 use test_utils::*;
 
 #[cfg(feature = "bigdecimal")]
@@ -327,25 +328,37 @@ fn parse_create_table_if_not_exists() {
 fn parse_bad_if_not_exists() {
     let res = pg().parse_sql_statements("CREATE TABLE NOT EXISTS uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: EXISTS".to_string()),
+        ParserError::ParserError {
+            message: "Expected end of statement, found: EXISTS".to_string(),
+            span: Span::new()
+        },
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF EXISTS uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: EXISTS".to_string()),
+        ParserError::ParserError {
+            message: "Expected end of statement, found: EXISTS".to_string(),
+            span: Span::new()
+        },
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: uk_cities".to_string()),
+        ParserError::ParserError {
+            message: "Expected end of statement, found: uk_cities".to_string(),
+            span: Span::new()
+        },
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF NOT uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: NOT".to_string()),
+        ParserError::ParserError {
+            message: "Expected end of statement, found: NOT".to_string(),
+            span: Span::new()
+        },
         res.unwrap_err()
     );
 }
@@ -468,23 +481,26 @@ fn parse_set() {
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET"),
-        Err(ParserError::ParserError(
-            "Expected identifier, found: EOF".to_string()
-        )),
+        Err(ParserError::ParserError {
+            message: "Expected identifier, found: EOF".to_string(),
+            span: Span::new()
+        }),
     );
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET a b"),
-        Err(ParserError::ParserError(
-            "Expected equals sign or TO, found: b".to_string()
-        )),
+        Err(ParserError::ParserError {
+            message: "Expected equals sign or TO, found: b".to_string(),
+            span: Span::new()
+        }),
     );
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET a ="),
-        Err(ParserError::ParserError(
-            "Expected variable value, found: EOF".to_string()
-        )),
+        Err(ParserError::ParserError {
+            message: "Expected variable value, found: EOF".to_string(),
+            span: Span::new()
+        }),
     );
 }
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -16,6 +16,7 @@
 
 #[macro_use]
 mod test_utils;
+use sqlparser::span::Span;
 use test_utils::*;
 
 use sqlparser::ast::*;
@@ -43,12 +44,18 @@ fn test_snowflake_single_line_tokenize() {
 
     let expected = vec![
         Token::make_keyword("CREATE"),
-        Token::Whitespace(Whitespace::Space),
+        Token::Whitespace {
+            value: Whitespace::Space,
+            span: Span::new(),
+        },
         Token::make_keyword("TABLE"),
-        Token::Whitespace(Whitespace::SingleLineComment {
-            prefix: "#".to_string(),
-            comment: " this is a comment \n".to_string(),
-        }),
+        Token::Whitespace {
+            value: Whitespace::SingleLineComment {
+                prefix: "#".to_string(),
+                comment: " this is a comment \n".to_string(),
+            },
+            span: Span::new(),
+        },
         Token::make_word("table_1", None),
     ];
 
@@ -60,12 +67,18 @@ fn test_snowflake_single_line_tokenize() {
 
     let expected = vec![
         Token::make_keyword("CREATE"),
-        Token::Whitespace(Whitespace::Space),
+        Token::Whitespace {
+            value: Whitespace::Space,
+            span: Span::new(),
+        },
         Token::make_keyword("TABLE"),
-        Token::Whitespace(Whitespace::SingleLineComment {
-            prefix: "//".to_string(),
-            comment: " this is a comment \n".to_string(),
-        }),
+        Token::Whitespace {
+            value: Whitespace::SingleLineComment {
+                prefix: "//".to_string(),
+                comment: " this is a comment \n".to_string(),
+            },
+            span: Span::new(),
+        },
         Token::make_word("table_1", None),
     ];
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -146,13 +146,19 @@ fn test_single_table_in_parenthesis_with_alias() {
 
     let res = snowflake_and_generic().parse_sql_statements("SELECT * FROM (a NATURAL JOIN b) c");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: c".to_string()),
+        ParserError::ParserError {
+            message: "Expected end of statement, found: c".to_string(),
+            span: Span::new()
+        },
         res.unwrap_err()
     );
 
     let res = snowflake().parse_sql_statements("SELECT * FROM (a b) c");
     assert_eq!(
-        ParserError::ParserError("duplicate alias b".to_string()),
+        ParserError::ParserError {
+            message: "duplicate alias b".to_string(),
+            span: Span::new()
+        },
         res.unwrap_err()
     );
 }


### PR DESCRIPTION
In order to give nice error messages, it would be helpful to have byte spans on Token and Ast Nodes.

This could be used with a library such as `codespan-reporting` to produce more usefull error messages:
```
error: sql parser error: Expected end of statement, found: ENGINE
   ┌─ test.sql:34:3
   │
34 │ ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
   │   ^^^^^^
```

It is hard to do this in a none invasive way. In this PR I have added a trait called `Spanned` that is implemented for `Token`, where the `span()` method returns the `Span` of the token. I have also implemented `Spanned` for `ParseError` such that one can get the span of the primary cause of a parse error.

I would like to also produce error messages afterwards by performing custom passes over the AST, in order to do that it would be helpful if the various AST nodes also implements `Spanned`. There are several ways this could be done, but I would propose
to store the spans explicitly on primitive values, and then store a few choice tokens in AST nodes, such as the 'SELECT' or 'CREATE TABLE' tokens. The span for complex AST nodes could then be computed by merging the spans of the children. This has the benefit over storing an explicit span on all notes, that it is easier to produce a modified AST (from a lowering pass or whatnot) without getting the span wrong.  I have not done much of this yet as it is a lot of work that I would rather wait with doing, until I know if upstream thinks I am on the right path.

In the suggested implementation the Span struct is allowed to be unset. This is done such that one can produce a modified AST with new nodes without having to invent spans.

Do you want something like this in the code, and if so what form would you like it to have. There are many possible ways of doing it, this is just the one I found the most straightforward.