### PR TITLE
feat: add support for parsing mysql intervals

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -14,7 +14,7 @@
 //! (commonly referred to as Data Definition Language, or DDL)
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, string::ToString, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt;
 
 #[cfg(feature = "serde")]

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 #[cfg(not(feature = "std"))]
-use alloc::string::String;
+use alloc::{boxed::Box, string::String};
 use core::fmt;
 
 #[cfg(feature = "bigdecimal")]
@@ -118,7 +118,7 @@ impl fmt::Display for Value {
                     _ => unreachable!(),
                 };
 
-                write!(f, "INTERVAL '{}'", escape_single_quote_string(value))?;
+                write!(f, "INTERVAL '{}'", escape_single_quote_string(&value))?;
                 if let Some(leading_field) = leading_field {
                     write!(f, " {}", leading_field)?;
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -963,7 +963,7 @@ impl<'a> Parser<'a> {
         // don't currently try to parse it. (The sign can instead be included
         // inside the value string.)
 
-        // MySQL allows for expressions following the INTERVAL keyword. If the 
+        // MySQL allows for expressions following the INTERVAL keyword. If the
         // dialect isn't MySQL a string literal is expected.
         let value = if dialect_of!(self is MySqlDialect) {
             self.parse_expr()?

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2463,11 +2463,14 @@ fn parse_literal_timestamp() {
 
 #[test]
 fn parse_literal_interval() {
+    fn interval_value(inner: &'static str) -> Box<Expr> {
+        Box::new(Expr::Value(Value::SingleQuotedString(inner.into())))
+    }
     let sql = "SELECT INTERVAL '1-1' YEAR TO MONTH";
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "1-1".into(),
+            value: interval_value("1-1"),
             leading_field: Some(DateTimeField::Year),
             leading_precision: None,
             last_field: Some(DateTimeField::Month),
@@ -2480,7 +2483,7 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "01:01.01".into(),
+            value: interval_value("01:01.01"),
             leading_field: Some(DateTimeField::Minute),
             leading_precision: Some(5),
             last_field: Some(DateTimeField::Second),
@@ -2493,7 +2496,7 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "1".into(),
+            value: interval_value("1"),
             leading_field: Some(DateTimeField::Second),
             leading_precision: Some(5),
             last_field: None,
@@ -2506,7 +2509,7 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "10".into(),
+            value: interval_value("10"),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: None,
             last_field: None,
@@ -2519,7 +2522,7 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "10".into(),
+            value: interval_value("10"),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: Some(1),
             last_field: None,
@@ -2532,7 +2535,7 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "1 DAY".into(),
+            value: interval_value("1 DAY"),
             leading_field: None,
             leading_precision: None,
             last_field: None,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -765,6 +765,17 @@ fn parse_substring_in_select() {
     }
 }
 
+#[test]
+fn test_temporal_intervals() {
+    mysql().verified_only_select("SELECT NOW() + INTERVAL '1' DAY");
+    mysql().verified_only_select("SELECT NOW() + INTERVAL 1 DAY");
+    mysql().verified_only_select("SELECT NOW() + INTERVAL table.column DAY");
+    mysql().one_statement_parses_to(
+        "SELECT NOW() + INTERVAL CAST(6/4 AS DECIMAL(3,1)) HOUR",
+        "SELECT NOW() + INTERVAL CAST(6 / 4 AS NUMERIC(3,1)) HOUR",
+    );
+}
+
 fn mysql() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],


### PR DESCRIPTION
 [MySQL handles intervals differently from the other dialects](https://dev.mysql.com/doc/refman/8.0/en/expressions.html#temporal-intervals). This PR adds support for parsing those intervals when using the MySQL dialect. 


One thing to note, in the tests, I have the following case:

```rust
mysql().one_statement_parses_to(
    "SELECT NOW() + INTERVAL CAST(6/4 AS DECIMAL(3,1)) HOUR",
    "SELECT NOW() + INTERVAL CAST(6 / 4 AS NUMERIC(3,1)) HOUR",
);
```

This may be wrong... The destination type probably should remain as `DECIMAL(3,1)`. I say "may" because a [bug was reported](https://bugs.mysql.com/bug.php?id=84558) to the MySQL team in 2017; however, it isn't clear if this bug or documentation issue, and there hasn't been any progress since then.