### PR TITLE
Add support of NVARCHAR data type

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -101,7 +101,7 @@ impl fmt::Display for DataType {
                 format_type_with_optional_length(f, "CHARACTER VARYING", size, false)
             }
             DataType::Nvarchar(size) => {
-                format_type_with_optional_length(f, "NUMERIC CHARACTER VARYING", size, false)
+                format_type_with_optional_length(f, "NVARCHAR", size, false)
             }
             DataType::Uuid => write!(f, "UUID"),
             DataType::Clob(size) => write!(f, "CLOB({})", size),

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -101,7 +101,7 @@ impl fmt::Display for DataType {
                 format_type_with_optional_length(f, "CHARACTER VARYING", size, false)
             }
             DataType::Nvarchar(size) => {
-                format_type_with_optional_length(f, "Numeric CHARACTER VARYING", size, false)
+                format_type_with_optional_length(f, "NUMERIC CHARACTER VARYING", size, false)
             }
             DataType::Uuid => write!(f, "UUID"),
             DataType::Clob(size) => write!(f, "CLOB({})", size),

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -29,6 +29,8 @@ pub enum DataType {
     Char(Option<u64>),
     /// Variable-length character type e.g. VARCHAR(10)
     Varchar(Option<u64>),
+    /// Variable-length character type e.g. NVARCHAR(10)
+    Nvarchar(Option<u64>),
     /// Uuid type
     Uuid,
     /// Large character object e.g. CLOB(1000)
@@ -97,6 +99,9 @@ impl fmt::Display for DataType {
             DataType::Char(size) => format_type_with_optional_length(f, "CHAR", size, false),
             DataType::Varchar(size) => {
                 format_type_with_optional_length(f, "CHARACTER VARYING", size, false)
+            }
+            DataType::Nvarchar(size) => {
+                format_type_with_optional_length(f, "Numeric CHARACTER VARYING", size, false)
             }
             DataType::Uuid => write!(f, "UUID"),
             DataType::Clob(size) => write!(f, "CLOB({})", size),

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -336,6 +336,7 @@ define_keywords!(
     NULLIF,
     NULLS,
     NUMERIC,
+    NVARCHAR,
     OBJECT,
     OCCURRENCES_REGEX,
     OCTET_LENGTH,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2548,6 +2548,7 @@ impl<'a> Parser<'a> {
                     }
                 }
                 Keyword::VARCHAR => Ok(DataType::Varchar(self.parse_optional_precision()?)),
+                Keyword::NVARCHAR => Ok(DataType::Nvarchar(self.parse_optional_precision()?)),
                 Keyword::CHAR | Keyword::CHARACTER => {
                     if self.parse_keyword(Keyword::VARYING) {
                         Ok(DataType::Varchar(self.parse_optional_precision()?))

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1365,6 +1365,16 @@ fn parse_cast() {
         "SELECT CAST(id AS DECIMAL) FROM customer",
         "SELECT CAST(id AS NUMERIC) FROM customer",
     );
+
+    let sql = "SELECT CAST(id AS NVARCHAR(50)) FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Cast {
+            expr: Box::new(Expr::Identifier(Ident::new("id"))),
+            data_type: DataType::Nvarchar(Some(50))
+        },
+        expr_from_projection(only(&select.projection))
+    );
 }
 
 #[test]


### PR DESCRIPTION
Redshift support the NVARCHAR datatype ([Redshift Data Types](https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html))

The following query can't be parsed using sqlparser:

```
SELECT cast(field as nvarchar(50)) as "field" 
FROM a

```