### PR TITLE
Fix escaping of trailing quote in quoted identifiers

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -23,7 +23,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::fmt::{self, Write};
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -128,16 +128,8 @@ impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.quote_style {
             Some(q) if q == '"' || q == '\'' || q == '`' => {
-                f.write_char(q)?;
-                let mut first = true;
-                for s in self.value.split_inclusive(q) {
-                    if !first {
-                        f.write_char(q)?;
-                    }
-                    first = false;
-                    f.write_str(s)?;
-                }
-                f.write_char(q)
+                let escaped = value::escape_quoted_string(&self.value, q);
+                write!(f, "{}{}{}", q, escaped, q)
             }
             Some(q) if q == '[' => write!(f, "[{}]", self.value),
             None => f.write_str(&self.value),

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -174,13 +174,16 @@ impl fmt::Display for DateTimeField {
     }
 }
 
-pub struct EscapeSingleQuoteString<'a>(&'a str);
+pub struct EscapeQuotedString<'a> {
+    string: &'a str,
+    quote: char,
+}
 
-impl<'a> fmt::Display for EscapeSingleQuoteString<'a> {
+impl<'a> fmt::Display for EscapeQuotedString<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for c in self.0.chars() {
-            if c == '\'' {
-                write!(f, "\'\'")?;
+        for c in self.string.chars() {
+            if c == self.quote {
+                write!(f, "{q}{q}", q = self.quote)?;
             } else {
                 write!(f, "{}", c)?;
             }
@@ -189,8 +192,12 @@ impl<'a> fmt::Display for EscapeSingleQuoteString<'a> {
     }
 }
 
-pub fn escape_single_quote_string(s: &str) -> EscapeSingleQuoteString<'_> {
-    EscapeSingleQuoteString(s)
+pub fn escape_quoted_string(string: &str, quote: char) -> EscapeQuotedString<'_> {
+    EscapeQuotedString { string, quote }
+}
+
+pub fn escape_single_quote_string(s: &str) -> EscapeQuotedString<'_> {
+    escape_quoted_string(s, '\'')
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -293,7 +293,7 @@ fn parse_quote_identifiers() {
 
 #[test]
 fn parse_quote_identifiers_2() {
-    let sql = "SELECT `quoted `` identifier`";
+    let sql = "SELECT ```quoted `` identifier```";
     assert_eq!(
         mysql().verified_stmt(sql),
         Statement::Query(Box::new(Query {
@@ -302,7 +302,7 @@ fn parse_quote_identifiers_2() {
                 distinct: false,
                 top: None,
                 projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-                    value: "quoted ` identifier".into(),
+                    value: "`quoted ` identifier`".into(),
                     quote_style: Some('`'),
                 }))],
                 into: None,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -293,7 +293,7 @@ fn parse_quote_identifiers() {
 
 #[test]
 fn parse_quote_identifiers_2() {
-    let sql = "SELECT ```quoted `` identifier```";
+    let sql = "SELECT `quoted `` identifier`";
     assert_eq!(
         mysql().verified_stmt(sql),
         Statement::Query(Box::new(Query {
@@ -302,7 +302,41 @@ fn parse_quote_identifiers_2() {
                 distinct: false,
                 top: None,
                 projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-                    value: "`quoted ` identifier`".into(),
+                    value: "quoted ` identifier".into(),
+                    quote_style: Some('`'),
+                }))],
+                into: None,
+                from: vec![],
+                lateral_views: vec![],
+                selection: None,
+                group_by: vec![],
+                cluster_by: vec![],
+                distribute_by: vec![],
+                sort_by: vec![],
+                having: None,
+                qualify: None
+            })),
+            order_by: vec![],
+            limit: None,
+            offset: None,
+            fetch: None,
+            lock: None,
+        }))
+    );
+}
+
+#[test]
+fn parse_quote_identifiers_3() {
+    let sql = "SELECT ```quoted identifier```";
+    assert_eq!(
+        mysql().verified_stmt(sql),
+        Statement::Query(Box::new(Query {
+            with: None,
+            body: SetExpr::Select(Box::new(Select {
+                distinct: false,
+                top: None,
+                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
+                    value: "`quoted identifier`".into(),
                     quote_style: Some('`'),
                 }))],
                 into: None,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1438,7 +1438,12 @@ fn parse_comments() {
 
 #[test]
 fn parse_quoted_identifier() {
-    pg_and_generic().verified_stmt(r#"SELECT """quoted "" ident""""#);
+    pg_and_generic().verified_stmt(r#"SELECT "quoted "" ident""#);
+}
+
+#[test]
+fn parse_quoted_identifier_2() {
+    pg_and_generic().verified_stmt(r#"SELECT """quoted ident""""#);
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1438,7 +1438,7 @@ fn parse_comments() {
 
 #[test]
 fn parse_quoted_identifier() {
-    pg_and_generic().verified_stmt(r#"SELECT "quoted "" ident""#);
+    pg_and_generic().verified_stmt(r#"SELECT """quoted "" ident""""#);
 }
 
 #[test]


### PR DESCRIPTION
The current `Display` impl for `Ident`
https://github.com/sqlparser-rs/sqlparser-rs/blob/a6d7a35dacbcfe282d1cae83916505c6294edf4e/src/ast/mod.rs#L130-L141
fails to escape a quote (', " or \`) when it's the last character in the identifier's value. Specifically, this quote is only written to the string once, rather than twice. For example, `Ident::with_quote('\'', "quoted'").to_string()` returns `"'quoted''"` (with two trailing single quotes) instead of `"'quoted'''"` (with three trailing single quotes — two for the escaped quote and one for the identifier's closing quote). This is because escaping is implemented by prepending an additional quote to each of the substrings returned by `split_inclusive` (except for the first), but `split_inclusive` (unlike `split`) *doesn't* return an empty substring after a trailing separator character.

Instead of trying to fix this code directly, I've reused the `EscapeSingleQuoteString` struct, which already provided a correct implementation of escaping for single-quoted strings, and was easily generalized to work with an arbitrary quote character.