### PR TITLE
support MySQL double quoted string

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -65,7 +65,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Value::Number(v, l) => write!(f, "{}{long}", v, long = if *l { "L" } else { "" }),
-            Value::DoubleQuotedString(v) => write!(f, "\"{}\"", v),
+            Value::DoubleQuotedString(v) => write!(f, "\"{}\"", escape_double_quote_string(v)),
             Value::SingleQuotedString(v) => write!(f, "'{}'", escape_single_quote_string(v)),
             Value::NationalStringLiteral(v) => write!(f, "N'{}'", v),
             Value::HexStringLiteral(v) => write!(f, "X'{}'", v),
@@ -137,6 +137,25 @@ impl fmt::Display for DateTimeField {
             DateTimeField::Second => "SECOND",
         })
     }
+}
+
+pub struct EscapeDoubleQuoteString<'a>(&'a str);
+
+impl<'a> fmt::Display for EscapeDoubleQuoteString<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for c in self.0.chars() {
+            if c == '"' {
+                write!(f, "\"\"")?;
+            } else {
+                write!(f, "{}", c)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn escape_double_quote_string(s: &str) -> EscapeDoubleQuoteString<'_> {
+    EscapeDoubleQuoteString(s)
 }
 
 pub struct EscapeSingleQuoteString<'a>(&'a str);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -479,6 +479,7 @@ impl<'a> Parser<'a> {
             }
             Token::Number(_, _)
             | Token::SingleQuotedString(_)
+            | Token::DoubleQuotedString(_)
             | Token::NationalStringLiteral(_)
             | Token::HexStringLiteral(_) => {
                 self.prev_token();
@@ -2139,6 +2140,7 @@ impl<'a> Parser<'a> {
                 Err(e) => parser_err!(format!("Could not parse '{}' as number: {}", n, e)),
             },
             Token::SingleQuotedString(ref s) => Ok(Value::SingleQuotedString(s.to_string())),
+            Token::DoubleQuotedString(ref s) => Ok(Value::DoubleQuotedString(s.to_string())),
             Token::NationalStringLiteral(ref s) => Ok(Value::NationalStringLiteral(s.to_string())),
             Token::HexStringLiteral(ref s) => Ok(Value::HexStringLiteral(s.to_string())),
             unexpected => self.expected("a value", unexpected),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1093,7 +1093,7 @@ mod tests {
         assert_eq!(
             tokenizer.tokenize(),
             Err(TokenizerError {
-                message: "Unterminated string literal".to_string(),
+                message: "Unterminated string literal with single quoted".to_string(),
                 line: 1,
                 col: 8
             })

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -49,7 +49,7 @@ pub enum Token {
     Char(char),
     /// Single quoted string: i.e: 'string'
     SingleQuotedString(String),
-    /// Double quoted string: i.e: 'string'
+    /// Double quoted string: i.e: "string"
     DoubleQuotedString(String),
     /// "National" string literal: i.e: N'string'
     NationalStringLiteral(String),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -151,7 +151,7 @@ impl fmt::Display for Token {
             Token::Number(ref n, l) => write!(f, "{}{long}", n, long = if *l { "L" } else { "" }),
             Token::Char(ref c) => write!(f, "{}", c),
             Token::SingleQuotedString(ref s) => write!(f, "'{}'", s),
-            Token::DoubleQuotedString(ref s) => write!(f, "{:#?}", s),
+            Token::DoubleQuotedString(ref s) => write!(f, "{:?}", s),
             Token::NationalStringLiteral(ref s) => write!(f, "N'{}'", s),
             Token::HexStringLiteral(ref s) => write!(f, "X'{}'", s),
             Token::Comma => f.write_str(","),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -223,7 +223,7 @@ fn parse_escaped_string() {
 }
 
 #[test]
-fn parse_escaped_double_quoated_string() {
+fn parse_escaped_double_quoted_string() {
     let sql = r#"SELECT "I\"m fine""#;
 
     let stmt = mysql().one_statement_parses_to(sql, "");


### PR DESCRIPTION
MySQL double quoated should be string type, like single quoated
example:
```
SELECT "abc_123"
```

`"abc_123"` should be string type, not ident(column name)