### PR TITLE
Parse merge source as table factor

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1040,9 +1040,7 @@ pub enum Statement {
         // Specifies the table to merge
         table: TableFactor,
         // Specifies the table or subquery to join with the target table
-        source: Box<SetExpr>,
-        // Specifies alias to the table that is joined with target table
-        alias: Option<TableAlias>,
+        source: TableFactor,
         // Specifies the expression on which to join the target table and source
         on: Box<Expr>,
         // Specifies the actions to perform when values match or do not match.
@@ -1751,14 +1749,10 @@ impl fmt::Display for Statement {
             Statement::Merge {
                 table,
                 source,
-                alias,
                 on,
                 clauses,
             } => {
                 write!(f, "MERGE INTO {} USING {} ", table, source)?;
-                if let Some(a) = alias {
-                    write!(f, "as {} ", a)?;
-                };
                 write!(f, "ON {} ", on)?;
                 write!(f, "{}", display_separated(clauses, " "))
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4252,16 +4252,14 @@ impl<'a> Parser<'a> {
         let table = self.parse_table_factor()?;
 
         self.expect_keyword(Keyword::USING)?;
-        let source = self.parse_query_body(0)?;
-        let alias = self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS)?;
+        let source = self.parse_table_factor()?;
         self.expect_keyword(Keyword::ON)?;
         let on = self.parse_expr()?;
         let clauses = self.parse_merge_clauses()?;
 
         Ok(Statement::Merge {
             table,
-            source: Box::new(source),
-            alias,
+            source: source,
             on: Box::new(on),
             clauses,
         })

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4259,7 +4259,7 @@ impl<'a> Parser<'a> {
 
         Ok(Statement::Merge {
             table,
-            source: source,
+            source,
             on: Box::new(on),
             clauses,
         })


### PR DESCRIPTION
Some MERGE queries need a table as a source (not just a subquery), added proper test showing it

See https://docs.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql?view=sql-server-ver15 and https://www.postgresql.org/message-id/attachment/23520/sql-merge.html