### PR TITLE
Fix redshift specific character

### DIFF
--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -20,7 +20,7 @@ impl Dialect for PostgreSqlDialect {
         // See https://www.postgresql.org/docs/11/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
         // We don't yet support identifiers beginning with "letters with
         // diacritical marks and non-Latin letters"
-        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_'
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_' || ch == '#'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
@@ -29,5 +29,6 @@ impl Dialect for PostgreSqlDialect {
             || ('0'..='9').contains(&ch)
             || ch == '$'
             || ch == '_'
+            || ch == '#'
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -422,7 +422,24 @@ impl<'a> Tokenizer<'a> {
                         s += s2.as_str();
                         return Ok(Some(Token::Number(s, false)));
                     }
-                    Ok(Some(Token::make_word(&s, None)))
+                    if s == "#" {
+                        match chars.peek() {
+                            Some('>') => {
+                                chars.next();
+                                match chars.peek() {
+                                    Some('>') => {
+                                        chars.next();
+                                        return Ok(Some(Token::HashLongArrow))
+                                    }
+                                    _ => Ok(Some(Token::HashArrow)),
+                                }
+                            }
+                            _ => Ok(Some(Token::Sharp)),
+                        }
+                    } else {
+                        Ok(Some(Token::make_word(&s, None)))
+                    }
+                    
                 }
                 // string
                 '\'' => {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -371,12 +371,12 @@ impl<'a> Tokenizer<'a> {
                 match chars.peek() {
                     Some('>') => {
                         chars.next();
-                        return Ok(Some(Token::HashLongArrow));
+                        Ok(Some(Token::HashLongArrow))
                     }
-                    _ => return Ok(Some(Token::HashArrow)),
+                    _ => Ok(Some(Token::HashArrow)),
                 }
             }
-            _ => return Ok(Some(Token::Sharp)),
+            _ => Ok(Some(Token::Sharp)),
         }
     }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -361,14 +361,17 @@ impl<'a> Tokenizer<'a> {
         Ok(tokens)
     }
 
-    fn consume_sharp(&self, chars: &mut Peekable<Chars<'_>>) -> Result<Option<Token>, TokenizerError> {
+    fn consume_sharp(
+        &self,
+        chars: &mut Peekable<Chars<'_>>,
+    ) -> Result<Option<Token>, TokenizerError> {
         match chars.peek() {
             Some('>') => {
                 chars.next();
                 match chars.peek() {
                     Some('>') => {
                         chars.next();
-                        return Ok(Some(Token::HashLongArrow))
+                        return Ok(Some(Token::HashLongArrow));
                     }
                     _ => return Ok(Some(Token::HashArrow)),
                 }
@@ -443,7 +446,6 @@ impl<'a> Tokenizer<'a> {
                     } else {
                         Ok(Some(Token::make_word(&s, None)))
                     }
-                    
                 }
                 // string
                 '\'' => {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -361,6 +361,22 @@ impl<'a> Tokenizer<'a> {
         Ok(tokens)
     }
 
+    fn consume_sharp(&self, chars: &mut Peekable<Chars<'_>>) -> Result<Option<Token>, TokenizerError> {
+        match chars.peek() {
+            Some('>') => {
+                chars.next();
+                match chars.peek() {
+                    Some('>') => {
+                        chars.next();
+                        return Ok(Some(Token::HashLongArrow))
+                    }
+                    _ => return Ok(Some(Token::HashArrow)),
+                }
+            }
+            _ => return Ok(Some(Token::Sharp)),
+        }
+    }
+
     /// Get the next token or return None
     fn next_token(&self, chars: &mut Peekable<Chars<'_>>) -> Result<Option<Token>, TokenizerError> {
         //println!("next_token: {:?}", chars.peek());
@@ -423,19 +439,7 @@ impl<'a> Tokenizer<'a> {
                         return Ok(Some(Token::Number(s, false)));
                     }
                     if s == "#" {
-                        match chars.peek() {
-                            Some('>') => {
-                                chars.next();
-                                match chars.peek() {
-                                    Some('>') => {
-                                        chars.next();
-                                        return Ok(Some(Token::HashLongArrow))
-                                    }
-                                    _ => Ok(Some(Token::HashArrow)),
-                                }
-                            }
-                            _ => Ok(Some(Token::Sharp)),
-                        }
+                        self.consume_sharp(chars)
                     } else {
                         Ok(Some(Token::make_word(&s, None)))
                     }
@@ -641,19 +645,7 @@ impl<'a> Tokenizer<'a> {
                 }
                 '#' => {
                     chars.next();
-                    match chars.peek() {
-                        Some('>') => {
-                            chars.next();
-                            match chars.peek() {
-                                Some('>') => {
-                                    chars.next();
-                                    Ok(Some(Token::HashLongArrow))
-                                }
-                                _ => Ok(Some(Token::HashArrow)),
-                            }
-                        }
-                        _ => Ok(Some(Token::Sharp)),
-                    }
+                    self.consume_sharp(chars)
                 }
                 '@' => self.consume_and_return(chars, Token::AtSign),
                 '?' => self.consume_and_return(chars, Token::Placeholder(String::from("?"))),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1373,3 +1373,13 @@ fn pg_and_generic() -> TestedDialects {
         dialects: vec![Box::new(PostgreSqlDialect {}), Box::new(GenericDialect {})],
     }
 }
+
+#[test]
+fn test_sharp() {
+    let sql = "SELECT #_of_values";
+    let select = pg().verified_only_select(sql);
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::Identifier(Ident::new("#_of_values"))),
+        select.projection[0]
+    );
+}


### PR DESCRIPTION
The following query is valid in Redshift:
```
SELECT #_of_values
FROM foo
```

In postgres, when running using pgadmin, the query is not valid and must written as the following:
(I'm not sure what is the behavior in other drivers/apps that can query postgres).
```
SELECT foo."#_of_values"
FROM foo
```

As redshift is based on postgres, for me it makes sense to change the postgres dialect.
I would love for some feedback.

Thanks!
