### PR TITLE
add support for postgres composite types

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -231,6 +231,11 @@ pub enum Expr {
         operator: JsonOperator,
         right: Box<Expr>,
     },
+    /// CompositeAccess (postgres) eg: SELECT (information_schema._pg_expandarray(array['i','i'])).n
+    CompositeAccess {
+        expr: Box<Expr>,
+        key: Ident,
+    },
     /// `IS NULL` operator
     IsNull(Box<Expr>),
     /// `IS NOT NULL` operator
@@ -552,6 +557,9 @@ impl fmt::Display for Expr {
                 right,
             } => {
                 write!(f, "{} {} {}", left, operator, right)
+            }
+            Expr::CompositeAccess { expr, key } => {
+                write!(f, "{}.{}", expr, key)
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -516,7 +516,18 @@ impl<'a> Parser<'a> {
                         }
                     };
                 self.expect_token(&Token::RParen)?;
-                Ok(expr)
+                if !self.consume_token(&Token::Period) {
+                    return Ok(expr);
+                }
+                let tok = self.next_token();
+                let key = match tok {
+                    Token::Word(word) => word.to_ident(),
+                    _ => return parser_err!(format!("Expected identifier, found: {}", tok)),
+                };
+                Ok(Expr::CompositeAccess {
+                    expr: Box::new(expr),
+                    key,
+                })
             }
             Token::Placeholder(_) => {
                 self.prev_token();

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1303,7 +1303,7 @@ fn test_json() {
 
 #[test]
 fn test_composite_value() {
-    let sql = "SELECT (on_hand.item).name FROM on_hand WHERE (on_hand.item).price > 9.99";
+    let sql = "SELECT (on_hand.item).name FROM on_hand WHERE (on_hand.item).price > 9";
     let select = pg().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::CompositeAccess {
@@ -1316,6 +1316,10 @@ fn test_composite_value() {
         select.projection[0]
     );
 
+    #[cfg(feature = "bigdecimal")]
+    let num: Expr = Expr::Value(Value::Number(bigdecimal::BigDecimal::from(9), false));
+    #[cfg(not(feature = "bigdecimal"))]
+    let num: Expr = Expr::Value(Value::Number("9".to_string(), false));
     assert_eq!(
         select.selection,
         Some(Expr::BinaryOp {
@@ -1327,7 +1331,7 @@ fn test_composite_value() {
                 ]))))
             }),
             op: BinaryOperator::Gt,
-            right: Box::new(Expr::Value(Value::Number("9.99".to_string(), false)))
+            right: Box::new(num)
         })
     );
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1302,6 +1302,63 @@ fn test_json() {
 }
 
 #[test]
+fn test_composite_value() {
+    let sql = "SELECT (on_hand.item).name FROM on_hand WHERE (on_hand.item).price > 9.99";
+    let select = pg().verified_only_select(sql);
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::CompositeAccess {
+            key: Ident::new("name"),
+            expr: Box::new(Expr::Nested(Box::new(Expr::CompoundIdentifier(vec![
+                Ident::new("on_hand"),
+                Ident::new("item")
+            ]))))
+        }),
+        select.projection[0]
+    );
+
+    assert_eq!(
+        select.selection,
+        Some(Expr::BinaryOp {
+            left: Box::new(Expr::CompositeAccess {
+                key: Ident::new("price"),
+                expr: Box::new(Expr::Nested(Box::new(Expr::CompoundIdentifier(vec![
+                    Ident::new("on_hand"),
+                    Ident::new("item")
+                ]))))
+            }),
+            op: BinaryOperator::Gt,
+            right: Box::new(Expr::Value(Value::Number("9.99".to_string(), false)))
+        })
+    );
+
+    let sql = "SELECT (information_schema._pg_expandarray(ARRAY['i', 'i'])).n";
+    let select = pg().verified_only_select(sql);
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::CompositeAccess {
+            key: Ident::new("n"),
+            expr: Box::new(Expr::Nested(Box::new(Expr::Function(Function {
+                name: ObjectName(vec![
+                    Ident::new("information_schema"),
+                    Ident::new("_pg_expandarray")
+                ]),
+                args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Array(
+                    Array {
+                        elem: vec![
+                            Expr::Value(Value::SingleQuotedString("i".to_string())),
+                            Expr::Value(Value::SingleQuotedString("i".to_string())),
+                        ],
+                        named: true
+                    }
+                )))],
+                over: None,
+                distinct: false,
+            }))))
+        }),
+        select.projection[0]
+    );
+}
+
+#[test]
 fn parse_comments() {
     match pg().verified_stmt("COMMENT ON COLUMN tab.name IS 'comment'") {
         Statement::Comment {


### PR DESCRIPTION
This PR adds support for postgres composite values. 
ref: https://www.postgresql.org/docs/current/rowtypes.html#:~:text=A%20composite%20type%20represents%20the,be%20of%20a%20composite%20type
Signed-off-by: password <rbalajis25@gmail.com>