### PR TITLE
set: allow dots in variables by moving to ObjectName

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -913,7 +913,7 @@ pub enum Statement {
     SetVariable {
         local: bool,
         hivevar: bool,
-        variable: Ident,
+        variable: ObjectName,
         value: Vec<SetVariableValue>,
     },
     /// SHOW <variable>

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3247,7 +3247,7 @@ impl<'a> Parser<'a> {
             });
         }
 
-        let variable = self.parse_identifier()?;
+        let variable = self.parse_object_name()?;
         if self.consume_token(&Token::Eq) || self.parse_keyword(Keyword::TO) {
             let mut values = vec![];
             loop {
@@ -3268,14 +3268,14 @@ impl<'a> Parser<'a> {
                     value: values,
                 });
             }
-        } else if variable.value == "CHARACTERISTICS" {
+        } else if variable.to_string() == "CHARACTERISTICS" {
             self.expect_keywords(&[Keyword::AS, Keyword::TRANSACTION])?;
             Ok(Statement::SetTransaction {
                 modes: self.parse_transaction_modes()?,
                 snapshot: None,
                 session: true,
             })
-        } else if variable.value == "TRANSACTION" && modifier.is_none() {
+        } else if variable.to_string() == "TRANSACTION" && modifier.is_none() {
             if self.parse_keyword(Keyword::SNAPSHOT) {
                 let snaphot_id = self.parse_value()?;
                 return Ok(Statement::SetTransaction {


### PR DESCRIPTION
Motivation for this change are Hive variables like 

```
SET hive.exec.dynamic.partition = true;
```

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>