### PR TITLE
Distinguish between `SELECT * FROM foo` and `SELECT * FROM foo()`

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -337,7 +337,11 @@ pub enum TableFactor {
         /// Arguments of a table-valued function, as supported by Postgres
         /// and MSSQL. Note that deprecated MSSQL `FROM foo (NOLOCK)` syntax
         /// will also be parsed as `args`.
-        args: Vec<FunctionArg>,
+        ///
+        /// This field's value is `Some(v)`, where `v` is a (possibly empty)
+        /// vector of arguments, in the case of a table-valued function call,
+        /// whereas it's `None` in the case of a regular table name.
+        args: Option<Vec<FunctionArg>>,
         /// MSSQL-specific `WITH (...)` hints such as NOLOCK.
         with_hints: Vec<Expr>,
     },
@@ -370,7 +374,7 @@ impl fmt::Display for TableFactor {
                 with_hints,
             } => {
                 write!(f, "{}", name)?;
-                if !args.is_empty() {
+                if let Some(args) = args {
                     write!(f, "({})", display_comma_separated(args))?;
                 }
                 if let Some(alias) = alias {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3620,9 +3620,9 @@ impl<'a> Parser<'a> {
             let name = self.parse_object_name()?;
             // Postgres, MSSQL: table-valued functions:
             let args = if self.consume_token(&Token::LParen) {
-                self.parse_optional_args()?
+                Some(self.parse_optional_args()?)
             } else {
-                vec![]
+                None
             };
             let alias = self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS)?;
             // MSSQL-specific table hints:

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -177,7 +177,7 @@ pub fn table(name: impl Into<String>) -> TableFactor {
     TableFactor::Table {
         name: ObjectName(vec![Ident::new(name.into())]),
         alias: None,
-        args: vec![],
+        args: None,
         with_hints: vec![],
     }
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -29,7 +29,7 @@ fn parse_table_identifiers() {
                 relation: TableFactor::Table {
                     name: ObjectName(expected),
                     alias: None,
-                    args: vec![],
+                    args: None,
                     with_hints: vec![],
                 },
                 joins: vec![]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -200,7 +200,7 @@ fn parse_update_with_table_alias() {
                             name: Ident::new("u"),
                             columns: vec![]
                         }),
-                        args: vec![],
+                        args: None,
                         with_hints: vec![],
                     },
                     joins: vec![]
@@ -2793,7 +2793,7 @@ fn parse_delimited_identifiers() {
         } => {
             assert_eq!(vec![Ident::with_quote('"', "a table")], name.0);
             assert_eq!(Ident::with_quote('"', "alias"), alias.unwrap().name);
-            assert!(args.is_empty());
+            assert!(args.is_none());
             assert!(with_hints.is_empty());
         }
         _ => panic!("Expecting TableFactor::Table"),
@@ -2913,6 +2913,12 @@ fn parse_from_advanced() {
 }
 
 #[test]
+fn parse_nullary_table_valued_function() {
+    let sql = "SELECT * FROM fn()";
+    let _select = verified_only_select(sql);
+}
+
+#[test]
 fn parse_implicit_join() {
     let sql = "SELECT * FROM t1, t2";
     let select = verified_only_select(sql);
@@ -2922,7 +2928,7 @@ fn parse_implicit_join() {
                 relation: TableFactor::Table {
                     name: ObjectName(vec!["t1".into()]),
                     alias: None,
-                    args: vec![],
+                    args: None,
                     with_hints: vec![],
                 },
                 joins: vec![],
@@ -2931,7 +2937,7 @@ fn parse_implicit_join() {
                 relation: TableFactor::Table {
                     name: ObjectName(vec!["t2".into()]),
                     alias: None,
-                    args: vec![],
+                    args: None,
                     with_hints: vec![],
                 },
                 joins: vec![],
@@ -2948,14 +2954,14 @@ fn parse_implicit_join() {
                 relation: TableFactor::Table {
                     name: ObjectName(vec!["t1a".into()]),
                     alias: None,
-                    args: vec![],
+                    args: None,
                     with_hints: vec![],
                 },
                 joins: vec![Join {
                     relation: TableFactor::Table {
                         name: ObjectName(vec!["t1b".into()]),
                         alias: None,
-                        args: vec![],
+                        args: None,
                         with_hints: vec![],
                     },
                     join_operator: JoinOperator::Inner(JoinConstraint::Natural),
@@ -2965,14 +2971,14 @@ fn parse_implicit_join() {
                 relation: TableFactor::Table {
                     name: ObjectName(vec!["t2a".into()]),
                     alias: None,
-                    args: vec![],
+                    args: None,
                     with_hints: vec![],
                 },
                 joins: vec![Join {
                     relation: TableFactor::Table {
                         name: ObjectName(vec!["t2b".into()]),
                         alias: None,
-                        args: vec![],
+                        args: None,
                         with_hints: vec![],
                     },
                     join_operator: JoinOperator::Inner(JoinConstraint::Natural),
@@ -2992,7 +2998,7 @@ fn parse_cross_join() {
             relation: TableFactor::Table {
                 name: ObjectName(vec![Ident::new("t2")]),
                 alias: None,
-                args: vec![],
+                args: None,
                 with_hints: vec![],
             },
             join_operator: JoinOperator::CrossJoin
@@ -3012,7 +3018,7 @@ fn parse_joins_on() {
             relation: TableFactor::Table {
                 name: ObjectName(vec![Ident::new(relation.into())]),
                 alias,
-                args: vec![],
+                args: None,
                 with_hints: vec![],
             },
             join_operator: f(JoinConstraint::On(Expr::BinaryOp {
@@ -3065,7 +3071,7 @@ fn parse_joins_using() {
             relation: TableFactor::Table {
                 name: ObjectName(vec![Ident::new(relation.into())]),
                 alias,
-                args: vec![],
+                args: None,
                 with_hints: vec![],
             },
             join_operator: f(JoinConstraint::Using(vec!["c1".into()])),
@@ -3110,7 +3116,7 @@ fn parse_natural_join() {
             relation: TableFactor::Table {
                 name: ObjectName(vec![Ident::new("t2")]),
                 alias: None,
-                args: vec![],
+                args: None,
                 with_hints: vec![],
             },
             join_operator: f(JoinConstraint::Natural),
@@ -3348,7 +3354,7 @@ fn parse_derived_tables() {
                 relation: TableFactor::Table {
                     name: ObjectName(vec!["t2".into()]),
                     alias: None,
-                    args: vec![],
+                    args: None,
                     with_hints: vec![],
                 },
                 join_operator: JoinOperator::Inner(JoinConstraint::Natural),
@@ -4431,7 +4437,7 @@ fn parse_merge() {
                         name: Ident::new("dest"),
                         columns: vec![]
                     }),
-                    args: vec![],
+                    args: None,
                     with_hints: vec![]
                 }
             );
@@ -4452,7 +4458,7 @@ fn parse_merge() {
                                 relation: TableFactor::Table {
                                     name: ObjectName(vec![Ident::new("s"), Ident::new("foo")]),
                                     alias: None,
-                                    args: vec![],
+                                    args: None,
                                     with_hints: vec![]
                                 },
                                 joins: vec![]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -626,7 +626,7 @@ fn parse_update_with_joins() {
                             name: Ident::new("o"),
                             columns: vec![]
                         }),
-                        args: vec![],
+                        args: None,
                         with_hints: vec![],
                     },
                     joins: vec![Join {
@@ -636,7 +636,7 @@ fn parse_update_with_joins() {
                                 name: Ident::new("c"),
                                 columns: vec![]
                             }),
-                            args: vec![],
+                            args: None,
                             with_hints: vec![],
                         },
                         join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
@@ -743,7 +743,7 @@ fn parse_substring_in_select() {
                                     quote_style: None
                                 }]),
                                 alias: None,
-                                args: vec![],
+                                args: None,
                                 with_hints: vec![]
                             },
                             joins: vec![]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -413,7 +413,7 @@ fn parse_update_set_from() {
                 relation: TableFactor::Table {
                     name: ObjectName(vec![Ident::new("t1")]),
                     alias: None,
-                    args: vec![],
+                    args: None,
                     with_hints: vec![],
                 },
                 joins: vec![],
@@ -439,7 +439,7 @@ fn parse_update_set_from() {
                                 relation: TableFactor::Table {
                                     name: ObjectName(vec![Ident::new("t1")]),
                                     alias: None,
-                                    args: vec![],
+                                    args: None,
                                     with_hints: vec![],
                                 },
                                 joins: vec![],

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -43,7 +43,7 @@ fn test_square_brackets_over_db_schema_table_name() {
                     }
                 ]),
                 alias: None,
-                args: vec![],
+                args: None,
                 with_hints: vec![],
             },
             joins: vec![],
@@ -87,7 +87,7 @@ fn test_double_quotes_over_db_schema_table_name() {
                     }
                 ]),
                 alias: None,
-                args: vec![],
+                args: None,
                 with_hints: vec![],
             },
             joins: vec![],

--- a/tests/sqpparser_clickhouse.rs
+++ b/tests/sqpparser_clickhouse.rs
@@ -58,7 +58,7 @@ fn parse_map_access_expr() {
                 relation: Table {
                     name: ObjectName(vec![Ident::new("foos")]),
                     alias: None,
-                    args: vec![],
+                    args: None,
                     with_hints: vec![],
                 },
                 joins: vec![]


### PR DESCRIPTION
Fixes #405. As stated in that issue,

> This is apparently a regression that was introduced in https://github.com/sqlparser-rs/sqlparser-rs/commit/5652b4676c65f0875fd8c4849dd7cb27c819bef6 (https://github.com/sqlparser-rs/sqlparser-rs/pull/73)

To fix it, I reintroduced the `Option` around the vector of arguments, which was removed in 5652b4676c65f0875fd8c4849dd7cb27c819bef6 even though it wasn't actually redundant. I also added a test which ensures that `SELECT * FROM fn()` is not modified after a serialization round-trip, and I added a brief explanation of the different meanings of `None` and `Some` (including `Some(vec![])`) to the documentation.