### PR TITLE
Support double quoted string

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -504,6 +504,7 @@ impl<'a> Parser<'a> {
             }
             Token::Number(_, _)
             | Token::SingleQuotedString(_)
+            | Token::DoubleQuotedString(_)
             | Token::NationalStringLiteral(_)
             | Token::HexStringLiteral(_) => {
                 self.prev_token();
@@ -2773,6 +2774,7 @@ impl<'a> Parser<'a> {
                 Err(e) => parser_err!(format!("Could not parse '{}' as number: {}", n, e)),
             },
             Token::SingleQuotedString(ref s) => Ok(Value::SingleQuotedString(s.to_string())),
+            Token::DoubleQuotedString(ref s) => Ok(Value::DoubleQuotedString(s.to_string())),
             Token::NationalStringLiteral(ref s) => Ok(Value::NationalStringLiteral(s.to_string())),
             Token::EscapedStringLiteral(ref s) => Ok(Value::EscapedStringLiteral(s.to_string())),
             Token::HexStringLiteral(ref s) => Ok(Value::HexStringLiteral(s.to_string())),
@@ -2807,6 +2809,7 @@ impl<'a> Parser<'a> {
         match self.next_token() {
             Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => Ok(value),
             Token::SingleQuotedString(s) => Ok(s),
+            Token::DoubleQuotedString(s) => Ok(s),
             Token::EscapedStringLiteral(s) if dialect_of!(self is PostgreSqlDialect | GenericDialect) => {
                 Ok(s)
             }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -19,6 +19,21 @@ use sqlparser::ast::*;
 use sqlparser::dialect::BigQueryDialect;
 
 #[test]
+fn parse_literal_string() {
+    let sql = r#"SELECT 'single', "double""#;
+    let select = bigquery().verified_only_select(sql);
+    assert_eq!(2, select.projection.len());
+    assert_eq!(
+        &Expr::Value(Value::SingleQuotedString("single".to_string())),
+        expr_from_projection(&select.projection[0])
+    );
+    assert_eq!(
+        &Expr::Value(Value::DoubleQuotedString("double".to_string())),
+        expr_from_projection(&select.projection[1])
+    );
+}
+
+#[test]
 fn parse_table_identifiers() {
     fn test_table_ident(ident: &str, expected: Vec<Ident>) {
         let sql = format!("SELECT 1 FROM {}", ident);

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -31,6 +31,21 @@ fn parse_identifiers() {
 }
 
 #[test]
+fn parse_literal_string() {
+    let sql = r#"SELECT 'single', "double""#;
+    let select = mysql().verified_only_select(sql);
+    assert_eq!(2, select.projection.len());
+    assert_eq!(
+        &Expr::Value(Value::SingleQuotedString("single".to_string())),
+        expr_from_projection(&select.projection[0])
+    );
+    assert_eq!(
+        &Expr::Value(Value::DoubleQuotedString("double".to_string())),
+        expr_from_projection(&select.projection[1])
+    );
+}
+
+#[test]
 fn parse_show_columns() {
     let table_name = ObjectName(vec![Ident::new("mytable")]);
     assert_eq!(


### PR DESCRIPTION
ref. https://github.com/sqlparser-rs/sqlparser-rs/issues/439

Support double quoted string for BigQuery and MySQL.
- BigQuery: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
- MySQL: https://dev.mysql.com/doc/refman/8.0/en/string-literals.html

Below is a test for other dialects.
https://github.com/sqlparser-rs/sqlparser-rs/blob/f29ce10a1a14ebaa55cb23e3daab0cb4204cddaf/tests/sqlparser_common.rs#L2917-L2921
