### PR TITLE
Add support for `FROM <filename>`, `DELIMITER`, and `CSV HEADER` options for `COPY` command

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1051,7 +1051,7 @@ impl fmt::Display for Statement {
                 values,
                 delimiter,
                 filename,
-                csv_header
+                csv_header,
             } => {
                 write!(f, "COPY {}", table_name)?;
                 if !columns.is_empty() {
@@ -1083,7 +1083,7 @@ impl fmt::Display for Statement {
                         }
                     }
                 }
-                if filename.is_none(){
+                if filename.is_none() {
                     write!(f, "\n\\.")?;
                 }
                 Ok(())

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -173,6 +173,7 @@ define_keywords!(
     DEFAULT,
     DELETE,
     DELIMITED,
+    DELIMITER,
     DENSE_RANK,
     DEREF,
     DESC,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2102,7 +2102,7 @@ impl<'a> Parser<'a> {
                     Keyword::DELIMITER => {
                         delimiter = Some(self.parse_identifier()?);
                         continue;
-                    },
+                    }
                     Keyword::CSV => {
                         self.expect_keyword(Keyword::HEADER)?;
                         csv_header = true

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2087,13 +2087,44 @@ impl<'a> Parser<'a> {
     pub fn parse_copy(&mut self) -> Result<Statement, ParserError> {
         let table_name = self.parse_object_name()?;
         let columns = self.parse_parenthesized_column_list(Optional)?;
-        self.expect_keywords(&[Keyword::FROM, Keyword::STDIN])?;
-        self.expect_token(&Token::SemiColon)?;
-        let values = self.parse_tsv();
+        self.expect_keywords(&[Keyword::FROM])?;
+        let mut filename = None;
+        // check whether data has to be copied form table or std in.
+        if !self.parse_keyword(Keyword::STDIN) {
+            filename = Some(self.parse_identifier()?)
+        }
+        // parse copy options.
+        let mut delimiter = None;
+        let mut csv_header = false;
+        loop {
+            if let Some(keyword) = self.parse_one_of_keywords(&[Keyword::DELIMITER, Keyword::CSV]) {
+                match keyword {
+                    Keyword::DELIMITER => {
+                        delimiter = Some(self.parse_identifier()?);
+                        continue;
+                    },
+                    Keyword::CSV => {
+                        self.expect_keyword(Keyword::HEADER)?;
+                        csv_header = true
+                    }
+                    _ => unreachable!("something wrong while parsing copy statment :("),
+                }
+            }
+            break;
+        }
+        // copy the values from stdin if there is no file to be copied from.
+        let mut values = vec![];
+        if filename.is_none() {
+            self.expect_token(&Token::SemiColon)?;
+            values = self.parse_tsv();
+        }
         Ok(Statement::Copy {
             table_name,
             columns,
             values,
+            filename,
+            delimiter,
+            csv_header,
         })
     }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -405,14 +405,14 @@ PHP	₱ USD $
 }
 
 #[test]
-fn test_copy(){
+fn test_copy() {
     let stmt = pg().verified_stmt("COPY users FROM 'data.csv'");
     assert_eq!(
         stmt,
-        Statement::Copy{
+        Statement::Copy {
             table_name: ObjectName(vec!["users".into()]),
             columns: vec![],
-            filename: Some(Ident{
+            filename: Some(Ident {
                 value: "data.csv".to_string(),
                 quote_style: Some('\'')
             }),
@@ -425,15 +425,15 @@ fn test_copy(){
     let stmt = pg().verified_stmt("COPY users FROM 'data.csv' DELIMITER ','");
     assert_eq!(
         stmt,
-        Statement::Copy{
+        Statement::Copy {
             table_name: ObjectName(vec!["users".into()]),
             columns: vec![],
-            filename: Some(Ident{
+            filename: Some(Ident {
                 value: "data.csv".to_string(),
                 quote_style: Some('\'')
             }),
             values: vec![],
-            delimiter: Some(Ident{
+            delimiter: Some(Ident {
                 value: ",".to_string(),
                 quote_style: Some('\'')
             }),
@@ -444,15 +444,15 @@ fn test_copy(){
     let stmt = pg().verified_stmt("COPY users FROM 'data.csv' DELIMITER ',' CSV HEADER");
     assert_eq!(
         stmt,
-        Statement::Copy{
+        Statement::Copy {
             table_name: ObjectName(vec!["users".into()]),
             columns: vec![],
-            filename: Some(Ident{
+            filename: Some(Ident {
                 value: "data.csv".to_string(),
                 quote_style: Some('\'')
             }),
             values: vec![],
-            delimiter: Some(Ident{
+            delimiter: Some(Ident {
                 value: ",".to_string(),
                 quote_style: Some('\'')
             }),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -405,6 +405,63 @@ PHP	₱ USD $
 }
 
 #[test]
+fn test_copy(){
+    let stmt = pg().verified_stmt("COPY users FROM 'data.csv'");
+    assert_eq!(
+        stmt,
+        Statement::Copy{
+            table_name: ObjectName(vec!["users".into()]),
+            columns: vec![],
+            filename: Some(Ident{
+                value: "data.csv".to_string(),
+                quote_style: Some('\'')
+            }),
+            values: vec![],
+            delimiter: None,
+            csv_header: false
+        }
+    );
+
+    let stmt = pg().verified_stmt("COPY users FROM 'data.csv' DELIMITER ','");
+    assert_eq!(
+        stmt,
+        Statement::Copy{
+            table_name: ObjectName(vec!["users".into()]),
+            columns: vec![],
+            filename: Some(Ident{
+                value: "data.csv".to_string(),
+                quote_style: Some('\'')
+            }),
+            values: vec![],
+            delimiter: Some(Ident{
+                value: ",".to_string(),
+                quote_style: Some('\'')
+            }),
+            csv_header: false,
+        }
+    );
+
+    let stmt = pg().verified_stmt("COPY users FROM 'data.csv' DELIMITER ',' CSV HEADER");
+    assert_eq!(
+        stmt,
+        Statement::Copy{
+            table_name: ObjectName(vec!["users".into()]),
+            columns: vec![],
+            filename: Some(Ident{
+                value: "data.csv".to_string(),
+                quote_style: Some('\'')
+            }),
+            values: vec![],
+            delimiter: Some(Ident{
+                value: ",".to_string(),
+                quote_style: Some('\'')
+            }),
+            csv_header: true,
+        }
+    )
+}
+
+#[test]
 fn parse_set() {
     let stmt = pg_and_generic().verified_stmt("SET a = b");
     assert_eq!(


### PR DESCRIPTION
This PR adds support for delimiter and csv header options in copy command

Signed-off-by: password <rbalajis25@gmail.com>