### PR TITLE
Prevent stack overflows by limiting recursion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["std"]
-std = []
+std = ["scopeguard"]
 # Enable JSON output in the `cli` example:
 json_example = ["serde_json", "serde"]
 
@@ -32,6 +32,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 # of dev-dependencies because of
 # https://github.com/rust-lang/cargo/issues/1596
 serde_json = { version = "1.0", optional = true }
+scopeguard = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 simple_logger = "2.1"

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4944,3 +4944,10 @@ fn parse_discard() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn parse_with_lots_of_stack_recursion() {
+    let sql = "(".repeat(1000);
+    let res = parse_sql_statements(&sql);
+    assert_eq!(ParserError::RecursionLimitExceeded, res.unwrap_err());
+}


### PR DESCRIPTION
Addresses #305

Until now it has been possible to trigger a stack overflow by passing crafted inputs (e.g. a string of 1000 `(`). This is problematic when using the library to parse user input.

This commit adds a recursion limit so long as the library is compiled with `std`. The limit ensures that malicious inputs cannot trigger a stack overflow, by preventing excessively deep recursion.

Since the SQL parser is so big, I've added this protection to every `Parser` method that returns a `Result`. The actual recursive patterns in the AST are more limited, but with such a large parser it's much harder to identify them and put targeted protections in place.