### PR TITLE
Add negative test for IN parsing

### DIFF
--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -952,6 +952,17 @@ fn parse_in_unnest() {
 }
 
 #[test]
+fn parse_in_error() {
+    // <expr> IN <expr> is no valid
+    let sql = "SELECT * FROM customers WHERE segment in segment";
+    let res = parse_sql_statements(sql);
+    assert_eq!(
+        ParserError::ParserError("Expected (, found: segment".to_string()),
+        res.unwrap_err()
+    );
+}
+
+#[test]
 fn parse_string_agg() {
     let sql = "SELECT a || b";
 


### PR DESCRIPTION
While reviewing https://github.com/sqlparser-rs/sqlparser-rs/pull/463 I wrote this test for expected errors errors when trying to parse `<expr> IN <expr>`

This is consistent with postgres

```sql
alamb=# select * from a where a in a;
ERROR:  syntax error at or near "a"
LINE 1: select * from a where a in a;
```

And mysql

```sql
mysql> select * from foo where bar IN bar;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'bar' at line 1
```
