### PR TITLE
Support `UNNEST` as a table factor

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -361,7 +361,7 @@ pub enum TableFactor {
     /// +---------+--------+
     UNNEST {
         alias: Option<TableAlias>,
-        array_expr: Box<Expr>,
+        expr: Expr,
         with_offset: bool,
     },
     /// Represents a parenthesized table factor. The SQL spec only allows a
@@ -417,10 +417,10 @@ impl fmt::Display for TableFactor {
             }
             TableFactor::UNNEST {
                 alias,
-                array_expr,
+                expr,
                 with_offset,
             } => {
-                write!(f, "UNNEST({})", array_expr)?;
+                write!(f, "UNNEST({})", expr)?;
                 if let Some(alias) = alias {
                     write!(f, " AS {}", alias)?;
                 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -361,7 +361,7 @@ pub enum TableFactor {
     /// +---------+--------+
     UNNEST {
         alias: Option<TableAlias>,
-        expr: Expr,
+        array_expr: Box<Expr>,
         with_offset: bool,
     },
     /// Represents a parenthesized table factor. The SQL spec only allows a
@@ -417,10 +417,10 @@ impl fmt::Display for TableFactor {
             }
             TableFactor::UNNEST {
                 alias,
-                expr,
+                array_expr,
                 with_offset,
             } => {
-                write!(f, "UNNEST({})", expr)?;
+                write!(f, "UNNEST({})", array_expr)?;
                 if let Some(alias) = alias {
                     write!(f, " AS {}", alias)?;
                 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -351,6 +351,19 @@ pub enum TableFactor {
         expr: Expr,
         alias: Option<TableAlias>,
     },
+    /// SELECT * FROM UNNEST ([10,20,30]) as numbers WITH OFFSET;
+    /// +---------+--------+
+    /// | numbers | offset |
+    /// +---------+--------+
+    /// | 10      | 0      |
+    /// | 20      | 1      |
+    /// | 30      | 2      |
+    /// +---------+--------+
+    UNNEST {
+        alias: Option<TableAlias>,
+        array_expr: Box<Expr>,
+        with_offset: bool,
+    },
     /// Represents a parenthesized table factor. The SQL spec only allows a
     /// join expression (`(foo <JOIN> bar [ <JOIN> baz ... ])`) to be nested,
     /// possibly several times.
@@ -399,6 +412,20 @@ impl fmt::Display for TableFactor {
                 write!(f, "TABLE({})", expr)?;
                 if let Some(alias) = alias {
                     write!(f, " AS {}", alias)?;
+                }
+                Ok(())
+            }
+            TableFactor::UNNEST {
+                alias,
+                array_expr,
+                with_offset,
+            } => {
+                write!(f, "UNNEST({})", array_expr)?;
+                if let Some(alias) = alias {
+                    write!(f, " AS {}", alias)?;
+                }
+                if *with_offset {
+                    write!(f, " WITH OFFSET")?;
                 }
                 Ok(())
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3627,7 +3627,7 @@ impl<'a> Parser<'a> {
 
             Ok(TableFactor::UNNEST {
                 alias,
-                expr,
+                array_expr: Box::new(expr),
                 with_offset,
             })
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3627,7 +3627,7 @@ impl<'a> Parser<'a> {
 
             Ok(TableFactor::UNNEST {
                 alias,
-                array_expr: Box::new(expr),
+                expr,
                 with_offset,
             })
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3609,27 +3609,32 @@ impl<'a> Parser<'a> {
                 // appearing alone in parentheses (e.g. `FROM (mytable)`)
                 self.expected("joined table", self.peek_token())
             }
-        } else if self.parse_keyword(Keyword::UNNEST) {
-            self.expect_token(&Token::LParen)?;
-            let expr = self.parse_expr()?;
-            self.expect_token(&Token::RParen)?;
+        } else if dialect_of!(self is BigQueryDialect | GenericDialect) {
+            if self.parse_keyword(Keyword::UNNEST) {
+                self.expect_token(&Token::LParen)?;
+                let expr = self.parse_expr()?;
+                self.expect_token(&Token::RParen)?;
 
-            let alias = match self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS) {
-                Ok(Some(alias)) => Some(alias),
-                Ok(None) => None,
-                Err(e) => return Err(e),
-            };
+                let alias =
+                    match self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS) {
+                        Ok(Some(alias)) => Some(alias),
+                        Ok(None) => None,
+                        Err(e) => return Err(e),
+                    };
 
-            let with_offset = match self.expect_keywords(&[Keyword::WITH, Keyword::OFFSET]) {
-                Ok(()) => true,
-                Err(_) => false,
-            };
+                let with_offset = match self.expect_keywords(&[Keyword::WITH, Keyword::OFFSET]) {
+                    Ok(()) => true,
+                    Err(_) => false,
+                };
 
-            Ok(TableFactor::UNNEST {
-                alias,
-                array_expr: Box::new(expr),
-                with_offset,
-            })
+                Ok(TableFactor::UNNEST {
+                    alias,
+                    array_expr: Box::new(expr),
+                    with_offset,
+                })
+            } else {
+                self.expected("UNNEST", self.peek_token())
+            }
         } else {
             let name = self.parse_object_name()?;
             // Postgres, MSSQL: table-valued functions:

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2779,13 +2779,23 @@ fn parse_table_function() {
 
 #[test]
 fn parse_unnest() {
+    fn chk(alias: bool, with_offset: bool, dialects: &TestedDialects, want: Vec<TableWithJoins>) {
+        let sql = &format!(
+            "SELECT * FROM UNNEST(expr){}{}",
+            if alias { " AS numbers" } else { "" },
+            if with_offset { " WITH OFFSET" } else { "" },
+        );
+        let select = dialects.verified_only_select(sql);
+        assert_eq!(select.from, want);
+    }
     let dialects = TestedDialects {
         dialects: vec![Box::new(BigQueryDialect {}), Box::new(GenericDialect {})],
     };
-    let sql = "SELECT * FROM UNNEST(expr) AS numbers WITH OFFSET";
-    let select = dialects.verified_only_select(sql);
-    assert_eq!(
-        select.from,
+    // 1. both Alias and WITH OFFSET clauses.
+    chk(
+        true,
+        true,
+        &dialects,
         vec![TableWithJoins {
             relation: TableFactor::UNNEST {
                 alias: Some(TableAlias {
@@ -2796,7 +2806,52 @@ fn parse_unnest() {
                 with_offset: true,
             },
             joins: vec![],
-        }]
+        }],
+    );
+    // 2. neither Alias nor WITH OFFSET clause.
+    chk(
+        false,
+        false,
+        &dialects,
+        vec![TableWithJoins {
+            relation: TableFactor::UNNEST {
+                alias: None,
+                array_expr: Box::new(Expr::Identifier(Ident::new("expr"))),
+                with_offset: false,
+            },
+            joins: vec![],
+        }],
+    );
+    // 3. Alias but no WITH OFFSET clause.
+    chk(
+        false,
+        true,
+        &dialects,
+        vec![TableWithJoins {
+            relation: TableFactor::UNNEST {
+                alias: None,
+                array_expr: Box::new(Expr::Identifier(Ident::new("expr"))),
+                with_offset: true,
+            },
+            joins: vec![],
+        }],
+    );
+    // 4. WITH OFFSET but no Alias.
+    chk(
+        true,
+        false,
+        &dialects,
+        vec![TableWithJoins {
+            relation: TableFactor::UNNEST {
+                alias: Some(TableAlias {
+                    name: Ident::new("numbers"),
+                    columns: vec![],
+                }),
+                array_expr: Box::new(Expr::Identifier(Ident::new("expr"))),
+                with_offset: false,
+            },
+            joins: vec![],
+        }],
     );
 }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2779,9 +2779,22 @@ fn parse_table_function() {
 
 #[test]
 fn parse_unnest() {
-    let sql = "SELECT * FROM UNNEST([10, 20, 30]) as numbers WITH OFFSET";
+    let sql = "SELECT * FROM UNNEST(expr) AS numbers WITH OFFSET";
     let select = verified_only_select(sql);
-    println!("{:?}", select);
+    assert_eq!(
+        select.from,
+        vec![TableWithJoins {
+            relation: TableFactor::UNNEST {
+                alias: Some(TableAlias {
+                    name: Ident::new("numbers"),
+                    columns: vec![],
+                }),
+                expr: Expr::Identifier(Ident::new("expr")),
+                with_offset: true,
+            },
+            joins: vec![],
+        }]
+    );
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2779,8 +2779,11 @@ fn parse_table_function() {
 
 #[test]
 fn parse_unnest() {
+    let dialects = TestedDialects {
+        dialects: vec![Box::new(BigQueryDialect {}), Box::new(GenericDialect {})],
+    };
     let sql = "SELECT * FROM UNNEST(expr) AS numbers WITH OFFSET";
-    let select = verified_only_select(sql);
+    let select = dialects.verified_only_select(sql);
     assert_eq!(
         select.from,
         vec![TableWithJoins {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2778,6 +2778,13 @@ fn parse_table_function() {
 }
 
 #[test]
+fn parse_unnest() {
+    let sql = "SELECT * FROM UNNEST([10, 20, 30]) as numbers WITH OFFSET";
+    let select = verified_only_select(sql);
+    println!("{:?}", select);
+}
+
+#[test]
 fn parse_delimited_identifiers() {
     // check that quoted identifiers in any position remain quoted after serialization
     let select = verified_only_select(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2789,7 +2789,7 @@ fn parse_unnest() {
                     name: Ident::new("numbers"),
                     columns: vec![],
                 }),
-                expr: Expr::Identifier(Ident::new("expr")),
+                array_expr: Box::new(Expr::Identifier(Ident::new("expr"))),
                 with_offset: true,
             },
             joins: vec![],


### PR DESCRIPTION
This PR adds support `UNNEST` for BigQuery.

```
from_item:
    {
      table_name [ as_alias ] [ FOR SYSTEM_TIME AS OF timestamp_expression ]
      | { join_operation | ( join_operation ) }
      | ( query_expr ) [ as_alias ]
      | field_path
      | unnest_operator
      | cte_name [ as_alias ]
    }

unnest_operator:
    {
      [UNNEST](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unnest)( array_expression )
      | UNNEST( array_path )
      | array_path
    }
    [ as_alias ]
    [ WITH OFFSET [ as_alias ] ]
```

https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unnest_operator