### PR TITLE
snowflake column identifier

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -18,7 +18,7 @@ pub struct SnowflakeDialect;
 impl Dialect for SnowflakeDialect {
     // see https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html
     fn is_identifier_start(&self, ch: char) -> bool {
-        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_'
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_' || ch == '@'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -100,6 +100,12 @@ fn test_single_table_in_parenthesis() {
 }
 
 #[test]
+fn test_snowflake_variables() {
+    let sql = "SELECT a.$1 AS a, a.$1.b AS b, a.$1:c AS c, d:d AS d, e$f AS f FROM @g AS g";
+    snowflake().verified_stmt(sql);
+}
+
+#[test]
 fn test_single_table_in_parenthesis_with_alias() {
     snowflake_and_generic().one_statement_parses_to(
         "SELECT * FROM (a NATURAL JOIN (b) c )",


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

resolves https://github.com/sqlparser-rs/sqlparser-rs/issues/519

According to documentation, Snowflake allows:
 * [query data staged in files](https://docs.snowflake.com/en/user-guide/querying-stage.html#required-parameters) with an identifier of a form `[<alias>.]$<file_col_num>[.<element>]`
* [copy into table](https://docs.snowflake.com/en/user-guide/data-load-transform.html) with an column identifier containing $ character like `select t.$1,t.$2,t.$3 from @~/datafile.csv.gz t;`
* [get-path](https://docs.snowflake.com/en/sql-reference/functions/get_path.html) like `select v:attr[0].name from vartab;`

Although the feature seems to be snowflake specific, it cannot be implemented within snowflake dialect. It's because tokens starting with `$` character are tokenized into `Token::Placeholder`. That's why parser's change is required.

Initial OpenLineage project issue: https://github.com/OpenLineage/OpenLineage/issues/814.

