### PR TITLE
Add support for postgres json operators `->`, `->>`, `#>`, and `#>>`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -197,11 +197,11 @@ pub enum JsonOperator {
 impl fmt::Display for JsonOperator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            JsonOperator::LongArrow => {
-                write!(f, "->>")
-            }
             JsonOperator::Arrow => {
                 write!(f, "->")
+            }
+            JsonOperator::LongArrow => {
+                write!(f, "->>")
             }
             JsonOperator::HashArrow => {
                 write!(f, "#>")
@@ -225,7 +225,7 @@ pub enum Expr {
     Identifier(Ident),
     /// Multi-part identifier, e.g. `table_alias.column` or `schema.table.col`
     CompoundIdentifier(Vec<Ident>),
-    /// JsonIdentifier eg: data->'tags'
+    /// JSON access (postgres)  eg: data->'tags'
     JsonAccess {
         left: Box<Expr>,
         operator: JsonOperator,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -180,6 +180,29 @@ impl fmt::Display for Array {
     }
 }
 
+/// JsonOperator
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum JsonOperator {
+    /// -> keeps the value as json
+    Arrow,
+    /// ->> keeps the value as text or int.
+    LongArrow,
+}
+
+impl fmt::Display for JsonOperator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JsonOperator::LongArrow => {
+                write!(f, "->>")
+            }
+            JsonOperator::Arrow => {
+                write!(f, "->")
+            }
+        }
+    }
+}
+
 /// An SQL expression of any type.
 ///
 /// The parser does not distinguish between expressions of different types
@@ -192,6 +215,12 @@ pub enum Expr {
     Identifier(Ident),
     /// Multi-part identifier, e.g. `table_alias.column` or `schema.table.col`
     CompoundIdentifier(Vec<Ident>),
+    /// JsonIdentifier eg: data->'tags'
+    JsonIdentifier {
+        ident: Ident,
+        operator: JsonOperator,
+        right_ident: Box<Expr>,
+    },
     /// `IS NULL` operator
     IsNull(Box<Expr>),
     /// `IS NOT NULL` operator
@@ -506,6 +535,15 @@ impl fmt::Display for Expr {
             }
             Expr::Array(set) => {
                 write!(f, "{}", set)
+            }
+            Expr::JsonIdentifier {
+                ident,
+                operator,
+                right_ident,
+            } => {
+                write!(f, "{}", ident)?;
+                write!(f, "{}", operator)?;
+                write!(f, "{}", right_ident)
             }
         }
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -188,6 +188,10 @@ pub enum JsonOperator {
     Arrow,
     /// ->> keeps the value as text or int.
     LongArrow,
+    /// #> Extracts JSON sub-object at the specified path
+    HashArrow,
+    /// #>> Extracts JSON sub-object at the specified path as text
+    HashLongArrow,
 }
 
 impl fmt::Display for JsonOperator {
@@ -198,6 +202,12 @@ impl fmt::Display for JsonOperator {
             }
             JsonOperator::Arrow => {
                 write!(f, "->")
+            }
+            JsonOperator::HashArrow => {
+                write!(f, "#>")
+            }
+            JsonOperator::HashLongArrow => {
+                write!(f, "#>>")
             }
         }
     }
@@ -216,10 +226,10 @@ pub enum Expr {
     /// Multi-part identifier, e.g. `table_alias.column` or `schema.table.col`
     CompoundIdentifier(Vec<Ident>),
     /// JsonIdentifier eg: data->'tags'
-    JsonIdentifier {
-        ident: Ident,
+    JsonAccess {
+        left: Box<Expr>,
         operator: JsonOperator,
-        right_ident: Box<Expr>,
+        right: Box<Expr>,
     },
     /// `IS NULL` operator
     IsNull(Box<Expr>),
@@ -536,14 +546,12 @@ impl fmt::Display for Expr {
             Expr::Array(set) => {
                 write!(f, "{}", set)
             }
-            Expr::JsonIdentifier {
-                ident,
+            Expr::JsonAccess {
+                left,
                 operator,
-                right_ident,
+                right,
             } => {
-                write!(f, "{}", ident)?;
-                write!(f, "{}", operator)?;
-                write!(f, "{}", right_ident)
+                write!(f, "{} {} {}", left, operator, right)
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -925,8 +925,8 @@ impl<'a> Parser<'a> {
                 Token::Arrow => {
                     self.next_token();
                     return Ok(Expr::JsonIdentifier {
-                        ident: ident,
-                        operator: operator,
+                        ident,
+                        operator,
                         right_ident: Box::new(self.parse_json_identifier(
                             Ident {
                                 value: w,
@@ -939,8 +939,8 @@ impl<'a> Parser<'a> {
                 Token::LongArrow => {
                     self.next_token();
                     return Ok(Expr::JsonIdentifier {
-                        ident: ident,
-                        operator: operator,
+                        ident,
+                        operator,
                         right_ident: Box::new(self.parse_json_identifier(
                             Ident {
                                 value: w,
@@ -952,8 +952,8 @@ impl<'a> Parser<'a> {
                 }
                 _ => {
                     return Ok(Expr::JsonIdentifier {
-                        ident: ident,
-                        operator: operator,
+                        ident,
+                        operator,
                         right_ident: Box::new(Expr::Identifier(Ident {
                             value: w,
                             quote_style: Some('\''),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -907,7 +907,6 @@ impl<'a> Parser<'a> {
         }))
     }
 
-
     // This function parses date/time fields for both the EXTRACT function-like
     // operator and interval qualifiers. EXTRACT supports a wider set of
     // date/time fields than interval qualifiers, so this function may need to
@@ -1159,11 +1158,11 @@ impl<'a> Parser<'a> {
                 Token::HashLongArrow => JsonOperator::HashLongArrow,
                 _ => unreachable!(),
             };
-            return Ok(Expr::JsonAccess {
+            Ok(Expr::JsonAccess {
                 left: Box::new(expr),
                 operator,
                 right: Box::new(self.parse_expr()?),
-            });
+            })
         } else {
             // Can only happen if `get_next_precedence` got out of sync with this function
             parser_err!(format!("No infix parser for token {:?}", tok))

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -143,7 +143,7 @@ pub enum Token {
     Placeholder(String),
     /// ->, used as a operator to extract json field in PostgreSQL
     Arrow,
-    /// -->, used as a operator to extract json field as text in PostgreSQL
+    /// ->>, used as a operator to extract json field as text in PostgreSQL
     LongArrow,
     /// #> Extracts JSON sub-object at the specified path
     HashArrow,
@@ -206,7 +206,7 @@ impl fmt::Display for Token {
             Token::PGCubeRoot => f.write_str("||/"),
             Token::Placeholder(ref s) => write!(f, "{}", s),
             Token::Arrow => write!(f, "->"),
-            Token::LongArrow => write!(f, "-->"),
+            Token::LongArrow => write!(f, "->>"),
             Token::HashArrow => write!(f, "#>"),
             Token::HashLongArrow => write!(f, "#>>"),
         }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -141,6 +141,10 @@ pub enum Token {
     PGCubeRoot,
     /// `?` or `$` , a prepared statement arg placeholder
     Placeholder(String),
+    /// ->, used as a operator to extract json field in PostgreSQL
+    Arrow,
+    /// -->, used as a operator to extract json field in PostgreSQL
+    LongArrow,
 }
 
 impl fmt::Display for Token {
@@ -197,6 +201,8 @@ impl fmt::Display for Token {
             Token::PGSquareRoot => f.write_str("|/"),
             Token::PGCubeRoot => f.write_str("||/"),
             Token::Placeholder(ref s) => write!(f, "{}", s),
+            Token::Arrow => write!(f, "->"),
+            Token::LongArrow => write!(f, "-->"),
         }
     }
 }
@@ -482,6 +488,16 @@ impl<'a> Tokenizer<'a> {
                                 prefix: "--".to_owned(),
                                 comment,
                             })))
+                        }
+                        Some('>') => {
+                            chars.next();
+                            match chars.peek() {
+                                Some('>') => {
+                                    chars.next();
+                                    Ok(Some(Token::LongArrow))
+                                }
+                                _ => Ok(Some(Token::Arrow)),
+                            }
                         }
                         // a regular '-' operator
                         _ => Ok(Some(Token::Minus)),


### PR DESCRIPTION
`arrow` are used to represent nested field of json.

```
SELECT info->'items'->>'product' FROM orders
```

This PR adds support to parse identifier which are separated using `arrow` 
 
Signed-off-by: password <rbalajis25@gmail.com>