### PR TITLE
Add `Expr::Tuple` and parsing support, remove special case in `DISTINCT` clause

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -284,6 +284,8 @@ pub enum Expr {
     Cube(Vec<Vec<Expr>>),
     /// The `ROLLUP` expr.
     Rollup(Vec<Vec<Expr>>),
+    /// ROW / TUPLE a single value, such as `SELECT (1, 2)`
+    Tuple(Vec<Expr>),
 }
 
 impl fmt::Display for Expr {
@@ -444,6 +446,9 @@ impl fmt::Display for Expr {
                 }
 
                 write!(f, ")")
+            }
+            Expr::Tuple(exprs) => {
+                write!(f, "({})", display_comma_separated(exprs))
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -494,7 +494,12 @@ impl<'a> Parser<'a> {
                         self.prev_token();
                         Expr::Subquery(Box::new(self.parse_query()?))
                     } else {
-                        Expr::Nested(Box::new(self.parse_expr()?))
+                        let exprs = self.parse_comma_separated(Parser::parse_expr)?;
+                        match exprs.len() {
+                            0 => unreachable!(), // parse_comma_separated ensures 1 or more
+                            1 => Expr::Nested(Box::new(exprs.into_iter().next().unwrap())),
+                            _ => Expr::Tuple(exprs),
+                        }
                     };
                 self.expect_token(&Token::RParen)?;
                 Ok(expr)
@@ -2680,18 +2685,7 @@ impl<'a> Parser<'a> {
             None
         };
 
-        // Not Sure if Top should be cheked here as well. Trino doesn't support TOP.
-        let is_l_paren = if distinct {
-            self.consume_token(&Token::LParen)
-        } else {
-            false
-        };
-
         let projection = self.parse_comma_separated(Parser::parse_select_item)?;
-
-        if is_l_paren && !self.consume_token(&Token::RParen) {
-            return self.expected(")", self.peek_token());
-        }
 
         // Note that for keywords to be properly handled here, they need to be
         // added to `RESERVED_FOR_COLUMN_ALIAS` / `RESERVED_FOR_TABLE_ALIAS`,


### PR DESCRIPTION
# Rationale:
@yuval-illumex  is trying to support parenthesized expressions like `(a, b)` in various places (see https://github.com/sqlparser-rs/sqlparser-rs/pull/390, and https://github.com/sqlparser-rs/sqlparser-rs/pull/391)

I believe these are more commonly called `tuple` or `row` types in postgres or trino. Rather than adding special case handling for parens in various places, it would be better to simply support parsing tuples in general 

# Changes
1. Support parsing tuple expressions in select statement
2. Tests for same
2. Remove special case added in #390 for `distinct` clause
2. Add tests in #391  demonstrating this code can parse paren'd expressions in the group by


# Reference:

This syntax is supported by postgres:

```sql
alamb=# select (1, 'foo');
   row   
---------
 (1,foo)
(1 row)
```

It is not supported by `mysql`:

```sql
mysql> select (1, 2);
ERROR 1241 (21000): Operand should contain 1 column(s)
```