### PR TITLE
fix: Support `expr` instead of `string` for argument to `interval`

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -11,6 +11,8 @@
 // limitations under the License.
 
 #[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 use core::fmt;
 

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -19,6 +19,8 @@ use bigdecimal::BigDecimal;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use super::Expr;
+
 /// Primitive SQL values such as number and string
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -50,7 +52,7 @@ pub enum Value {
     /// that the `<leading_field>` units >= the units in `<last_field>`,
     /// so the user will have to reject intervals like `HOUR TO YEAR`.
     Interval {
-        value: String,
+        value: Box<Expr>,
         leading_field: Option<DateTimeField>,
         leading_precision: Option<u64>,
         last_field: Option<DateTimeField>,
@@ -88,10 +90,8 @@ impl fmt::Display for Value {
                 assert!(last_field.is_none());
                 write!(
                     f,
-                    "INTERVAL '{}' SECOND ({}, {})",
-                    escape_single_quote_string(value),
-                    leading_precision,
-                    fractional_seconds_precision
+                    "INTERVAL {} SECOND ({}, {})",
+                    value, leading_precision, fractional_seconds_precision
                 )
             }
             Value::Interval {
@@ -101,7 +101,7 @@ impl fmt::Display for Value {
                 last_field,
                 fractional_seconds_precision,
             } => {
-                write!(f, "INTERVAL '{}'", escape_single_quote_string(value))?;
+                write!(f, "INTERVAL {}", value)?;
                 if let Some(leading_field) = leading_field {
                     write!(f, " {}", leading_field)?;
                 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2688,7 +2688,7 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: Box::new(Expr::Value(Value::Number(String::from("5"), false))),
+            value: Box::new(Expr::Value(number("5"))),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
             last_field: None,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2634,7 +2634,7 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "1-1".into(),
+            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1-1")))),
             leading_field: Some(DateTimeField::Year),
             leading_precision: None,
             last_field: Some(DateTimeField::Month),
@@ -2647,7 +2647,9 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "01:01.01".into(),
+            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
+                "01:01.01"
+            )))),
             leading_field: Some(DateTimeField::Minute),
             leading_precision: Some(5),
             last_field: Some(DateTimeField::Second),
@@ -2660,7 +2662,7 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "1".into(),
+            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1")))),
             leading_field: Some(DateTimeField::Second),
             leading_precision: Some(5),
             last_field: None,
@@ -2673,8 +2675,38 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "10".into(),
+            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
             leading_field: Some(DateTimeField::Hour),
+            leading_precision: None,
+            last_field: None,
+            fractional_seconds_precision: None,
+        }),
+        expr_from_projection(only(&select.projection)),
+    );
+
+    let sql = "SELECT INTERVAL 5 DAY";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Value(Value::Interval {
+            value: Box::new(Expr::Value(Value::Number(String::from("5"), false))),
+            leading_field: Some(DateTimeField::Day),
+            leading_precision: None,
+            last_field: None,
+            fractional_seconds_precision: None,
+        }),
+        expr_from_projection(only(&select.projection)),
+    );
+
+    let sql = "SELECT INTERVAL 1 + 1 DAY";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Value(Value::Interval {
+            value: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Value(number("1"))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expr::Value(number("1")))
+            }),
+            leading_field: Some(DateTimeField::Day),
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
@@ -2686,7 +2718,7 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "10".into(),
+            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: Some(1),
             last_field: None,
@@ -2699,7 +2731,9 @@ fn parse_literal_interval() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Value(Value::Interval {
-            value: "1 DAY".into(),
+            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
+                "1 DAY"
+            )))),
             leading_field: None,
             leading_precision: None,
             last_field: None,


### PR DESCRIPTION
In Big Query and MySQL, the following query is valid:
```
SELECT DATE_ADD(DATE "2008-12-25", INTERVAL 5 DAY);
```
https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#date_add
https://www.w3schools.com/mysql/func_mysql_date_add.asp

But now if the expression is number, an error occurred because the type of the value in `interval` is `String`
https://github.com/sqlparser-rs/sqlparser-rs/blob/ca15a4edbf1de4c00304b12e44d3adf9ac729406/src/ast/value.rs#L53

This PR replaces `String` with `Expr` to run correctly in `Interval`

One concern thing is that should I validate when the other dialect like `PostgresSQL`, `sqlite`. I don't know if the query is valid except for Big query and MySQL.