### PR TITLE
set: allow negative ident values

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3287,6 +3287,16 @@ impl<'a> Parser<'a> {
                 let value = match (self.parse_value(), token) {
                     (Ok(value), _) => SetVariableValue::Literal(value),
                     (Err(_), Token::Word(ident)) => SetVariableValue::Ident(ident.to_ident()),
+                    (Err(_), Token::Minus) => {
+                        let next_token = self.next_token();
+                        match next_token {
+                            Token::Word(ident) => SetVariableValue::Ident(Ident {
+                                quote_style: ident.quote_style,
+                                value: format!("-{}", ident.value),
+                            }),
+                            _ => self.expected("word", next_token)?,
+                        }
+                    }
                     (Err(_), unexpected) => self.expected("variable value", unexpected)?,
                 };
                 values.push(value);


### PR DESCRIPTION
Sometimes, SET statement values can start with `Token::Minus`. For example - as in test -  setting Java's properties.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>