### PR TITLE
Allow `array` to be used as a function name again

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -159,7 +159,8 @@ impl fmt::Display for ObjectName {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-/// Represetns
+/// Represents an Array Expression, either
+/// `ARRAY[..]`, or `[..]`
 pub struct Array {
     /// The list of expressions between brackets
     pub elem: Vec<Expr>,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -159,8 +159,12 @@ impl fmt::Display for ObjectName {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+/// Represetns
 pub struct Array {
+    /// The list of expressions between brackets
     pub elem: Vec<Expr>,
+
+    /// `true` for  `ARRAY[..]`, `false` for `[..]`
     pub named: bool,
 }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2246,19 +2246,27 @@ fn parse_bad_constraint() {
 
 #[test]
 fn parse_scalar_function_in_projection() {
-    let sql = "SELECT sqrt(id) FROM foo";
-    let select = verified_only_select(sql);
-    assert_eq!(
-        &Expr::Function(Function {
-            name: ObjectName(vec![Ident::new("sqrt")]),
-            args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                Expr::Identifier(Ident::new("id"))
-            ))],
-            over: None,
-            distinct: false,
-        }),
-        expr_from_projection(only(&select.projection))
-    );
+    let names = vec![
+        "sqrt", // array is also valid function name
+        "array", "foo",
+    ];
+
+    for function_name in names {
+        // like SELECT sqrt(id) FROM foo
+        let sql = dbg!(format!("SELECT {}(id) FROM foo", function_name));
+        let select = verified_only_select(&sql);
+        assert_eq!(
+            &Expr::Function(Function {
+                name: ObjectName(vec![Ident::new(function_name)]),
+                args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
+                    Expr::Identifier(Ident::new("id"))
+                ))],
+                over: None,
+                distinct: false,
+            }),
+            expr_from_projection(only(&select.projection))
+        );
+    }
 }
 
 fn run_explain_analyze(query: &str, expected_verbose: bool, expected_analyze: bool) {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2247,7 +2247,7 @@ fn parse_bad_constraint() {
 #[test]
 fn parse_scalar_function_in_projection() {
     let names = vec![
-        "sqrt", // array is also valid function name
+        "sqrt",
         "array", "foo",
     ];
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2246,10 +2246,7 @@ fn parse_bad_constraint() {
 
 #[test]
 fn parse_scalar_function_in_projection() {
-    let names = vec![
-        "sqrt",
-        "array", "foo",
-    ];
+    let names = vec!["sqrt", "array", "foo"];
 
     for function_name in names {
         // like SELECT sqrt(id) FROM foo


### PR DESCRIPTION
# Rationale

https://github.com/sqlparser-rs/sqlparser-rs/pull/429 accidentally introduced a regression that found while testing downstream in DataFusion : https://github.com/apache/arrow-datafusion/pull/1956

In particular, sql parser used to parse queries like this:

```sql
SELECT array(c1, cast(c2 as varchar)) FROM test
```

As a call to a function named `array`. However, after https://github.com/sqlparser-rs/sqlparser-rs/pull/429 it generates a parser error: ` SQL(ParserError("Expected [, found: ("))', `

# Changes
1. Restore the behavior of parsing `array(..)` as a function call. 
2. Tests for same


Note `array[]` is still parsed as an array expression.


More details here https://github.com/sqlparser-rs/sqlparser-rs/pull/429#issuecomment-1062041430

cc @monadbobo 