### PR TITLE
Update doc reference to Query

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -121,7 +121,7 @@ impl fmt::Display for SetOperator {
 }
 
 /// A restricted variant of `SELECT` (without CTEs/`ORDER BY`), which may
-/// appear either as the only body item of an `SQLQuery`, or as an operand
+/// appear either as the only body item of an `Query`, or as an operand
 /// to a set operation like `UNION`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
I guess it used to be called SQLQuery?
