### PR TITLE
Fix parsing of `COLLATE` after parentheses in expressions

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -520,17 +520,18 @@ impl<'a> Parser<'a> {
                     };
                 self.expect_token(&Token::RParen)?;
                 if !self.consume_token(&Token::Period) {
-                    return Ok(expr);
+                    Ok(expr)
+                } else {
+                    let tok = self.next_token();
+                    let key = match tok {
+                        Token::Word(word) => word.to_ident(),
+                        _ => return parser_err!(format!("Expected identifier, found: {}", tok)),
+                    };
+                    Ok(Expr::CompositeAccess {
+                        expr: Box::new(expr),
+                        key,
+                    })
                 }
-                let tok = self.next_token();
-                let key = match tok {
-                    Token::Word(word) => word.to_ident(),
-                    _ => return parser_err!(format!("Expected identifier, found: {}", tok)),
-                };
-                Ok(Expr::CompositeAccess {
-                    expr: Box::new(expr),
-                    key,
-                })
             }
             Token::Placeholder(_) => {
                 self.prev_token();

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -562,6 +562,15 @@ fn parse_collate() {
 }
 
 #[test]
+fn parse_collate_after_parens() {
+    let sql = "SELECT (name) COLLATE \"de_DE\" FROM customer";
+    assert_matches!(
+        only(&all_dialects().verified_only_select(sql).projection),
+        SelectItem::UnnamedExpr(Expr::Collate { .. })
+    );
+}
+
+#[test]
 fn parse_select_string_predicate() {
     let sql = "SELECT id, fname, lname FROM customer \
                WHERE salary <> 'Not Provided' AND salary <> ''";


### PR DESCRIPTION
Version 0.17.0 fails to parse `COLLATE` after an expression that's surrounded by parentheses, like `(name) COLLATE "de_DE"`. This regression was introduced by da6a17bcf8b93aa9d7cf89c3e67c1472ae59a981 (#466), where an "early `return`" is used to return the parsed expression when the closing parenthesis isn't followed by a period, https://github.com/sqlparser-rs/sqlparser-rs/blob/4070f3ec6e616be6e9249f7202338e0f05969237/src/parser.rs#L521-L524 but this `return` causes the code which parses `COLLATE` https://github.com/sqlparser-rs/sqlparser-rs/blob/4070f3ec6e616be6e9249f7202338e0f05969237/src/parser.rs#L542-L549 to be skipped.

Replacing the early `return` with `if`-`else` fixes this regression, as verified by a test that I've added.