### PR TITLE
support MySQL UNSIGNED

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -377,6 +377,7 @@ pub enum ColumnOption {
     DialectSpecific(Vec<Token>),
     CharacterSet(ObjectName),
     Comment(String),
+    Unsigned,
 }
 
 impl fmt::Display for ColumnOption {
@@ -411,6 +412,7 @@ impl fmt::Display for ColumnOption {
             DialectSpecific(val) => write!(f, "{}", display_separated(val, " ")),
             CharacterSet(n) => write!(f, "CHARACTER SET {}", n),
             Comment(v) => write!(f, "COMMENT '{}'", escape_single_quote_string(v)),
+            Unsigned => write!(f, "UNSIGNED"),
         }
     }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -484,6 +484,7 @@ define_keywords!(
     UNIQUE,
     UNKNOWN,
     UNNEST,
+    UNSIGNED,
     UPDATE,
     UPPER,
     USAGE,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1829,6 +1829,19 @@ impl<'a> Parser<'a> {
                 break;
             };
         }
+        if self.parse_keyword(Keyword::UNSIGNED) {
+            println!(
+                "{}",
+                ColumnOptionDef {
+                    name: None,
+                    option: ColumnOption::Unsigned
+                }
+            );
+            options.push(ColumnOptionDef {
+                name: None,
+                option: ColumnOption::Unsigned,
+            });
+        };
         Ok(ColumnDef {
             name,
             data_type,
@@ -1898,6 +1911,11 @@ impl<'a> Parser<'a> {
             Ok(Some(ColumnOption::DialectSpecific(vec![
                 Token::make_keyword("AUTOINCREMENT"),
             ])))
+        } else if self.parse_keyword(Keyword::UNSIGNED)
+            && dialect_of!(self is MySqlDialect |  GenericDialect)
+        {
+            // Support UNSIGNED for MySQL
+            Ok(Some(ColumnOption::Unsigned))
         } else {
             Ok(None)
         }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -381,6 +381,29 @@ fn parse_create_table_with_minimum_display_width() {
 }
 
 #[test]
+fn parse_create_table_unsigned() {
+    let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3) UNSIGNED)";
+    match mysql().verified_stmt(sql) {
+        Statement::CreateTable { name, columns, .. } => {
+            assert_eq!(name.to_string(), "foo");
+            assert_eq!(
+                vec![ColumnDef {
+                    name: Ident::new("bar_tinyint"),
+                    data_type: DataType::TinyInt(Some(3)),
+                    collation: None,
+                    options: vec![ColumnOptionDef {
+                        name: None,
+                        option: ColumnOption::Unsigned
+                    }],
+                },],
+                columns
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 #[cfg(not(feature = "bigdecimal"))]
 fn parse_simple_insert() {
     let sql = r"INSERT INTO tasks (title, priority) VALUES ('Test Some Inserts', 1), ('Test Entry 2', 2), ('Test Entry 3', 3)";


### PR DESCRIPTION
This MySQL DDL I'm using in my project has the following definition.

```sql
❯ cat create_table.sql
CREATE TABLE `warehouses` (
  `id` bigint UNSIGNED NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`),
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
```

ParseError occurred.

```shell
❯ cargo run --features json_example --example cli create_table.sql --mysql
   Compiling sqlparser v0.14.0 (/Users/watarukura/src/github.com/sqlparser-rs/sqlparser-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 9.47s
     Running `target/debug/examples/cli create_table.sql --mysql`
Parsing from file 'create_table.sql' using MySqlDialect
2022-02-20T08:14:31.123Z DEBUG [sqlparser::parser] Parsing sql 'CREATE TABLE `warehouses` (
  `id` bigint UNSIGNED NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`),
-- ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
'...
Error during parsing: ParserError("Expected ',' or ')' after column definition, found: UNSIGNED")
```

add `UNSIGNED` to column option for MySQL Dialect.

```shell
❯ cargo run --features json_example --example cli create_table.sql --mysql
   Compiling sqlparser v0.14.0 (/Users/watarukura/src/github.com/sqlparser-rs/sqlparser-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 7.95s
     Running `target/debug/examples/cli create_table.sql --mysql`
Parsing from file 'create_table.sql' using MySqlDialect
2022-02-20T08:15:27.661Z DEBUG [sqlparser::parser] Parsing sql 'CREATE TABLE `warehouses` (
  `id` bigint UNSIGNED NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`),
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
'...
Round-trip:
'CREATE TABLE `warehouses` (`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
Serialized as JSON:
[
  {
    "CreateTable": {
      "or_replace": false,
      "temporary": false,
      "external": false,
      "if_not_exists": false,
      "name": [
        {
          "value": "warehouses",
          "quote_style": "`"
        }
      ],
      "columns": [
        {
          "name": {
            "value": "id",
            "quote_style": "`"
          },
          "data_type": {
            "BigInt": null
          },
          "collation": null,
          "options": [
            {
              "name": null,
              "option": "Unsigned"
            },
            {
              "name": null,
              "option": "NotNull"
            },
            {
              "name": null,
              "option": {
                "DialectSpecific": [
                  {
                    "Word": {
                      "value": "AUTO_INCREMENT",
                      "quote_style": null,
                      "keyword": "AUTO_INCREMENT"
                    }
                  }
                ]
              }
            }
          ]
        }
      ],
      "constraints": [
        {
          "Unique": {
            "name": null,
            "columns": [
              {
                "value": "id",
                "quote_style": "`"
              }
            ],
            "is_primary": true
          }
        }
      ],
      "hive_distribution": "NONE",
      "hive_formats": {
        "row_format": null,
        "storage": null,
        "location": null
      },
      "table_properties": [],
      "with_options": [],
      "file_format": null,
      "location": null,
      "query": null,
      "without_rowid": false,
      "like": null,
      "engine": "InnoDB",
      "default_charset": "utf8mb4"
    }
  }
]
```