### PR TITLE
Support `DROP CONSTRAINT [ IF EXISTS ] <name> [ CASCADE ]`

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -31,8 +31,8 @@ pub enum AlterTableOperation {
     AddConstraint(TableConstraint),
     /// `ADD [ COLUMN ] <column_def>`
     AddColumn { column_def: ColumnDef },
-    /// TODO: implement `DROP CONSTRAINT <name>`
-    DropConstraint { name: Ident },
+    /// `DROP CONSTRAINT [ IF EXISTS ] <name>`
+    DropConstraint { if_exists: bool, name: Ident },
     /// `DROP [ COLUMN ] [ IF EXISTS ] <column_name> [ CASCADE ]`
     DropColumn {
         column_name: Ident,
@@ -106,7 +106,14 @@ impl fmt::Display for AlterTableOperation {
                 display_comma_separated(partitions),
                 ie = if *if_exists { " IF EXISTS" } else { "" }
             ),
-            AlterTableOperation::DropConstraint { name } => write!(f, "DROP CONSTRAINT {}", name),
+            AlterTableOperation::DropConstraint { if_exists, name } => {
+                write!(
+                    f,
+                    "DROP CONSTRAINT {}{}",
+                    if *if_exists { "IF EXISTS " } else { "" },
+                    name
+                )
+            }
             AlterTableOperation::DropColumn {
                 column_name,
                 if_exists,

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -32,7 +32,11 @@ pub enum AlterTableOperation {
     /// `ADD [ COLUMN ] <column_def>`
     AddColumn { column_def: ColumnDef },
     /// `DROP CONSTRAINT [ IF EXISTS ] <name>`
-    DropConstraint { if_exists: bool, name: Ident },
+    DropConstraint {
+        if_exists: bool,
+        name: Ident,
+        cascade: bool,
+    },
     /// `DROP [ COLUMN ] [ IF EXISTS ] <column_name> [ CASCADE ]`
     DropColumn {
         column_name: Ident,
@@ -106,12 +110,17 @@ impl fmt::Display for AlterTableOperation {
                 display_comma_separated(partitions),
                 ie = if *if_exists { " IF EXISTS" } else { "" }
             ),
-            AlterTableOperation::DropConstraint { if_exists, name } => {
+            AlterTableOperation::DropConstraint {
+                if_exists,
+                name,
+                cascade,
+            } => {
                 write!(
                     f,
-                    "DROP CONSTRAINT {}{}",
+                    "DROP CONSTRAINT {}{}{}",
                     if *if_exists { "IF EXISTS " } else { "" },
-                    name
+                    name,
+                    if *cascade { " CASCADE" } else { "" },
                 )
             }
             AlterTableOperation::DropColumn {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1985,7 +1985,12 @@ impl<'a> Parser<'a> {
             } else if self.parse_keyword(Keyword::CONSTRAINT) {
                 let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
                 let name = self.parse_identifier()?;
-                AlterTableOperation::DropConstraint { if_exists, name }
+                let cascade = self.parse_keyword(Keyword::CASCADE);
+                AlterTableOperation::DropConstraint {
+                    if_exists,
+                    name,
+                    cascade,
+                }
             } else {
                 let _ = self.parse_keyword(Keyword::COLUMN);
                 let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1982,6 +1982,10 @@ impl<'a> Parser<'a> {
                     partitions,
                     if_exists: false,
                 }
+            } else if self.parse_keyword(Keyword::CONSTRAINT) {
+                let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
+                let name = self.parse_identifier()?;
+                AlterTableOperation::DropConstraint { if_exists, name }
             } else {
                 let _ = self.parse_keyword(Keyword::COLUMN);
                 let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2055,18 +2055,20 @@ fn parse_alter_table_alter_column_type() {
 #[test]
 fn parse_alter_table_drop_constraint() {
     let alter_stmt = "ALTER TABLE tab";
-    match verified_stmt("ALTER TABLE tab DROP CONSTRAINT constraint_name") {
+    match verified_stmt("ALTER TABLE tab DROP CONSTRAINT constraint_name CASCADE") {
         Statement::AlterTable {
             name,
             operation:
                 AlterTableOperation::DropConstraint {
                     name: constr_name,
                     if_exists,
+                    cascade,
                 },
         } => {
             assert_eq!("tab", name.to_string());
             assert_eq!("constraint_name", constr_name.to_string());
             assert!(!if_exists);
+            assert!(cascade);
         }
         _ => unreachable!(),
     }
@@ -2077,11 +2079,13 @@ fn parse_alter_table_drop_constraint() {
                 AlterTableOperation::DropConstraint {
                     name: constr_name,
                     if_exists,
+                    cascade,
                 },
         } => {
             assert_eq!("tab", name.to_string());
             assert_eq!("constraint_name", constr_name.to_string());
             assert!(if_exists);
+            assert!(!cascade);
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
Support for the following syntax `DROP CONSTRAINT [ IF EXISTS ] <name> [ CASCADE ]`. PostgreSQL's seems to support the syntax `DROP CONSTRAINT [ IF EXISTS ] <name> [ RESTRICT | CASCADE ]`, but that didn't seem to be consistent with other parts of the AST so I left it like that. 

Addressing  #342.