### PR TITLE
Support `DATETIME` keyword

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -71,6 +71,8 @@ pub enum DataType {
     Date,
     /// Time
     Time,
+    /// Datetime
+    Datetime,
     /// Timestamp
     Timestamp,
     /// Interval
@@ -143,6 +145,7 @@ impl fmt::Display for DataType {
             DataType::Boolean => write!(f, "BOOLEAN"),
             DataType::Date => write!(f, "DATE"),
             DataType::Time => write!(f, "TIME"),
+            DataType::Datetime => write!(f, "DATETIME"),
             DataType::Timestamp => write!(f, "TIMESTAMP"),
             DataType::Interval => write!(f, "INTERVAL"),
             DataType::Regclass => write!(f, "REGCLASS"),

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -169,6 +169,7 @@ define_keywords!(
     DATA,
     DATABASE,
     DATE,
+    DATETIME,
     DAY,
     DEALLOCATE,
     DEC,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2733,6 +2733,7 @@ impl<'a> Parser<'a> {
                 }
                 Keyword::UUID => Ok(DataType::Uuid),
                 Keyword::DATE => Ok(DataType::Date),
+                Keyword::DATETIME => Ok(DataType::Datetime),
                 Keyword::TIMESTAMP => {
                     // TBD: we throw away "with/without timezone" information
                     if self.parse_keyword(Keyword::WITH) || self.parse_keyword(Keyword::WITHOUT) {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2616,6 +2616,19 @@ fn parse_literal_time() {
 }
 
 #[test]
+fn parse_literal_datetime() {
+    let sql = "SELECT DATETIME '1999-01-01 01:23:34.45'";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::TypedString {
+            data_type: DataType::Datetime,
+            value: "1999-01-01 01:23:34.45".into()
+        },
+        expr_from_projection(only(&select.projection)),
+    );
+}
+
+#[test]
 fn parse_literal_timestamp() {
     let sql = "SELECT TIMESTAMP '1999-01-01 01:23:34'";
     let select = verified_only_select(sql);


### PR DESCRIPTION
BigQuery can parse `DATETIME`.
https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#datetime_literals

Before this PR, `SELECT DATETIME '1999-01-01 01:23:34.45'` was parsed as DATETIME column with '1999-01-..' alias.