### PR TITLE
Add Redshift dialect, handle square brackets properly

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -43,6 +43,7 @@ $ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
         "--mysql" => Box::new(MySqlDialect {}),
         "--snowflake" => Box::new(SnowflakeDialect {}),
         "--hive" => Box::new(HiveDialect {}),
+        "--redshift" => Box::new(RedshiftSqlDialect {}),
         "--generic" | "" => Box::new(GenericDialect {}),
         s => panic!("Unexpected parameter: {}", s),
     };

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -14,7 +14,7 @@
 //! (commonly referred to as Data Definition Language, or DDL)
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, string::ToString, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt;
 
 #[cfg(feature = "serde")]

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -23,8 +23,8 @@ mod sqlite;
 
 use core::any::{Any, TypeId};
 use core::fmt::Debug;
-use std::iter::Peekable;
-use std::str::Chars;
+use core::iter::Peekable;
+use core::str::Chars;
 
 pub use self::ansi::AnsiDialect;
 pub use self::clickhouse::ClickHouseDialect;

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -17,11 +17,14 @@ mod hive;
 mod mssql;
 mod mysql;
 mod postgresql;
+mod redshift;
 mod snowflake;
 mod sqlite;
 
 use core::any::{Any, TypeId};
 use core::fmt::Debug;
+use std::iter::Peekable;
+use std::str::Chars;
 
 pub use self::ansi::AnsiDialect;
 pub use self::clickhouse::ClickHouseDialect;
@@ -30,6 +33,7 @@ pub use self::hive::HiveDialect;
 pub use self::mssql::MsSqlDialect;
 pub use self::mysql::MySqlDialect;
 pub use self::postgresql::PostgreSqlDialect;
+pub use self::redshift::RedshiftSqlDialect;
 pub use self::snowflake::SnowflakeDialect;
 pub use self::sqlite::SQLiteDialect;
 pub use crate::keywords;
@@ -50,6 +54,10 @@ pub trait Dialect: Debug + Any {
     /// in `Word::matching_end_quote` here
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
         ch == '"'
+    }
+    /// Determine if quoted characters are proper for identifier
+    fn is_proper_identifier_inside_quotes(&self, mut _chars: Peekable<Chars<'_>>) -> bool {
+        true
     }
     /// Determine if a character is a valid start character for an unquoted identifier
     fn is_identifier_start(&self, ch: char) -> bool;

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -32,9 +32,9 @@ impl Dialect for RedshiftSqlDialect {
     /// It's needed to distinguish treating square brackets as quotes from
     /// treating them as json path. If there is identifier then we assume
     /// there is no json path.
-    fn is_proper_identifier_inside_quotes(&self, mut _chars: Peekable<Chars<'_>>) -> bool {
-        _chars.next();
-        let mut not_white_chars = _chars.skip_while(|ch| ch.is_whitespace()).peekable();
+    fn is_proper_identifier_inside_quotes(&self, mut chars: Peekable<Chars<'_>>) -> bool {
+        chars.next();
+        let mut not_white_chars = chars.skip_while(|ch| ch.is_whitespace()).peekable();
         if let Some(&ch) = not_white_chars.peek() {
             return self.is_identifier_start(ch);
         }

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -11,8 +11,8 @@
 // limitations under the License.
 
 use crate::dialect::Dialect;
-use std::iter::Peekable;
-use std::str::Chars;
+use core::iter::Peekable;
+use core::str::Chars;
 
 use super::PostgreSqlDialect;
 
@@ -20,10 +20,10 @@ use super::PostgreSqlDialect;
 pub struct RedshiftSqlDialect {}
 
 // In most cases the redshift dialect is identical to [`PostgresSqlDialect`].
-// 
-// Notable differences: 
+//
+// Notable differences:
 // 1. Redshift treats brackets `[` and `]` differently. For example, `SQL SELECT a[1][2] FROM b`
-// in the Postgres dialect, the query will be parsed as an array, while in the Redshift dialect it will 
+// in the Postgres dialect, the query will be parsed as an array, while in the Redshift dialect it will
 // be a json path
 impl Dialect for RedshiftSqlDialect {
     fn is_delimited_identifier_start(&self, ch: char) -> bool {

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -1,0 +1,51 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::dialect::Dialect;
+use std::iter::Peekable;
+use std::str::Chars;
+
+use super::PostgreSqlDialect;
+
+#[derive(Debug)]
+pub struct RedshiftSqlDialect {}
+
+// In most cases the redshift dialect is identical to postgres dialect.
+// However there is no distinguish between datatype array in postgres and super in Redsfhit, where the sql syntax is similar
+// e.g the SQL SELECT a[1][2] FROM b In postgres Dialect and Redshift's have totally different meaning.
+// In Postgres dialect, the query will be parsed as an array, while in Redshift it will be an json path
+impl Dialect for RedshiftSqlDialect {
+    fn is_delimited_identifier_start(&self, ch: char) -> bool {
+        ch == '"' || ch == '['
+    }
+
+    /// Determine if quoted characters are proper for identifier
+    /// It's needed to distinguish treating square brackets as quotes from
+    /// treating them as json path. If there is identifier then we assume
+    /// there is no json path.
+    fn is_proper_identifier_inside_quotes(&self, mut _chars: Peekable<Chars<'_>>) -> bool {
+        _chars.next();
+        let mut not_white_chars = _chars.skip_while(|ch| ch.is_whitespace()).peekable();
+        if let Some(&ch) = not_white_chars.peek() {
+            return self.is_identifier_start(ch);
+        }
+        false
+    }
+
+    fn is_identifier_start(&self, ch: char) -> bool {
+        PostgreSqlDialect {}.is_identifier_start(ch)
+    }
+
+    fn is_identifier_part(&self, ch: char) -> bool {
+        PostgreSqlDialect {}.is_identifier_part(ch)
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -141,6 +141,7 @@ pub fn all_dialects() -> TestedDialects {
             Box::new(AnsiDialect {}),
             Box::new(SnowflakeDialect {}),
             Box::new(HiveDialect {}),
+            Box::new(RedshiftSqlDialect {}),
         ],
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -431,7 +431,12 @@ impl<'a> Tokenizer<'a> {
                     Ok(Some(Token::SingleQuotedString(s)))
                 }
                 // delimited (quoted) identifier
-                quote_start if self.dialect.is_delimited_identifier_start(quote_start) => {
+                quote_start
+                    if self.dialect.is_delimited_identifier_start(ch)
+                        && self
+                            .dialect
+                            .is_proper_identifier_inside_quotes(chars.clone()) =>
+                {
                     chars.next(); // consume the opening quote
                     let quote_end = Word::matching_end_quote(quote_start);
                     let (s, last_char) = parse_quoted_ident(chars, quote_end);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4601,3 +4601,20 @@ fn parse_position() {
         expr_from_projection(only(&select.projection))
     );
 }
+
+#[test]
+fn parse_position_negative() {
+    let sql = "SELECT POSITION(foo) from bar";
+    let res = parse_sql_statements(sql);
+    assert_eq!(
+        ParserError::ParserError("Position function must include IN keyword".to_string()),
+        res.unwrap_err()
+    );
+
+    let sql = "SELECT POSITION(foo IN) from bar";
+    let res = parse_sql_statements(sql);
+    assert_eq!(
+        ParserError::ParserError("Expected an expression:, found: )".to_string()),
+        res.unwrap_err()
+    );
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -589,7 +589,7 @@ fn test_copy_to() {
 
 #[test]
 fn parse_copy_from() {
-    let sql = "COPY table (a, b) FROM 'file.csv' WITH 
+    let sql = "COPY table (a, b) FROM 'file.csv' WITH
     (
         FORMAT CSV,
         FREEZE,

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -1,0 +1,90 @@
+#[macro_use]
+mod test_utils;
+
+use test_utils::*;
+
+use sqlparser::ast::*;
+use sqlparser::dialect::RedshiftSqlDialect;
+
+#[test]
+fn test_square_brackets_over_db_schema_table_name() {
+    let select = redshift().verified_only_select("SELECT [col1] FROM [test_schema].[test_table]");
+    assert_eq!(
+        select.projection[0],
+        SelectItem::UnnamedExpr(Expr::Identifier(Ident {
+            value: "col1".to_string(),
+            quote_style: Some('[')
+        })),
+    );
+    assert_eq!(
+        select.from[0],
+        TableWithJoins {
+            relation: TableFactor::Table {
+                name: ObjectName(vec![
+                    Ident {
+                        value: "test_schema".to_string(),
+                        quote_style: Some('[')
+                    },
+                    Ident {
+                        value: "test_table".to_string(),
+                        quote_style: Some('[')
+                    }
+                ]),
+                alias: None,
+                args: vec![],
+                with_hints: vec![],
+            },
+            joins: vec![],
+        }
+    );
+}
+
+#[test]
+fn brackets_over_db_schema_table_name_with_whites_paces() {
+    match redshift().parse_sql_statements("SELECT [   col1  ] FROM [  test_schema].[ test_table]") {
+        Ok(statements) => {
+            assert_eq!(statements.len(), 1);
+        }
+        Err(e) => assert!(false, "failed to parse: {}", e),
+    }
+}
+
+#[test]
+fn test_double_quotes_over_db_schema_table_name() {
+    let select =
+        redshift().verified_only_select("SELECT \"col1\" FROM \"test_schema\".\"test_table\"");
+    assert_eq!(
+        select.projection[0],
+        SelectItem::UnnamedExpr(Expr::Identifier(Ident {
+            value: "col1".to_string(),
+            quote_style: Some('"')
+        })),
+    );
+    assert_eq!(
+        select.from[0],
+        TableWithJoins {
+            relation: TableFactor::Table {
+                name: ObjectName(vec![
+                    Ident {
+                        value: "test_schema".to_string(),
+                        quote_style: Some('"')
+                    },
+                    Ident {
+                        value: "test_table".to_string(),
+                        quote_style: Some('"')
+                    }
+                ]),
+                alias: None,
+                args: vec![],
+                with_hints: vec![],
+            },
+            joins: vec![],
+        }
+    );
+}
+
+fn redshift() -> TestedDialects {
+    TestedDialects {
+        dialects: vec![Box::new(RedshiftSqlDialect {})],
+    }
+}

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -1,3 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[macro_use]
 mod test_utils;
 

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -45,7 +45,7 @@ fn brackets_over_db_schema_table_name_with_whites_paces() {
         Ok(statements) => {
             assert_eq!(statements.len(), 1);
         }
-        Err(e) => assert!(false, "failed to parse: {}", e),
+        _ => unreachable!(),
     }
 }
 


### PR DESCRIPTION
We need to detect `[` or `"` for Redshift quotes around indentifier and at the same time exclude
treating JSON paths as indentifer