### PR TITLE
Support prepared statement placeholder arg `?` and `$`

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -59,6 +59,8 @@ pub enum Value {
     },
     /// `NULL` value
     Null,
+    /// `?` or `$` Prepared statement arg placeholder
+    Placeholder(String),
 }
 
 impl fmt::Display for Value {
@@ -111,6 +113,7 @@ impl fmt::Display for Value {
                 Ok(())
             }
             Value::Null => write!(f, "NULL"),
+            Value::Placeholder(v) => write!(f, "{}", v),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -504,6 +504,10 @@ impl<'a> Parser<'a> {
                 self.expect_token(&Token::RParen)?;
                 Ok(expr)
             }
+            Token::Placeholder(_) => {
+                self.prev_token();
+                Ok(Expr::Value(self.parse_value()?))
+            }
             unexpected => self.expected("an expression:", unexpected),
         }?;
 
@@ -2234,6 +2238,7 @@ impl<'a> Parser<'a> {
             Token::SingleQuotedString(ref s) => Ok(Value::SingleQuotedString(s.to_string())),
             Token::NationalStringLiteral(ref s) => Ok(Value::NationalStringLiteral(s.to_string())),
             Token::HexStringLiteral(ref s) => Ok(Value::HexStringLiteral(s.to_string())),
+            Token::Placeholder(ref s) => Ok(Value::Placeholder(s.to_string())),
             unexpected => self.expected("a value", unexpected),
         }
     }


### PR DESCRIPTION
#145 support `?` or `$foo` prepared statement arg placeholder.
```sql
SELECT * FROM student WHERE id = ?;
SELECT * FROM student WHERE id = $Id1;
```