### PR TITLE
Add support for multi-part identifiers with colons

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -442,14 +442,14 @@ impl<'a> Parser<'a> {
                 // Here `w` is a word, check if it's a part of a multi-part
                 // identifier, a function call, or a simple identifier:
                 _ => match self.peek_token() {
-                    Token::LParen | Token::Period => {
+                    Token::LParen | Token::Period | Token::Colon => {
                         let mut id_parts: Vec<Ident> = vec![w.to_ident()];
-                        while self.consume_token(&Token::Period) {
+                        while self.consume_token(&Token::Period) || self.consume_token(&Token::Colon) {
                             match self.next_token() {
                                 Token::Word(w) => id_parts.push(w.to_ident()),
                                 unexpected => {
                                     return self
-                                        .expected("an identifier or a '*' after '.'", unexpected);
+                                        .expected("an identifier or a '*' after '.' or ':'", unexpected);
                                 }
                             }
                         }


### PR DESCRIPTION
Snowflake SQL uses colons for multi-part identifiers as part of semi-structured data support, such that a multi-part identifier may include both periods and colons.  I didn't see a way to add this as part of the Snowflake-dialect support, so proposing to add here.  Don't see a big downside.