### PR TITLE
Redshift - Add support in sharp as start of the field name

### DIFF
--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -14,8 +14,6 @@ use crate::dialect::Dialect;
 use core::iter::Peekable;
 use core::str::Chars;
 
-use super::PostgreSqlDialect;
-
 #[derive(Debug)]
 pub struct RedshiftSqlDialect {}
 
@@ -44,10 +42,17 @@ impl Dialect for RedshiftSqlDialect {
     }
 
     fn is_identifier_start(&self, ch: char) -> bool {
-        PostgreSqlDialect {}.is_identifier_start(ch)
+        // Extends Postgres dialect with sharp
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_' || ch == '#'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        PostgreSqlDialect {}.is_identifier_part(ch)
+        // Extends Postgres dialect with sharp
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
+            || ('0'..='9').contains(&ch)
+            || ch == '$'
+            || ch == '_'
+            || ch == '#'
     }
 }

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -14,6 +14,8 @@ use crate::dialect::Dialect;
 use core::iter::Peekable;
 use core::str::Chars;
 
+use super::PostgreSqlDialect;
+
 #[derive(Debug)]
 pub struct RedshiftSqlDialect {}
 
@@ -43,16 +45,11 @@ impl Dialect for RedshiftSqlDialect {
 
     fn is_identifier_start(&self, ch: char) -> bool {
         // Extends Postgres dialect with sharp
-        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_' || ch == '#'
+        PostgreSqlDialect {}.is_identifier_start(ch) || ch == '#'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
         // Extends Postgres dialect with sharp
-        ('a'..='z').contains(&ch)
-            || ('A'..='Z').contains(&ch)
-            || ('0'..='9').contains(&ch)
-            || ch == '$'
-            || ch == '_'
-            || ch == '#'
+        PostgreSqlDialect {}.is_identifier_part(ch) || ch == '#'
     }
 }

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -100,3 +100,13 @@ fn redshift() -> TestedDialects {
         dialects: vec![Box::new(RedshiftSqlDialect {})],
     }
 }
+
+#[test]
+fn test_sharp() {
+    let sql = "SELECT #_of_values";
+    let select = redshift().verified_only_select(sql);
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::Identifier(Ident::new("#_of_values"))),
+        select.projection[0]
+    );
+}


### PR DESCRIPTION
The following query is valid in Redshift but not valid in Postgres:

`SELECT #_of_users
from users
`