### PR TITLE
feat: Allow ArrayIndex for GenericDialect

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1173,7 +1173,7 @@ impl<'a> Parser<'a> {
                 expr: Box::new(expr),
             })
         } else if Token::LBracket == tok {
-            if dialect_of!(self is PostgreSqlDialect) {
+            if dialect_of!(self is PostgreSqlDialect | GenericDialect) {
                 // parse index
                 return self.parse_array_index(expr);
             }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1137,7 +1137,7 @@ fn parse_array_index_expr() {
         .collect();
 
     let sql = "SELECT foo[0] FROM foos";
-    let select = pg().verified_only_select(sql);
+    let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
         &Expr::ArrayIndex {
             obj: Box::new(Expr::Identifier(Ident::new("foo"))),
@@ -1147,7 +1147,7 @@ fn parse_array_index_expr() {
     );
 
     let sql = "SELECT foo[0][0] FROM foos";
-    let select = pg().verified_only_select(sql);
+    let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
         &Expr::ArrayIndex {
             obj: Box::new(Expr::Identifier(Ident::new("foo"))),
@@ -1157,7 +1157,7 @@ fn parse_array_index_expr() {
     );
 
     let sql = r#"SELECT bar[0]["baz"]["fooz"] FROM foos"#;
-    let select = pg().verified_only_select(sql);
+    let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
         &Expr::ArrayIndex {
             obj: Box::new(Expr::Identifier(Ident::new("bar"))),
@@ -1177,7 +1177,7 @@ fn parse_array_index_expr() {
     );
 
     let sql = "SELECT (CAST(ARRAY[ARRAY[2, 3]] AS INT[][]))[1][2]";
-    let select = pg().verified_only_select(sql);
+    let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
         &Expr::ArrayIndex {
             obj: Box::new(Expr::Nested(Box::new(Expr::Cast {


### PR DESCRIPTION
Hello!

From discussion: https://github.com/apache/arrow-datafusion/pull/2195#issuecomment-1096599374
Looks like it's a good decision to allow ArrayIndex for Generic dialect, but anyway it will be cool to improve dialect with feature flags.

Thanks