### PR TITLE
Count characters instead of bytes

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -351,11 +351,11 @@ impl<'a> Tokenizer<'a> {
                 }
 
                 Token::Whitespace(Whitespace::Tab) => self.col += 4,
-                Token::Word(w) if w.quote_style == None => self.col += w.value.len() as u64,
-                Token::Word(w) if w.quote_style != None => self.col += w.value.len() as u64 + 2,
-                Token::Number(s, _) => self.col += s.len() as u64,
-                Token::SingleQuotedString(s) => self.col += s.len() as u64,
-                Token::Placeholder(s) => self.col += s.len() as u64,
+                Token::Word(w) if w.quote_style == None => self.col += w.value.chars().count() as u64,
+                Token::Word(w) if w.quote_style != None => self.col += w.value.chars().count() as u64 + 2,
+                Token::Number(s, _) => self.col += s.chars().count() as u64,
+                Token::SingleQuotedString(s) => self.col += s.chars().count() as u64,
+                Token::Placeholder(s) => self.col += s.chars().count() as u64,
                 _ => self.col += 1,
             }
 


### PR DESCRIPTION
For queries such as `SELECT "なにか" FROM Y WHERE "なにか" = 'test;` which are using UTF-8 characters as column names, counting lengths as byte counts (which `len()` does) may cause bugs.

For instance, the above query would produce an error `Unterminated string literal at Line: 1, Column 47`, while the correct column number is 35.

So, simply use `.chars().count()` instead. Replacing `len()` with this produces correct output.