### PR TITLE
mysql unsigned datatype

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -41,20 +41,34 @@ pub enum DataType {
     Blob(u64),
     /// Decimal type with optional precision and scale e.g. DECIMAL(10,2)
     Decimal(Option<u64>, Option<u64>),
+    /// Unsigned decimal type with optional precision and scale e.g. DECIMAL(10,2) UNSIGNED
+    UnsignedDecimal(Option<u64>, Option<u64>),
     /// Floating point with optional precision e.g. FLOAT(8)
     Float(Option<u64>),
+    /// Unsigned floating point with optional precision e.g. FLOAT(8) UNSIGNED
+    UnsignedFloat(Option<u64>),
     /// Tiny integer with optional display width e.g. TINYINT or TINYINT(3)
     TinyInt(Option<u64>),
+    /// Unsigned tiny integer with optional display width e.g. TINYINT UNSIGNED or TINYINT(3) UNSIGNED
+    UnsignedTinyInt(Option<u64>),
     /// Small integer with optional display width e.g. SMALLINT or SMALLINT(5)
     SmallInt(Option<u64>),
+    /// Unsigned small integer with optional display width e.g. SMALLINT UNSIGNED or SMALLINT(5) UNSIGNED
+    UnsignedSmallInt(Option<u64>),
     /// Integer with optional display width e.g. INT or INT(11)
     Int(Option<u64>),
+    /// Unsigned integer with optional display width e.g. INT UNSIGNED or INT(11) UNSIGNED
+    UnsignedInt(Option<u64>),
     /// Big integer with optional display width e.g. BIGINT or BIGINT(20)
     BigInt(Option<u64>),
+    /// Unsigned big integer with optional display width e.g. BIGINT UNSIGNED or BIGINT(20) UNSIGNED
+    UnsignedBigInt(Option<u64>),
     /// Floating point e.g. REAL
     Real,
     /// Double e.g. DOUBLE PRECISION
     Double,
+    /// Double e.g. DOUBLE PRECISION
+    UnsignedDouble,
     /// Boolean
     Boolean,
     /// Date

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -100,9 +100,9 @@ pub enum DataType {
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            DataType::Char(size) => format_type_with_optional_length(f, "CHAR", size),
+            DataType::Char(size) => format_type_with_optional_length(f, "CHAR", size, false),
             DataType::Varchar(size) => {
-                format_type_with_optional_length(f, "CHARACTER VARYING", size)
+                format_type_with_optional_length(f, "CHARACTER VARYING", size, false)
             }
             DataType::Uuid => write!(f, "UUID"),
             DataType::Clob(size) => write!(f, "CLOB({})", size),
@@ -113,18 +113,45 @@ impl fmt::Display for DataType {
                 if let Some(scale) = scale {
                     write!(f, "NUMERIC({},{})", precision.unwrap(), scale)
                 } else {
-                    format_type_with_optional_length(f, "NUMERIC", precision)
+                    format_type_with_optional_length(f, "NUMERIC", precision, false)
                 }
             }
-            DataType::Float(size) => format_type_with_optional_length(f, "FLOAT", size),
-            DataType::TinyInt(zerofill) => format_type_with_optional_length(f, "TINYINT", zerofill),
-            DataType::SmallInt(zerofill) => {
-                format_type_with_optional_length(f, "SMALLINT", zerofill)
+            DataType::UnsignedDecimal(precision, scale) => {
+                if let Some(scale) = scale {
+                    write!(f, "NUMERIC({},{}) UNSIGNED", precision.unwrap(), scale)
+                } else {
+                    format_type_with_optional_length(f, "NUMERIC", precision, true)
+                }
             }
-            DataType::Int(zerofill) => format_type_with_optional_length(f, "INT", zerofill),
-            DataType::BigInt(zerofill) => format_type_with_optional_length(f, "BIGINT", zerofill),
+            DataType::Float(size) => format_type_with_optional_length(f, "FLOAT", size, false),
+            DataType::UnsignedFloat(size) => {
+                format_type_with_optional_length(f, "FLOAT", size, true)
+            }
+            DataType::TinyInt(zerofill) => {
+                format_type_with_optional_length(f, "TINYINT", zerofill, false)
+            }
+            DataType::UnsignedTinyInt(zerofill) => {
+                format_type_with_optional_length(f, "TINYINT", zerofill, true)
+            }
+            DataType::SmallInt(zerofill) => {
+                format_type_with_optional_length(f, "SMALLINT", zerofill, false)
+            }
+            DataType::UnsignedSmallInt(zerofill) => {
+                format_type_with_optional_length(f, "SMALLINT", zerofill, true)
+            }
+            DataType::Int(zerofill) => format_type_with_optional_length(f, "INT", zerofill, false),
+            DataType::UnsignedInt(zerofill) => {
+                format_type_with_optional_length(f, "INT", zerofill, true)
+            }
+            DataType::BigInt(zerofill) => {
+                format_type_with_optional_length(f, "BIGINT", zerofill, false)
+            }
+            DataType::UnsignedBigInt(zerofill) => {
+                format_type_with_optional_length(f, "BIGINT", zerofill, true)
+            }
             DataType::Real => write!(f, "REAL"),
             DataType::Double => write!(f, "DOUBLE"),
+            DataType::UnsignedDouble => write!(f, "DOUBLE UNSIGNED"),
             DataType::Boolean => write!(f, "BOOLEAN"),
             DataType::Date => write!(f, "DATE"),
             DataType::Time => write!(f, "TIME"),
@@ -164,10 +191,14 @@ fn format_type_with_optional_length(
     f: &mut fmt::Formatter,
     sql_type: &'static str,
     len: &Option<u64>,
+    unsigned: bool,
 ) -> fmt::Result {
     write!(f, "{}", sql_type)?;
     if let Some(len) = len {
         write!(f, "({})", len)?;
+    }
+    if unsigned {
+        write!(f, " UNSIGNED")?;
     }
     Ok(())
 }

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -41,12 +41,8 @@ pub enum DataType {
     Blob(u64),
     /// Decimal type with optional precision and scale e.g. DECIMAL(10,2)
     Decimal(Option<u64>, Option<u64>),
-    /// Unsigned decimal type with optional precision and scale e.g. DECIMAL(10,2) UNSIGNED
-    UnsignedDecimal(Option<u64>, Option<u64>),
     /// Floating point with optional precision e.g. FLOAT(8)
     Float(Option<u64>),
-    /// Unsigned floating point with optional precision e.g. FLOAT(8) UNSIGNED
-    UnsignedFloat(Option<u64>),
     /// Tiny integer with optional display width e.g. TINYINT or TINYINT(3)
     TinyInt(Option<u64>),
     /// Unsigned tiny integer with optional display width e.g. TINYINT UNSIGNED or TINYINT(3) UNSIGNED
@@ -67,8 +63,6 @@ pub enum DataType {
     Real,
     /// Double e.g. DOUBLE PRECISION
     Double,
-    /// Double e.g. DOUBLE PRECISION
-    UnsignedDouble,
     /// Boolean
     Boolean,
     /// Date
@@ -116,17 +110,7 @@ impl fmt::Display for DataType {
                     format_type_with_optional_length(f, "NUMERIC", precision, false)
                 }
             }
-            DataType::UnsignedDecimal(precision, scale) => {
-                if let Some(scale) = scale {
-                    write!(f, "NUMERIC({},{}) UNSIGNED", precision.unwrap(), scale)
-                } else {
-                    format_type_with_optional_length(f, "NUMERIC", precision, true)
-                }
-            }
             DataType::Float(size) => format_type_with_optional_length(f, "FLOAT", size, false),
-            DataType::UnsignedFloat(size) => {
-                format_type_with_optional_length(f, "FLOAT", size, true)
-            }
             DataType::TinyInt(zerofill) => {
                 format_type_with_optional_length(f, "TINYINT", zerofill, false)
             }
@@ -151,7 +135,6 @@ impl fmt::Display for DataType {
             }
             DataType::Real => write!(f, "REAL"),
             DataType::Double => write!(f, "DOUBLE"),
-            DataType::UnsignedDouble => write!(f, "DOUBLE UNSIGNED"),
             DataType::Boolean => write!(f, "BOOLEAN"),
             DataType::Date => write!(f, "DATE"),
             DataType::Time => write!(f, "TIME"),

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -377,7 +377,6 @@ pub enum ColumnOption {
     DialectSpecific(Vec<Token>),
     CharacterSet(ObjectName),
     Comment(String),
-    Unsigned,
 }
 
 impl fmt::Display for ColumnOption {
@@ -412,7 +411,6 @@ impl fmt::Display for ColumnOption {
             DialectSpecific(val) => write!(f, "{}", display_separated(val, " ")),
             CharacterSet(n) => write!(f, "CHARACTER SET {}", n),
             Comment(v) => write!(f, "COMMENT '{}'", escape_single_quote_string(v)),
-            Unsigned => write!(f, "UNSIGNED"),
         }
     }
 }

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -377,6 +377,7 @@ pub enum ColumnOption {
     DialectSpecific(Vec<Token>),
     CharacterSet(ObjectName),
     Comment(String),
+    Unsigned,
 }
 
 impl fmt::Display for ColumnOption {
@@ -411,6 +412,7 @@ impl fmt::Display for ColumnOption {
             DialectSpecific(val) => write!(f, "{}", display_separated(val, " ")),
             CharacterSet(n) => write!(f, "CHARACTER SET {}", n),
             Comment(v) => write!(f, "COMMENT '{}'", escape_single_quote_string(v)),
+            Unsigned => write!(f, "UNSIGNED"),
         }
     }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -486,6 +486,7 @@ define_keywords!(
     UNIQUE,
     UNKNOWN,
     UNNEST,
+    UNSIGNED,
     UPDATE,
     UPPER,
     USAGE,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2346,11 +2346,22 @@ impl<'a> Parser<'a> {
         let mut data = match self.next_token() {
             Token::Word(w) => match w.keyword {
                 Keyword::BOOLEAN => Ok(DataType::Boolean),
-                Keyword::FLOAT => Ok(DataType::Float(self.parse_optional_precision()?)),
+                Keyword::FLOAT => {
+                    let optional_precision = self.parse_optional_precision();
+                    if self.parse_keyword(Keyword::UNSIGNED) {
+                        Ok(DataType::UnsignedFloat(optional_precision?))
+                    } else {
+                        Ok(DataType::Float(optional_precision?))
+                    }
+                }
                 Keyword::REAL => Ok(DataType::Real),
                 Keyword::DOUBLE => {
                     let _ = self.parse_keyword(Keyword::PRECISION);
-                    Ok(DataType::Double)
+                    if self.parse_keyword(Keyword::UNSIGNED) {
+                        Ok(DataType::UnsignedDouble)
+                    } else {
+                        Ok(DataType::Double)
+                    }
                 }
                 Keyword::TINYINT => {
                     let optional_precision = self.parse_optional_precision();
@@ -2360,11 +2371,30 @@ impl<'a> Parser<'a> {
                         Ok(DataType::TinyInt(optional_precision?))
                     }
                 }
-                Keyword::SMALLINT => Ok(DataType::SmallInt(self.parse_optional_precision()?)),
-                Keyword::INT | Keyword::INTEGER => {
-                    Ok(DataType::Int(self.parse_optional_precision()?))
+                Keyword::SMALLINT => {
+                    let optional_precision = self.parse_optional_precision();
+                    if self.parse_keyword(Keyword::UNSIGNED) {
+                        Ok(DataType::UnsignedSmallInt(optional_precision?))
+                    } else {
+                        Ok(DataType::SmallInt(optional_precision?))
+                    }
                 }
-                Keyword::BIGINT => Ok(DataType::BigInt(self.parse_optional_precision()?)),
+                Keyword::INT | Keyword::INTEGER => {
+                    let optional_precision = self.parse_optional_precision();
+                    if self.parse_keyword(Keyword::UNSIGNED) {
+                        Ok(DataType::UnsignedInt(optional_precision?))
+                    } else {
+                        Ok(DataType::Int(optional_precision?))
+                    }
+                }
+                Keyword::BIGINT => {
+                    let optional_precision = self.parse_optional_precision();
+                    if self.parse_keyword(Keyword::UNSIGNED) {
+                        Ok(DataType::UnsignedBigInt(optional_precision?))
+                    } else {
+                        Ok(DataType::BigInt(optional_precision?))
+                    }
+                }
                 Keyword::VARCHAR => Ok(DataType::Varchar(self.parse_optional_precision()?)),
                 Keyword::CHAR | Keyword::CHARACTER => {
                     if self.parse_keyword(Keyword::VARYING) {
@@ -2399,7 +2429,11 @@ impl<'a> Parser<'a> {
                 Keyword::BYTEA => Ok(DataType::Bytea),
                 Keyword::NUMERIC | Keyword::DECIMAL | Keyword::DEC => {
                     let (precision, scale) = self.parse_optional_precision_scale()?;
-                    Ok(DataType::Decimal(precision, scale))
+                    if self.parse_keyword(Keyword::UNSIGNED) {
+                        Ok(DataType::UnsignedDecimal(precision, scale))
+                    } else {
+                        Ok(DataType::Decimal(precision, scale))
+                    }
                 }
                 Keyword::ENUM => Ok(DataType::Enum(self.parse_string_values()?)),
                 Keyword::SET => Ok(DataType::Set(self.parse_string_values()?)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1853,19 +1853,6 @@ impl<'a> Parser<'a> {
                 break;
             };
         }
-        if self.parse_keyword(Keyword::UNSIGNED) {
-            println!(
-                "{}",
-                ColumnOptionDef {
-                    name: None,
-                    option: ColumnOption::Unsigned
-                }
-            );
-            options.push(ColumnOptionDef {
-                name: None,
-                option: ColumnOption::Unsigned,
-            });
-        };
         Ok(ColumnDef {
             name,
             data_type,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2346,22 +2346,11 @@ impl<'a> Parser<'a> {
         let mut data = match self.next_token() {
             Token::Word(w) => match w.keyword {
                 Keyword::BOOLEAN => Ok(DataType::Boolean),
-                Keyword::FLOAT => {
-                    let optional_precision = self.parse_optional_precision();
-                    if self.parse_keyword(Keyword::UNSIGNED) {
-                        Ok(DataType::UnsignedFloat(optional_precision?))
-                    } else {
-                        Ok(DataType::Float(optional_precision?))
-                    }
-                }
+                Keyword::FLOAT => Ok(DataType::Float(self.parse_optional_precision()?)),
                 Keyword::REAL => Ok(DataType::Real),
                 Keyword::DOUBLE => {
                     let _ = self.parse_keyword(Keyword::PRECISION);
-                    if self.parse_keyword(Keyword::UNSIGNED) {
-                        Ok(DataType::UnsignedDouble)
-                    } else {
                         Ok(DataType::Double)
-                    }
                 }
                 Keyword::TINYINT => {
                     let optional_precision = self.parse_optional_precision();
@@ -2429,11 +2418,7 @@ impl<'a> Parser<'a> {
                 Keyword::BYTEA => Ok(DataType::Bytea),
                 Keyword::NUMERIC | Keyword::DECIMAL | Keyword::DEC => {
                     let (precision, scale) = self.parse_optional_precision_scale()?;
-                    if self.parse_keyword(Keyword::UNSIGNED) {
-                        Ok(DataType::UnsignedDecimal(precision, scale))
-                    } else {
-                        Ok(DataType::Decimal(precision, scale))
-                    }
+                    Ok(DataType::Decimal(precision, scale))
                 }
                 Keyword::ENUM => Ok(DataType::Enum(self.parse_string_values()?)),
                 Keyword::SET => Ok(DataType::Set(self.parse_string_values()?)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2350,7 +2350,7 @@ impl<'a> Parser<'a> {
                 Keyword::REAL => Ok(DataType::Real),
                 Keyword::DOUBLE => {
                     let _ = self.parse_keyword(Keyword::PRECISION);
-                        Ok(DataType::Double)
+                    Ok(DataType::Double)
                 }
                 Keyword::TINYINT => {
                     let optional_precision = self.parse_optional_precision();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1853,6 +1853,19 @@ impl<'a> Parser<'a> {
                 break;
             };
         }
+        if self.parse_keyword(Keyword::UNSIGNED) {
+            println!(
+                "{}",
+                ColumnOptionDef {
+                    name: None,
+                    option: ColumnOption::Unsigned
+                }
+            );
+            options.push(ColumnOptionDef {
+                name: None,
+                option: ColumnOption::Unsigned,
+            });
+        };
         Ok(ColumnDef {
             name,
             data_type,
@@ -1922,6 +1935,11 @@ impl<'a> Parser<'a> {
             Ok(Some(ColumnOption::DialectSpecific(vec![
                 Token::make_keyword("AUTOINCREMENT"),
             ])))
+        } else if self.parse_keyword(Keyword::UNSIGNED)
+            && dialect_of!(self is MySqlDialect |  GenericDialect)
+        {
+            // Support UNSIGNED for MySQL
+            Ok(Some(ColumnOption::Unsigned))
         } else {
             Ok(None)
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2352,7 +2352,14 @@ impl<'a> Parser<'a> {
                     let _ = self.parse_keyword(Keyword::PRECISION);
                     Ok(DataType::Double)
                 }
-                Keyword::TINYINT => Ok(DataType::TinyInt(self.parse_optional_precision()?)),
+                Keyword::TINYINT => {
+                    let optional_precision = self.parse_optional_precision();
+                    if self.parse_keyword(Keyword::UNSIGNED) {
+                        Ok(DataType::UnsignedTinyInt(optional_precision?))
+                    } else {
+                        Ok(DataType::TinyInt(optional_precision?))
+                    }
+                }
                 Keyword::SMALLINT => Ok(DataType::SmallInt(self.parse_optional_precision()?)),
                 Keyword::INT | Keyword::INTEGER => {
                     Ok(DataType::Int(self.parse_optional_precision()?))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1935,11 +1935,6 @@ impl<'a> Parser<'a> {
             Ok(Some(ColumnOption::DialectSpecific(vec![
                 Token::make_keyword("AUTOINCREMENT"),
             ])))
-        } else if self.parse_keyword(Keyword::UNSIGNED)
-            && dialect_of!(self is MySqlDialect |  GenericDialect)
-        {
-            // Support UNSIGNED for MySQL
-            Ok(Some(ColumnOption::Unsigned))
         } else {
             Ok(None)
         }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -416,12 +416,9 @@ fn parse_create_table_unsigned() {
             assert_eq!(
                 vec![ColumnDef {
                     name: Ident::new("bar_tinyint"),
-                    data_type: DataType::TinyInt(Some(3)),
+                    data_type: DataType::UnsignedTinyInt(Some(3)),
                     collation: None,
-                    options: vec![ColumnOptionDef {
-                        name: None,
-                        option: ColumnOption::Unsigned
-                    }],
+                    options: vec![],
                 },],
                 columns
             );

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -409,17 +409,37 @@ fn parse_create_table_with_minimum_display_width() {
 
 #[test]
 fn parse_create_table_unsigned() {
-    let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3) UNSIGNED)";
+    let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3) UNSIGNED, bar_smallint SMALLINT(5) UNSIGNED, bar_int INT(11) UNSIGNED, bar_bigint BIGINT(20) UNSIGNED)";
     match mysql().verified_stmt(sql) {
         Statement::CreateTable { name, columns, .. } => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
-                vec![ColumnDef {
-                    name: Ident::new("bar_tinyint"),
-                    data_type: DataType::UnsignedTinyInt(Some(3)),
-                    collation: None,
-                    options: vec![],
-                },],
+                vec![
+                    ColumnDef {
+                        name: Ident::new("bar_tinyint"),
+                        data_type: DataType::UnsignedTinyInt(Some(3)),
+                        collation: None,
+                        options: vec![],
+                    },
+                    ColumnDef {
+                        name: Ident::new("bar_smallint"),
+                        data_type: DataType::UnsignedSmallInt(Some(5)),
+                        collation: None,
+                        options: vec![],
+                    },
+                    ColumnDef {
+                        name: Ident::new("bar_int"),
+                        data_type: DataType::UnsignedInt(Some(11)),
+                        collation: None,
+                        options: vec![],
+                    },
+                    ColumnDef {
+                        name: Ident::new("bar_bigint"),
+                        data_type: DataType::UnsignedBigInt(Some(20)),
+                        collation: None,
+                        options: vec![],
+                    },
+                ],
                 columns
             );
         }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -408,6 +408,29 @@ fn parse_create_table_with_minimum_display_width() {
 }
 
 #[test]
+fn parse_create_table_unsigned() {
+    let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3) UNSIGNED)";
+    match mysql().verified_stmt(sql) {
+        Statement::CreateTable { name, columns, .. } => {
+            assert_eq!(name.to_string(), "foo");
+            assert_eq!(
+                vec![ColumnDef {
+                    name: Ident::new("bar_tinyint"),
+                    data_type: DataType::TinyInt(Some(3)),
+                    collation: None,
+                    options: vec![ColumnOptionDef {
+                        name: None,
+                        option: ColumnOption::Unsigned
+                    }],
+                },],
+                columns
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 #[cfg(not(feature = "bigdecimal"))]
 fn parse_simple_insert() {
     let sql = r"INSERT INTO tasks (title, priority) VALUES ('Test Some Inserts', 1), ('Test Entry 2', 2), ('Test Entry 3', 3)";


### PR DESCRIPTION
https://github.com/sqlparser-rs/sqlparser-rs/pull/425/files#r816162124

- add DataType for `UNSIGNED`
  - UnsignedTinyInt, UnsignedSmallInt, UnsignedInt, UnsignedBigInt
  - Decimal, Float, Double can be `UNSIGNED`, but not implemented. Because, these types `UNSIGNED` support to be removed in a future version of MySQL.
    - https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html
- `select cast(x as unsigned)` is no longer panic
- `create table foo (bar int unsigned)` is no longer panic

```sql
❯ cat select_cast.sql 
select cast(x as unsigned) from bar;
select cast(y as int unsigned) from baz;
```

```json
❯ cargo run --features json_example --example cli select_cast.sql --mysql
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/examples/cli select_cast.sql --mysql`
Parsing from file 'select_cast.sql' using MySqlDialect
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] Parsing sql 'select cast(x as unsigned) from bar;
select cast(y as int unsigned) from baz;'...
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] parsing expr
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] parsing expr
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] prefix: Identifier(Ident { value: "x", quote_style: None })
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] get_next_precedence() Word(Word { value: "as", quote_style: None, keyword: AS })
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] next precedence: 0
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] prefix: Cast { expr: Identifier(Ident { value: "x", quote_style: None }), data_type: Custom(ObjectName([Ident { value: "unsigned", quote_style: None }])) }
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] get_next_precedence() Word(Word { value: "from", quote_style: None, keyword: FROM })
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] next precedence: 0
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] parsing expr
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] parsing expr
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] prefix: Identifier(Ident { value: "y", quote_style: None })
2022-03-06T05:45:40.058Z DEBUG [sqlparser::parser] get_next_precedence() Word(Word { value: "as", quote_style: None, keyword: AS })
2022-03-06T05:45:40.059Z DEBUG [sqlparser::parser] next precedence: 0
2022-03-06T05:45:40.059Z DEBUG [sqlparser::parser] prefix: Cast { expr: Identifier(Ident { value: "y", quote_style: None }), data_type: UnsignedInt(None) }
2022-03-06T05:45:40.059Z DEBUG [sqlparser::parser] get_next_precedence() Word(Word { value: "from", quote_style: None, keyword: FROM })
2022-03-06T05:45:40.059Z DEBUG [sqlparser::parser] next precedence: 0
Round-trip:
'SELECT CAST(x AS unsigned) FROM bar
SELECT CAST(y AS INT UNSIGNED) FROM baz'
Serialized as JSON:
[
  {
    "Query": {
      "with": null,
      "body": {
        "Select": {
          "distinct": false,
          "top": null,
          "projection": [
            {
              "UnnamedExpr": {
                "Cast": {
                  "expr": {
                    "Identifier": {
                      "value": "x",
                      "quote_style": null
                    }
                  },
                  "data_type": {
                    "Custom": [
                      {
                        "value": "unsigned",
                        "quote_style": null
                      }
                    ]
                  }
                }
              }
            }
          ],
          "from": [
            {
              "relation": {
                "Table": {
                  "name": [
                    {
                      "value": "bar",
                      "quote_style": null
                    }
                  ],
                  "alias": null,
                  "args": [],
                  "with_hints": []
                }
              },
              "joins": []
            }
          ],
          "lateral_views": [],
          "selection": null,
          "group_by": [],
          "cluster_by": [],
          "distribute_by": [],
          "sort_by": [],
          "having": null
        }
      },
      "order_by": [],
      "limit": null,
      "offset": null,
      "fetch": null,
      "lock": null
    }
  },
  {
    "Query": {
      "with": null,
      "body": {
        "Select": {
          "distinct": false,
          "top": null,
          "projection": [
            {
              "UnnamedExpr": {
                "Cast": {
                  "expr": {
                    "Identifier": {
                      "value": "y",
                      "quote_style": null
                    }
                  },
                  "data_type": {
                    "UnsignedInt": null
                  }
                }
              }
            }
          ],
          "from": [
            {
              "relation": {
                "Table": {
                  "name": [
                    {
                      "value": "baz",
                      "quote_style": null
                    }
                  ],
                  "alias": null,
                  "args": [],
                  "with_hints": []
                }
              },
              "joins": []
            }
          ],
          "lateral_views": [],
          "selection": null,
          "group_by": [],
          "cluster_by": [],
          "distribute_by": [],
          "sort_by": [],
          "having": null
        }
      },
      "order_by": [],
      "limit": null,
      "offset": null,
      "fetch": null,
      "lock": null
    }
  }
]
```