### PR TITLE
Add support for ClickHouse DDL query syntax (`on cluster`)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -867,6 +867,8 @@ pub enum Statement {
         default_charset: Option<String>,
         collation: Option<String>,
         on_commit: Option<OnCommit>,
+        /// Click house "ON CLUSTER" clause: 
+        /// <https://clickhouse.com/docs/en/sql-reference/distributed-ddl/>
         on_cluster: Option<String>,
     },
     /// SQLite's `CREATE VIRTUAL TABLE .. USING <module_name> (<module_args>)`

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1500,7 +1500,7 @@ impl fmt::Display for Statement {
                 //   `CREATE TABLE t (a INT) AS SELECT a from t2`
                 write!(
                     f,
-                    "CREATE {or_replace}{external}{global}{temporary}TABLE {if_not_exists}{name}",
+                    "CREATE {or_replace}{external}{global}{temporary}TABLE {if_not_exists}{name}{on_cluster}",
                     or_replace = if *or_replace { "OR REPLACE " } else { "" },
                     external = if *external { "EXTERNAL " } else { "" },
                     global = global
@@ -1515,6 +1515,10 @@ impl fmt::Display for Statement {
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
                     temporary = if *temporary { "TEMPORARY " } else { "" },
                     name = name,
+                    on_cluster = match on_cluster {
+                        Some(s) => format!(" ON CLUSTER {}", s.replace("{", "'{").replace("}", "}'")),
+                        None => "".to_string()
+                    }
                 )?;
                 if !columns.is_empty() || !constraints.is_empty() {
                     write!(f, " ({}", display_comma_separated(columns))?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -867,6 +867,7 @@ pub enum Statement {
         default_charset: Option<String>,
         collation: Option<String>,
         on_commit: Option<OnCommit>,
+        on_cluster: Option<String>,
     },
     /// SQLite's `CREATE VIRTUAL TABLE .. USING <module_name> (<module_args>)`
     CreateVirtualTable {
@@ -1488,6 +1489,7 @@ impl fmt::Display for Statement {
                 engine,
                 collation,
                 on_commit,
+                on_cluster,
             } => {
                 // We want to allow the following options
                 // Empty column list, allowed by PostgreSQL:

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -867,7 +867,7 @@ pub enum Statement {
         default_charset: Option<String>,
         collation: Option<String>,
         on_commit: Option<OnCommit>,
-        /// Click house "ON CLUSTER" clause: 
+        /// Click house "ON CLUSTER" clause:
         /// <https://clickhouse.com/docs/en/sql-reference/distributed-ddl/>
         on_cluster: Option<String>,
     },
@@ -1502,7 +1502,7 @@ impl fmt::Display for Statement {
                 //   `CREATE TABLE t (a INT) AS SELECT a from t2`
                 write!(
                     f,
-                    "CREATE {or_replace}{external}{global}{temporary}TABLE {if_not_exists}{name}{on_cluster}",
+                    "CREATE {or_replace}{external}{global}{temporary}TABLE {if_not_exists}{name}",
                     or_replace = if *or_replace { "OR REPLACE " } else { "" },
                     external = if *external { "EXTERNAL " } else { "" },
                     global = global
@@ -1517,11 +1517,14 @@ impl fmt::Display for Statement {
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
                     temporary = if *temporary { "TEMPORARY " } else { "" },
                     name = name,
-                    on_cluster = match on_cluster {
-                        Some(s) => format!(" ON CLUSTER {}", s.replace("{", "'{").replace("}", "}'")),
-                        None => "".to_string()
-                    }
                 )?;
+                if let Some(on_cluster) = on_cluster {
+                    write!(
+                        f,
+                        " ON CLUSTER {}",
+                        on_cluster.replace('{', "'{").replace('}', "}'")
+                    )?;
+                }
                 if !columns.is_empty() || !constraints.is_empty() {
                     write!(f, " ({}", display_comma_separated(columns))?;
                     if !columns.is_empty() && !constraints.is_empty() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2063,7 +2063,7 @@ impl<'a> Parser<'a> {
         // Clickhouse has `ON CLUSTER 'cluster'` syntax for DDLs
         let on_cluster = if self.parse_keywords(&[Keyword::ON, Keyword::CLUSTER]) {
             match self.next_token() {
-                Token::SingleQuotedString(s) => Some(s.to_string()),
+                Token::SingleQuotedString(s) => Some(s),
                 Token::Word(s) => Some(s.to_string()),
                 unexpected => self.expected("identifier or cluster literal", unexpected)?,
             }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -243,7 +243,7 @@ pub struct Word {
     /// The value of the token, without the enclosing quotes, and with the
     /// escape sequences (if any) processed (TODO: escapes are not handled)
     pub value: String,
-    /// An oidentifier can be "quoted" (&lt;delimited identifier> in ANSI parlance).
+    /// An identifier can be "quoted" (&lt;delimited identifier> in ANSI parlance).
     /// The standard and most implementations allow using double quotes for this,
     /// but some implementations support other quoting styles as well (e.g. \[MS SQL])
     pub quote_style: Option<char>,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -243,7 +243,7 @@ pub struct Word {
     /// The value of the token, without the enclosing quotes, and with the
     /// escape sequences (if any) processed (TODO: escapes are not handled)
     pub value: String,
-    /// An identifier can be "quoted" (&lt;delimited identifier> in ANSI parlance).
+    /// An oidentifier can be "quoted" (&lt;delimited identifier> in ANSI parlance).
     /// The standard and most implementations allow using double quotes for this,
     /// but some implementations support other quoting styles as well (e.g. \[MS SQL])
     pub quote_style: Option<char>,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1927,6 +1927,27 @@ fn parse_create_table_as() {
 }
 
 #[test]
+fn parse_create_table_on_cluster() {
+    // Using single-quote literal to define current cluster
+    let sql = "CREATE TABLE t ON CLUSTER '{cluster}' (a INT, b INT)";
+    match verified_stmt(sql) {
+        Statement::CreateTable { on_cluster, .. } => {
+            assert_eq!(on_cluster.unwrap(), "{cluster}".to_string());
+        }
+        _ => unreachable!(),
+    }
+
+    // Using explicitly declared cluster name
+    let sql = "CREATE TABLE t ON CLUSTER my_cluster (a INT, b INT)";
+    match verified_stmt(sql) {
+        Statement::CreateTable { on_cluster, .. } => {
+            assert_eq!(on_cluster.unwrap(), "my_cluster".to_string());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_create_or_replace_table() {
     let sql = "CREATE OR REPLACE TABLE t (a INT)";
 


### PR DESCRIPTION
Add support for ClickHouse DDL query syntax [(source)](https://clickhouse.com/docs/en/sql-reference/distributed-ddl/)

This is an example only on `CREATE TABLE` statements. If you're happy to go ahead with supporting this, I can add this to all `CREATE` `DROP` `ALTER` and `RENAME` queries