### PR TITLE
feat: Support escaped string literals (PostgreSQL)

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -30,6 +30,8 @@ pub enum Value {
     Number(BigDecimal, bool),
     /// 'string value'
     SingleQuotedString(String),
+    /// e'string value'
+    EscapedStringLiteral(String),
     /// N'string value'
     NationalStringLiteral(String),
     /// X'hex value'
@@ -69,6 +71,7 @@ impl fmt::Display for Value {
             Value::Number(v, l) => write!(f, "{}{long}", v, long = if *l { "L" } else { "" }),
             Value::DoubleQuotedString(v) => write!(f, "\"{}\"", v),
             Value::SingleQuotedString(v) => write!(f, "'{}'", escape_single_quote_string(v)),
+            Value::EscapedStringLiteral(v) => write!(f, "E'{}'", escape_escaped_string(v)),
             Value::NationalStringLiteral(v) => write!(f, "N'{}'", v),
             Value::HexStringLiteral(v) => write!(f, "X'{}'", v),
             Value::Boolean(v) => write!(f, "{}", v),
@@ -191,6 +194,40 @@ impl<'a> fmt::Display for EscapeSingleQuoteString<'a> {
 
 pub fn escape_single_quote_string(s: &str) -> EscapeSingleQuoteString<'_> {
     EscapeSingleQuoteString(s)
+}
+
+pub struct EscapeEscapedStringLiteral<'a>(&'a str);
+
+impl<'a> fmt::Display for EscapeEscapedStringLiteral<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut is_escaped = true;
+
+        for c in self.0.chars() {
+            match c {
+                '\'' => {
+                    write!(f, "\'\'")?;
+                }
+                '\\' => {
+                    if is_escaped {
+                        write!(f, r#"\\"#)?;
+                    } else {
+                        is_escaped = true;
+                    }
+                }
+                '\n' => {
+                    write!(f, r#"\n"#)?;
+                }
+                _ => {
+                    write!(f, "{}", c)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn escape_escaped_string(s: &str) -> EscapeEscapedStringLiteral<'_> {
+    EscapeEscapedStringLiteral(s)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -496,6 +496,10 @@ impl<'a> Parser<'a> {
                     expr: Box::new(self.parse_subexpr(Self::PLUS_MINUS_PREC)?),
                 })
             }
+            Token::EscapedStringLiteral(_) if dialect_of!(self is PostgreSqlDialect) => {
+                self.prev_token();
+                Ok(Expr::Value(self.parse_value()?))
+            }
             Token::Number(_, _)
             | Token::SingleQuotedString(_)
             | Token::NationalStringLiteral(_)
@@ -901,6 +905,7 @@ impl<'a> Parser<'a> {
                         None
                     }
                     Token::SingleQuotedString(_)
+                    | Token::EscapedStringLiteral(_)
                     | Token::NationalStringLiteral(_)
                     | Token::HexStringLiteral(_) => Some(Box::new(self.parse_expr()?)),
                     unexpected => {
@@ -2565,6 +2570,7 @@ impl<'a> Parser<'a> {
             },
             Token::SingleQuotedString(ref s) => Ok(Value::SingleQuotedString(s.to_string())),
             Token::NationalStringLiteral(ref s) => Ok(Value::NationalStringLiteral(s.to_string())),
+            Token::EscapedStringLiteral(ref s) => Ok(Value::EscapedStringLiteral(s.to_string())),
             Token::HexStringLiteral(ref s) => Ok(Value::HexStringLiteral(s.to_string())),
             Token::Placeholder(ref s) => Ok(Value::Placeholder(s.to_string())),
             unexpected => self.expected("a value", unexpected),
@@ -2596,6 +2602,7 @@ impl<'a> Parser<'a> {
         match self.next_token() {
             Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => Ok(value),
             Token::SingleQuotedString(s) => Ok(s),
+            Token::EscapedStringLiteral(s) if dialect_of!(self is PostgreSqlDialect) => Ok(s),
             unexpected => self.expected("literal string", unexpected),
         }
     }


### PR DESCRIPTION
Hello!

It's a draft which implements special PostgreSQL escaped string syntax.

https://www.postgresql.org/docs/8.3/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS

> PostgreSQL also accepts "escape" string constants, which are an extension to the SQL standard. An escape string constant is specified by writing the letter E (upper or lower case) just before the opening single quote, e.g. E'foo'. (When continuing an escape string constant across lines, write E only before the first opening quote.) Within an escape string, a backslash character (\) begins a C-like backslash escape sequence, in which the combination of backslash and following character(s) represents a special byte value. \b is a backspace, \f is a form feed, \n is a newline, \r is a carriage return, \t is a tab.

<img width="622" alt="image" src="https://user-images.githubusercontent.com/572096/169123792-e4f16713-8caa-4e91-b13a-dd255de76bd5.png">

Thanks