### PR TITLE
Add support in IS boolean filter

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1130,9 +1130,21 @@ impl<'a> Parser<'a> {
                     {
                         let expr2 = self.parse_expr()?;
                         Ok(Expr::IsNotDistinctFrom(Box::new(expr), Box::new(expr2)))
+                    } else if let Some(right) =
+                        self.parse_one_of_keywords(&[Keyword::TRUE, Keyword::FALSE])
+                    {
+                        let mut val = Value::Boolean(true);
+                        if right == Keyword::FALSE {
+                            val = Value::Boolean(false);
+                        }
+                        Ok(Expr::BinaryOp {
+                            left: Box::new(expr),
+                            op: BinaryOperator::Eq,
+                            right: Box::new(Expr::Value(val)),
+                        })
                     } else {
                         self.expected(
-                            "[NOT] NULL or [NOT] DISTINCT FROM after IS",
+                            "[NOT] NULL or [NOT] DISTINCT FROM TRUE FALSE after IS",
                             self.peek_token(),
                         )
                     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4618,3 +4618,18 @@ fn parse_position_negative() {
         res.unwrap_err()
     );
 }
+
+#[test]
+fn parse_is_boolean() {
+    one_statement_parses_to(
+        "SELECT f from foo where field is true",
+        "SELECT f FROM foo WHERE field = true",
+    );
+
+    let sql = "SELECT f from foo where field is 0";
+    let res = parse_sql_statements(sql);
+    assert_eq!(
+        ParserError::ParserError("Expected [NOT] NULL or [NOT] DISTINCT FROM TRUE FALSE after IS, found: 0".to_string()),
+        res.unwrap_err()
+    );
+}

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4626,6 +4626,11 @@ fn parse_is_boolean() {
         "SELECT f FROM foo WHERE field = true",
     );
 
+    one_statement_parses_to(
+        "SELECT f from foo where field is false",
+        "SELECT f FROM foo WHERE field = false",
+    );
+
     let sql = "SELECT f from foo where field is 0";
     let res = parse_sql_statements(sql);
     assert_eq!(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4629,7 +4629,9 @@ fn parse_is_boolean() {
     let sql = "SELECT f from foo where field is 0";
     let res = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected [NOT] NULL or [NOT] DISTINCT FROM TRUE FALSE after IS, found: 0".to_string()),
+        ParserError::ParserError(
+            "Expected [NOT] NULL or [NOT] DISTINCT FROM TRUE FALSE after IS, found: 0".to_string()
+        ),
         res.unwrap_err()
     );
 }


### PR DESCRIPTION
The following query is valid and should be supported:
`SELECT f FROM foo WHERE field = true`

Verified on latest postgres version