### PR TITLE
Support `IN UNNEST(expression)`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -189,6 +189,12 @@ pub enum Expr {
         subquery: Box<Query>,
         negated: bool,
     },
+    /// `[ NOT ] IN UNNEST(array_expression)`
+    InUnnest {
+        expr: Box<Expr>,
+        array_expr: Box<Expr>,
+        negated: bool,
+    },
     /// `<expr> [ NOT ] BETWEEN <low> AND <high>`
     Between {
         expr: Box<Expr>,
@@ -334,6 +340,17 @@ impl fmt::Display for Expr {
                 expr,
                 if *negated { "NOT " } else { "" },
                 subquery
+            ),
+            Expr::InUnnest {
+                expr,
+                array_expr,
+                negated,
+            } => write!(
+                f,
+                "{} {}IN UNNEST({})",
+                expr,
+                if *negated { "NOT " } else { "" },
+                array_expr
             ),
             Expr::Between {
                 expr,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -905,16 +905,23 @@ fn parse_in_subquery() {
 
 #[test]
 fn parse_in_unnest() {
-    let sql = "SELECT * FROM customers WHERE segment IN UNNEST(expr)";
-    let select = verified_only_select(sql);
-    assert_eq!(
-        Expr::InUnnest {
-            expr: Box::new(Expr::Identifier(Ident::new("segment"))),
-            array_expr: Box::new(verified_expr("expr")),
-            negated: false,
-        },
-        select.selection.unwrap()
-    );
+    fn chk(negated: bool) {
+        let sql = &format!(
+            "SELECT * FROM customers WHERE segment {}IN UNNEST(expr)",
+            if negated { "NOT " } else { "" }
+        );
+        let select = verified_only_select(sql);
+        assert_eq!(
+            Expr::InUnnest {
+                expr: Box::new(Expr::Identifier(Ident::new("segment"))),
+                array_expr: Box::new(verified_expr("expr")),
+                negated,
+            },
+            select.selection.unwrap()
+        );
+    }
+    chk(false);
+    chk(true);
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -904,6 +904,20 @@ fn parse_in_subquery() {
 }
 
 #[test]
+fn parse_in_unnest() {
+    let sql = "SELECT * FROM customers WHERE segment IN UNNEST(expr)";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        Expr::InUnnest {
+            expr: Box::new(Expr::Identifier(Ident::new("segment"))),
+            array_expr: Box::new(verified_expr("expr")),
+            negated: false,
+        },
+        select.selection.unwrap()
+    );
+}
+
+#[test]
 fn parse_string_agg() {
     let sql = "SELECT a || b";
 


### PR DESCRIPTION
This PR adds support `IN UNNEST(array_expression)` for BigQuery.

```
search_value [NOT] IN value_set

value_set:
  {
    (expression[, ...])
    | (subquery)
    | UNNEST(array_expression)
  }
```
https://cloud.google.com/bigquery/docs/reference/standard-sql/operators#in_operators

