### PR TITLE
add support for MERGE statement

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -295,6 +295,7 @@ define_keywords!(
     LOWER,
     MANAGEDLOCATION,
     MATCH,
+    MATCHED,
     MATERIALIZED,
     MAX,
     MEMBER,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3919,7 +3919,9 @@ impl<'a> Parser<'a> {
                 ]) {
                     Some(Keyword::UPDATE) => {
                         if is_not_matched {
-                            parser_err!("UPDATE in NOT MATCHED merge clause")?;
+                            return Err(ParserError::ParserError(
+                                "UPDATE in NOT MATCHED merge clause".to_string(),
+                            ));
                         }
                         self.expect_keyword(Keyword::SET)?;
                         let assignments = self.parse_comma_separated(Parser::parse_assignment)?;
@@ -3930,13 +3932,17 @@ impl<'a> Parser<'a> {
                     }
                     Some(Keyword::DELETE) => {
                         if is_not_matched {
-                            parser_err!("DELETE in NOT MATCHED merge clause")?;
+                            return Err(ParserError::ParserError(
+                                "DELETE in NOT MATCHED merge clause".to_string(),
+                            ));
                         }
                         MergeClause::MatchedDelete(predicate)
                     }
                     Some(Keyword::INSERT) => {
                         if !is_not_matched {
-                            parser_err!("INSERT in MATCHED merge clause")?;
+                            return Err(ParserError::ParserError(
+                                "INSERT in MATCHED merge clause".to_string(),
+                            ));
                         }
                         let columns = self.parse_parenthesized_column_list(Optional)?;
                         self.expect_keyword(Keyword::VALUES)?;
@@ -3947,8 +3953,16 @@ impl<'a> Parser<'a> {
                             values,
                         }
                     }
-                    Some(_) => parser_err!("expected UPDATE, DELETE or INSERT in merge clause")?,
-                    None => parser_err!("expected UPDATE, DELETE or INSERT in merge clause")?,
+                    Some(_) => {
+                        return Err(ParserError::ParserError(
+                            "expected UPDATE, DELETE or INSERT in merge clause".to_string(),
+                        ))
+                    }
+                    None => {
+                        return Err(ParserError::ParserError(
+                            "expected UPDATE, DELETE or INSERT in merge clause".to_string(),
+                        ))
+                    }
                 },
             );
         }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4204,6 +4204,144 @@ fn test_revoke() {
 }
 
 #[test]
+fn parse_merge() {
+    let sql = "MERGE INTO s.bar AS dest USING (SELECT * FROM s.foo) as stg ON dest.D = stg.D AND dest.E = stg.E WHEN NOT MATCHED THEN INSERT (A, B, C) VALUES (stg.A, stg.B, stg.C) WHEN MATCHED AND dest.A = 'a' THEN UPDATE SET dest.F = stg.F, dest.G = stg.G WHEN MATCHED THEN DELETE";
+    match verified_stmt(sql) {
+        Statement::Merge {
+            table,
+            source,
+            alias,
+            on,
+            clauses,
+        } => {
+            assert_eq!(
+                table,
+                TableFactor::Table {
+                    name: ObjectName(vec![Ident::new("s"), Ident::new("bar")]),
+                    alias: Some(TableAlias {
+                        name: Ident::new("dest"),
+                        columns: vec![]
+                    }),
+                    args: vec![],
+                    with_hints: vec![]
+                }
+            );
+            assert_eq!(
+                source,
+                Box::new(SetExpr::Query(Box::new(Query {
+                    with: None,
+                    body: SetExpr::Select(Box::new(Select {
+                        distinct: false,
+                        top: None,
+                        projection: vec![SelectItem::Wildcard],
+                        from: vec![TableWithJoins {
+                            relation: TableFactor::Table {
+                                name: ObjectName(vec![Ident::new("s"), Ident::new("foo")]),
+                                alias: None,
+                                args: vec![],
+                                with_hints: vec![],
+                            },
+                            joins: vec![]
+                        }],
+                        lateral_views: vec![],
+                        selection: None,
+                        group_by: vec![],
+                        cluster_by: vec![],
+                        distribute_by: vec![],
+                        sort_by: vec![],
+                        having: None
+                    })),
+                    order_by: vec![],
+                    limit: None,
+                    offset: None,
+                    fetch: None,
+                    lock: None
+                })))
+            );
+            assert_eq!(
+                alias,
+                Some(TableAlias {
+                    name: Ident::new("stg"),
+                    columns: vec![]
+                })
+            );
+            assert_eq!(
+                on,
+                Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::BinaryOp {
+                        left: Box::new(Expr::CompoundIdentifier(vec![
+                            Ident::new("dest"),
+                            Ident::new("D")
+                        ])),
+                        op: BinaryOperator::Eq,
+                        right: Box::new(Expr::CompoundIdentifier(vec![
+                            Ident::new("stg"),
+                            Ident::new("D")
+                        ]))
+                    }),
+                    op: BinaryOperator::And,
+                    right: Box::new(Expr::BinaryOp {
+                        left: Box::new(Expr::CompoundIdentifier(vec![
+                            Ident::new("dest"),
+                            Ident::new("E")
+                        ])),
+                        op: BinaryOperator::Eq,
+                        right: Box::new(Expr::CompoundIdentifier(vec![
+                            Ident::new("stg"),
+                            Ident::new("E")
+                        ]))
+                    })
+                })
+            );
+            assert_eq!(
+                clauses,
+                vec![
+                    MergeClause::NotMatched {
+                        predicate: None,
+                        columns: vec![Ident::new("A"), Ident::new("B"), Ident::new("C")],
+                        values: Values(vec![vec![
+                            Expr::CompoundIdentifier(vec![Ident::new("stg"), Ident::new("A")]),
+                            Expr::CompoundIdentifier(vec![Ident::new("stg"), Ident::new("B")]),
+                            Expr::CompoundIdentifier(vec![Ident::new("stg"), Ident::new("C")]),
+                        ]])
+                    },
+                    MergeClause::MatchedUpdate {
+                        predicate: Some(Expr::BinaryOp {
+                            left: Box::new(Expr::CompoundIdentifier(vec![
+                                Ident::new("dest"),
+                                Ident::new("A")
+                            ])),
+                            op: BinaryOperator::Eq,
+                            right: Box::new(Expr::Value(Value::SingleQuotedString(
+                                "a".to_string()
+                            )))
+                        }),
+                        assignments: vec![
+                            Assignment {
+                                id: vec![Ident::new("dest"), Ident::new("F")],
+                                value: Expr::CompoundIdentifier(vec![
+                                    Ident::new("stg"),
+                                    Ident::new("F")
+                                ])
+                            },
+                            Assignment {
+                                id: vec![Ident::new("dest"), Ident::new("G")],
+                                value: Expr::CompoundIdentifier(vec![
+                                    Ident::new("stg"),
+                                    Ident::new("G")
+                                ])
+                            }
+                        ]
+                    },
+                    MergeClause::MatchedDelete(None)
+                ]
+            )
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn test_lock() {
     let sql = "SELECT * FROM student WHERE id = '1' FOR UPDATE";
     let ast = verified_query(sql);


### PR DESCRIPTION
This PR adds support for `MERGE` statement based on the Snowflake syntax: 
https://docs.snowflake.com/en/sql-reference/sql/merge.html

but should work with Hive based one neverthless.
https://cwiki.apache.org/confluence/display/hive/languagemanual+dml#LanguageManualDML-Merge

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>