### PR TITLE
feat: Convert IS TRUE|FALSE to expression

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -233,6 +233,10 @@ pub enum Expr {
     },
     /// CompositeAccess (postgres) eg: SELECT (information_schema._pg_expandarray(array['i','i'])).n
     CompositeAccess { expr: Box<Expr>, key: Ident },
+    /// `IS FALSE` operator
+    IsFalse(Box<Expr>),
+    /// `IS TRUE` operator
+    IsTrue(Box<Expr>),
     /// `IS NULL` operator
     IsNull(Box<Expr>),
     /// `IS NOT NULL` operator
@@ -379,6 +383,8 @@ impl fmt::Display for Expr {
                 Ok(())
             }
             Expr::CompoundIdentifier(s) => write!(f, "{}", display_separated(s, ".")),
+            Expr::IsTrue(ast) => write!(f, "{} IS TRUE", ast),
+            Expr::IsFalse(ast) => write!(f, "{} IS FALSE", ast),
             Expr::IsNull(ast) => write!(f, "{} IS NULL", ast),
             Expr::IsNotNull(ast) => write!(f, "{} IS NOT NULL", ast),
             Expr::InList {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1155,6 +1155,10 @@ impl<'a> Parser<'a> {
                         Ok(Expr::IsNull(Box::new(expr)))
                     } else if self.parse_keywords(&[Keyword::NOT, Keyword::NULL]) {
                         Ok(Expr::IsNotNull(Box::new(expr)))
+                    } else if self.parse_keywords(&[Keyword::TRUE]) {
+                        Ok(Expr::IsTrue(Box::new(expr)))
+                    } else if self.parse_keywords(&[Keyword::FALSE]) {
+                        Ok(Expr::IsFalse(Box::new(expr)))
                     } else if self.parse_keywords(&[Keyword::DISTINCT, Keyword::FROM]) {
                         let expr2 = self.parse_expr()?;
                         Ok(Expr::IsDistinctFrom(Box::new(expr), Box::new(expr2)))
@@ -1162,21 +1166,9 @@ impl<'a> Parser<'a> {
                     {
                         let expr2 = self.parse_expr()?;
                         Ok(Expr::IsNotDistinctFrom(Box::new(expr), Box::new(expr2)))
-                    } else if let Some(right) =
-                        self.parse_one_of_keywords(&[Keyword::TRUE, Keyword::FALSE])
-                    {
-                        let mut val = Value::Boolean(true);
-                        if right == Keyword::FALSE {
-                            val = Value::Boolean(false);
-                        }
-                        Ok(Expr::BinaryOp {
-                            left: Box::new(expr),
-                            op: BinaryOperator::Eq,
-                            right: Box::new(Expr::Value(val)),
-                        })
                     } else {
                         self.expected(
-                            "[NOT] NULL or [NOT] DISTINCT FROM TRUE FALSE after IS",
+                            "[NOT] NULL or TRUE|FALSE or [NOT] DISTINCT FROM after IS",
                             self.peek_token(),
                         )
                     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4768,21 +4768,30 @@ fn parse_position_negative() {
 
 #[test]
 fn parse_is_boolean() {
-    one_statement_parses_to(
-        "SELECT f from foo where field is true",
-        "SELECT f FROM foo WHERE field = true",
+    use self::Expr::*;
+
+    let sql = "a IS FALSE";
+    assert_eq!(
+        IsFalse(Box::new(Identifier(Ident::new("a")))),
+        verified_expr(sql)
     );
 
-    one_statement_parses_to(
-        "SELECT f from foo where field is false",
-        "SELECT f FROM foo WHERE field = false",
+    let sql = "a IS TRUE";
+    assert_eq!(
+        IsTrue(Box::new(Identifier(Ident::new("a")))),
+        verified_expr(sql)
     );
+
+    verified_stmt("SELECT f FROM foo WHERE field IS TRUE");
+
+    verified_stmt("SELECT f FROM foo WHERE field IS FALSE");
 
     let sql = "SELECT f from foo where field is 0";
     let res = parse_sql_statements(sql);
     assert_eq!(
         ParserError::ParserError(
-            "Expected [NOT] NULL or [NOT] DISTINCT FROM TRUE FALSE after IS, found: 0".to_string()
+            "Expected [NOT] NULL or TRUE|FALSE or [NOT] DISTINCT FROM after IS, found: 0"
+                .to_string()
         ),
         res.unwrap_err()
     );


### PR DESCRIPTION
Hello!

Support for `IS TRUE|FALSE` operator was introduced in https://github.com/sqlparser-rs/sqlparser-rs/pull/474 by [yuval-illumex](https://github.com/yuval-illumex), but it has a limitation.

There is a difference between `IS TRUE|false` and `= true|false`, it how it handles nulls:

```sql
CREATE TABLE test_boolean (
    col boolean
);
INSERT INTO test_boolean VALUES (true), (false), (null);
SELECT col, col IS FALSE, col = false, col is true, col = true from test_boolean;
```

<img width="698" alt="image" src="https://user-images.githubusercontent.com/572096/168888038-95e911a9-9de8-454f-a126-e72bdb90fb98.png">

As you can see from the output, it handles `null` values differently.

Thanks