### PR TITLE
Correct typo: Rename `ArrayIndex::indexs` to `ArrayIndex::indexes`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -371,7 +371,7 @@ pub enum Expr {
     /// An array index expression e.g. `(ARRAY[1, 2])[1]` or `(current_schemas(FALSE))[1]`
     ArrayIndex {
         obj: Box<Expr>,
-        indexs: Vec<Expr>,
+        indexes: Vec<Expr>,
     },
     /// An array expression e.g. `ARRAY[1, 2]`
     Array(Array),
@@ -553,9 +553,9 @@ impl fmt::Display for Expr {
             Expr::Tuple(exprs) => {
                 write!(f, "({})", display_comma_separated(exprs))
             }
-            Expr::ArrayIndex { obj, indexs } => {
+            Expr::ArrayIndex { obj, indexes } => {
                 write!(f, "{}", obj)?;
-                for i in indexs {
+                for i in indexes {
                     write!(f, "[{}]", i)?;
                 }
                 Ok(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1234,15 +1234,15 @@ impl<'a> Parser<'a> {
     pub fn parse_array_index(&mut self, expr: Expr) -> Result<Expr, ParserError> {
         let index = self.parse_expr()?;
         self.expect_token(&Token::RBracket)?;
-        let mut indexs: Vec<Expr> = vec![index];
+        let mut indexes: Vec<Expr> = vec![index];
         while self.consume_token(&Token::LBracket) {
             let index = self.parse_expr()?;
             self.expect_token(&Token::RBracket)?;
-            indexs.push(index);
+            indexes.push(index);
         }
         Ok(Expr::ArrayIndex {
             obj: Box::new(expr),
-            indexs,
+            indexes,
         })
     }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1173,7 +1173,7 @@ fn parse_array_index_expr() {
     assert_eq!(
         &Expr::ArrayIndex {
             obj: Box::new(Expr::Identifier(Ident::new("foo"))),
-            indexs: vec![num[0].clone()],
+            indexes: vec![num[0].clone()],
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -1183,7 +1183,7 @@ fn parse_array_index_expr() {
     assert_eq!(
         &Expr::ArrayIndex {
             obj: Box::new(Expr::Identifier(Ident::new("foo"))),
-            indexs: vec![num[0].clone(), num[0].clone()],
+            indexes: vec![num[0].clone(), num[0].clone()],
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -1193,7 +1193,7 @@ fn parse_array_index_expr() {
     assert_eq!(
         &Expr::ArrayIndex {
             obj: Box::new(Expr::Identifier(Ident::new("bar"))),
-            indexs: vec![
+            indexes: vec![
                 num[0].clone(),
                 Expr::Identifier(Ident {
                     value: "baz".to_string(),
@@ -1224,7 +1224,7 @@ fn parse_array_index_expr() {
                     None
                 )))))
             }))),
-            indexs: vec![num[1].clone(), num[2].clone()],
+            indexes: vec![num[1].clone(), num[2].clone()],
         },
         expr_from_projection(only(&select.projection)),
     );


### PR DESCRIPTION
The correct spelling of the English plural form of `index` is `indexes` or `indicies` -- I chose to go with `indexes` as it is closer to the original in the code

This was added in #419