### PR TITLE
Support for empty array literals (`ARRAY[]`)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -883,9 +883,17 @@ impl<'a> Parser<'a> {
     /// Parses an array expression `[ex1, ex2, ..]`
     /// if `named` is `true`, came from an expression like  `ARRAY[ex1, ex2]`
     pub fn parse_array_expr(&mut self, named: bool) -> Result<Expr, ParserError> {
-        let exprs = self.parse_comma_separated(Parser::parse_expr)?;
-        self.expect_token(&Token::RBracket)?;
-        Ok(Expr::Array(Array { elem: exprs, named }))
+        if self.peek_token() == Token::RBracket {
+            let _ = self.next_token();
+            Ok(Expr::Array(Array {
+                elem: vec![],
+                named,
+            }))
+        } else {
+            let exprs = self.parse_comma_separated(Parser::parse_expr)?;
+            self.expect_token(&Token::RBracket)?;
+            Ok(Expr::Array(Array { elem: exprs, named }))
+        }
     }
 
     /// Parse a SQL LISTAGG expression, e.g. `LISTAGG(...) WITHIN GROUP (ORDER BY ...)`.

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1228,6 +1228,16 @@ fn parse_array_index_expr() {
         },
         expr_from_projection(only(&select.projection)),
     );
+
+    let sql = "SELECT ARRAY[]";
+    let select = pg_and_generic().verified_only_select(sql);
+    assert_eq!(
+        &Expr::Array(sqlparser::ast::Array {
+            elem: vec![],
+            named: true
+        }),
+        expr_from_projection(only(&select.projection)),
+    );
 }
 
 #[test]


### PR DESCRIPTION
We had SQL queries that contained fragments that looked like this:

```
,COALESCE(t.location_id_tokenized, ARRAY []) AS location_id_tokenized
```

We needed to coalesce the values down to empty arrays. This is the recommended syntax on the AWS Athena docs: https://docs.aws.amazon.com/athena/latest/ug/creating-arrays.html

Oddly, the parser assumed all `ARRAY` keyword literal values would have a comma separated list of values inside of them. This initially threw me off as I assumed it would be a lexing problem. That's one reason there's an AthenaSqlDialect in here. The other reason is that I wasn't sure if I should bolt the `ARRAY[]` test onto an existing dialect or carve out an Athena dialect. The Athena SQL dialect tests are a hodgepodge of Hive tests with a single array literal test from PostgreSQL adapted to this specific missing feature.

If you want to migrate the test into an existing dialect and nuke the Athena dialect, that's fine by me. Athena SQL is basically Presto+Hive I think, so it's whatever you want to do. This problem is fixed for all SQL dialects regardless because it's in the parser.

Cheers and thanks for the parser, this thing has saved me countless hours.