### PR TITLE
feat: Support `TABLE` keyword with `SELECT INTO`

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -654,6 +654,7 @@ impl fmt::Display for Values {
 pub struct SelectInto {
     pub temporary: bool,
     pub unlogged: bool,
+    pub table: bool,
     pub name: ObjectName,
 }
 
@@ -661,7 +662,8 @@ impl fmt::Display for SelectInto {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let temporary = if self.temporary { " TEMPORARY" } else { "" };
         let unlogged = if self.unlogged { " UNLOGGED" } else { "" };
+        let table = if self.table { " TABLE" } else { "" };
 
-        write!(f, "INTO{}{} {}", temporary, unlogged, self.name)
+        write!(f, "INTO{}{}{} {}", temporary, unlogged, table, self.name)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3138,10 +3138,12 @@ impl<'a> Parser<'a> {
                 .parse_one_of_keywords(&[Keyword::TEMP, Keyword::TEMPORARY])
                 .is_some();
             let unlogged = self.parse_keyword(Keyword::UNLOGGED);
+            let table = self.parse_keyword(Keyword::TABLE);
             let name = self.parse_object_name()?;
             Some(SelectInto {
                 temporary,
                 unlogged,
+                table,
                 name,
             })
         } else {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -390,13 +390,17 @@ fn parse_select_into() {
         &SelectInto {
             temporary: false,
             unlogged: false,
+            table: false,
             name: ObjectName(vec![Ident::new("table0")])
         },
         only(&select.into)
     );
 
-    let sql = "SELECT * INTO TEMPORARY UNLOGGED table0 FROM table1";
-    one_statement_parses_to(sql, "SELECT * INTO TEMPORARY UNLOGGED table0 FROM table1");
+    let sql = "SELECT * INTO TEMPORARY UNLOGGED TABLE table0 FROM table1";
+    one_statement_parses_to(
+        sql,
+        "SELECT * INTO TEMPORARY UNLOGGED TABLE table0 FROM table1",
+    );
 
     // Do not allow aliases here
     let sql = "SELECT * INTO table0 asdf FROM table1";


### PR DESCRIPTION
This PR adds support for `TABLE` keyword with `SELECT INTO` queries which is valid as per [PostgreSQL docs](https://www.postgresql.org/docs/current/sql-selectinto.html).
This allows processing queries like `SELECT * INTO TEMPORARY TABLE "tmp" FROM (SELECT 1 AS COL) AS CHECKTEMP` which otherwise would fail as `TABLE` would be parsed as a table name.