### PR TITLE
Fix new clippy errors

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -92,7 +92,7 @@ impl fmt::Display for AlterTableOperation {
             ),
             AlterTableOperation::AddConstraint(c) => write!(f, "ADD {}", c),
             AlterTableOperation::AddColumn { column_def } => {
-                write!(f, "ADD COLUMN {}", column_def.to_string())
+                write!(f, "ADD COLUMN {}", column_def)
             }
             AlterTableOperation::AlterColumn { column_name, op } => {
                 write!(f, "ALTER COLUMN {} {}", column_name, op)

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1548,7 +1548,7 @@ impl fmt::Display for Privileges {
                 )
             }
             Privileges::Actions(actions) => {
-                write!(f, "{}", display_comma_separated(actions).to_string())
+                write!(f, "{}", display_comma_separated(actions))
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2649,7 +2649,7 @@ impl<'a> Parser<'a> {
         };
 
         // Not Sure if Top should be cheked here as well. Trino doesn't support TOP.
-        let is_l_parent = if distinct {
+        let is_l_paren = if distinct {
             self.consume_token(&Token::LParen)
         } else {
             false
@@ -2657,8 +2657,8 @@ impl<'a> Parser<'a> {
 
         let projection = self.parse_comma_separated(Parser::parse_select_item)?;
 
-        if is_l_parent {
-            self.consume_token(&Token::RParen);
+        if is_l_paren && !self.consume_token(&Token::RParen) {
+            return self.expected(")", self.peek_token());
         }
 
         // Note that for keywords to be properly handled here, they need to be

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -344,6 +344,15 @@ fn parse_select_distinct_two_fields() {
 }
 
 #[test]
+fn parse_select_distinct_missing_paren() {
+    let result = parse_sql_statements("SELECT DISTINCT (name, id FROM customer");
+    assert_eq!(
+        ParserError::ParserError("Expected ), found: FROM".to_string()),
+        result.unwrap_err(),
+    );
+}
+
+#[test]
 fn parse_select_all() {
     one_statement_parses_to("SELECT ALL name FROM customer", "SELECT name FROM customer");
 }


### PR DESCRIPTION
Fixes new clippy lints introduced in newer `rustc` releases

Also check for missing paren in code added in https://github.com/sqlparser-rs/sqlparser-rs/pull/391 (found by clippy lint)