### PR TITLE
fix: Handle double quotes inside quoted identifiers correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { version = "1.0", optional = true }
 [dev-dependencies]
 simple_logger = "1.9"
 matches = "0.1"
+pretty_assertions = "1"
 
 [package.metadata.release]
 # Instruct `cargo release` to not run `cargo publish` locally:

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -23,7 +23,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::fmt;
+use core::fmt::{self, Write};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -127,7 +127,18 @@ impl From<&str> for Ident {
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.quote_style {
-            Some(q) if q == '"' || q == '\'' || q == '`' => write!(f, "{}{}{}", q, self.value, q),
+            Some(q) if q == '"' || q == '\'' || q == '`' => {
+                f.write_char(q)?;
+                let mut first = true;
+                for s in self.value.split_inclusive(q) {
+                    if !first {
+                        f.write_char(q)?;
+                    }
+                    first = false;
+                    f.write_str(s)?;
+                }
+                f.write_char(q)
+            }
             Some(q) if q == '[' => write!(f, "[{}]", self.value),
             None => f.write_str(&self.value),
             _ => panic!("unexpected quote style"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,10 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[macro_use]
+#[cfg(test)]
+extern crate pretty_assertions;
+
 pub mod ast;
 #[macro_use]
 pub mod dialect;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1304,11 +1304,11 @@ mod tests {
         let tokens = tokenizer.tokenize().unwrap();
         let expected = vec![
             Token::Whitespace(Whitespace::Space),
-            Token::make_word(r#"a " b"#.into(), Some('"')),
+            Token::make_word(r#"a " b"#, Some('"')),
             Token::Whitespace(Whitespace::Space),
-            Token::make_word(r#"a ""#.into(), Some('"')),
+            Token::make_word(r#"a ""#, Some('"')),
             Token::Whitespace(Whitespace::Space),
-            Token::make_word(r#"c """#.into(), Some('"')),
+            Token::make_word(r#"c """#, Some('"')),
             Token::Whitespace(Whitespace::Space),
         ];
         compare(expected, tokens);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1296,6 +1296,24 @@ mod tests {
         compare(expected, tokens);
     }
 
+    #[test]
+    fn tokenize_quoted_identifier() {
+        let sql = r#" "a "" b" "a """ "c """"" "#;
+        let dialect = GenericDialect {};
+        let mut tokenizer = Tokenizer::new(&dialect, sql);
+        let tokens = tokenizer.tokenize().unwrap();
+        let expected = vec![
+            Token::Whitespace(Whitespace::Space),
+            Token::make_word(r#"a " b"#.into(), Some('"')),
+            Token::Whitespace(Whitespace::Space),
+            Token::make_word(r#"a ""#.into(), Some('"')),
+            Token::Whitespace(Whitespace::Space),
+            Token::make_word(r#"c """#.into(), Some('"')),
+            Token::Whitespace(Whitespace::Space),
+        ];
+        compare(expected, tokens);
+    }
+
     fn compare(expected: Vec<Token>, actual: Vec<Token>) {
         //println!("------------------------------");
         //println!("tokens   = {:?}", actual);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -418,24 +418,7 @@ impl<'a> Tokenizer<'a> {
                 quote_start if self.dialect.is_delimited_identifier_start(quote_start) => {
                     chars.next(); // consume the opening quote
                     let quote_end = Word::matching_end_quote(quote_start);
-                    let mut last_char = None;
-                    let s = {
-                        let mut s = String::new();
-                        while let Some(ch) = chars.next() {
-                            if ch == quote_end {
-                                if chars.peek() == Some(&quote_end) {
-                                    chars.next();
-                                    s.push(ch);
-                                } else {
-                                    last_char = Some(quote_end);
-                                    break;
-                                }
-                            } else {
-                                s.push(ch);
-                            }
-                        }
-                        s
-                    };
+                    let (s, last_char) = parse_quoted_ident(chars, quote_end);
 
                     if last_char == Some(quote_end) {
                         Ok(Some(Token::make_word(&s, Some(quote_start))))
@@ -744,6 +727,25 @@ fn peeking_take_while(
         }
     }
     s
+}
+
+fn parse_quoted_ident(chars: &mut Peekable<Chars<'_>>, quote_end: char) -> (String, Option<char>) {
+    let mut last_char = None;
+    let mut s = String::new();
+    while let Some(ch) = chars.next() {
+        if ch == quote_end {
+            if chars.peek() == Some(&quote_end) {
+                chars.next();
+                s.push(ch);
+            } else {
+                last_char = Some(quote_end);
+                break;
+            }
+        } else {
+            s.push(ch);
+        }
+    }
+    (s, last_char)
 }
 
 #[cfg(test)]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -179,6 +179,37 @@ fn parse_quote_identifiers() {
 }
 
 #[test]
+fn parse_quote_identifiers_2() {
+    let sql = "SELECT `quoted `` identifier`";
+    assert_eq!(
+        mysql().verified_stmt(sql),
+        Statement::Query(Box::new(Query {
+            with: None,
+            body: SetExpr::Select(Box::new(Select {
+                distinct: false,
+                top: None,
+                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
+                    value: "quoted ` identifier".into(),
+                    quote_style: Some('`'),
+                }))],
+                from: vec![],
+                lateral_views: vec![],
+                selection: None,
+                group_by: vec![],
+                cluster_by: vec![],
+                distribute_by: vec![],
+                sort_by: vec![],
+                having: None,
+            })),
+            order_by: vec![],
+            limit: None,
+            offset: None,
+            fetch: None,
+        }))
+    );
+}
+
+#[test]
 fn parse_unterminated_escape() {
     let sql = r#"SELECT 'I\'m not fine\'"#;
     let result = std::panic::catch_unwind(|| mysql().one_statement_parses_to(sql, ""));

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -834,6 +834,11 @@ fn parse_comments() {
     }
 }
 
+#[test]
+fn parse_quoted_identifier() {
+    pg_and_generic().verified_stmt(r#"SELECT "quoted "" ident""#);
+}
+
 fn pg() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(PostgreSqlDialect {})],


### PR DESCRIPTION
This fixes #410 for standard SQL, however I don't know enough about other dialects to know if they
handle this differently. May need more extensive testing as well.