### PR TITLE
feat: Support ANY/ALL operators

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -270,6 +270,10 @@ pub enum Expr {
         op: BinaryOperator,
         right: Box<Expr>,
     },
+    /// Any operation e.g. `1 ANY (1)` or `foo > ANY(bar)`, It will be wrapped in the right side of BinaryExpr
+    AnyOp(Box<Expr>),
+    /// ALL operation e.g. `1 ALL (1)` or `foo > ALL(bar)`, It will be wrapped in the right side of BinaryExpr
+    AllOp(Box<Expr>),
     /// Unary operation e.g. `NOT foo`
     UnaryOp {
         op: UnaryOperator,
@@ -433,6 +437,8 @@ impl fmt::Display for Expr {
                 high
             ),
             Expr::BinaryOp { left, op, right } => write!(f, "{} {} {}", left, op, right),
+            Expr::AnyOp(expr) => write!(f, "ANY({})", expr),
+            Expr::AllOp(expr) => write!(f, "ALL({})", expr),
             Expr::UnaryOp { op, expr } => {
                 if op == &UnaryOperator::PGPostfixFactorial {
                     write!(f, "{}{}", expr, op)

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1000,7 +1000,7 @@ fn parse_bitwise_ops() {
 
 #[test]
 fn parse_binary_any() {
-    let select = verified_only_select(&"SELECT a = ANY(b)");
+    let select = verified_only_select("SELECT a = ANY(b)");
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("a"))),
@@ -1013,7 +1013,7 @@ fn parse_binary_any() {
 
 #[test]
 fn parse_binary_all() {
-    let select = verified_only_select(&"SELECT a = ALL(b)");
+    let select = verified_only_select("SELECT a = ALL(b)");
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("a"))),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -999,6 +999,32 @@ fn parse_bitwise_ops() {
 }
 
 #[test]
+fn parse_binary_any() {
+    let select = verified_only_select(&"SELECT a = ANY(b)");
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::BinaryOp {
+            left: Box::new(Expr::Identifier(Ident::new("a"))),
+            op: BinaryOperator::Eq,
+            right: Box::new(Expr::AnyOp(Box::new(Expr::Identifier(Ident::new("b"))))),
+        }),
+        select.projection[0]
+    );
+}
+
+#[test]
+fn parse_binary_all() {
+    let select = verified_only_select(&"SELECT a = ALL(b)");
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::BinaryOp {
+            left: Box::new(Expr::Identifier(Ident::new("a"))),
+            op: BinaryOperator::Eq,
+            right: Box::new(Expr::AllOp(Box::new(Expr::Identifier(Ident::new("b"))))),
+        }),
+        select.projection[0]
+    );
+}
+
+#[test]
 fn parse_logical_xor() {
     let sql = "SELECT true XOR true, false XOR false, true XOR false, false XOR true";
     let select = verified_only_select(sql);


### PR DESCRIPTION
Hello!

Ref issue: https://github.com/sqlparser-rs/sqlparser-rs/issues/476

I want to support `a = ANY(expr)` in DF, but after reviewing I come to decision that it requires changes in `sql-parser` to simplify code (because hacking when the right side is a function is a super tricky)

Thanks