### PR TITLE
Add support for mysql 'SHOW CREATE VIEW' statement

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -705,6 +705,7 @@ pub enum ShowCreateObject {
     Procedure,
     Table,
     Trigger,
+    View,
 }
 
 impl fmt::Display for ShowCreateObject {
@@ -715,6 +716,7 @@ impl fmt::Display for ShowCreateObject {
             ShowCreateObject::Procedure => f.write_str("PROCEDURE"),
             ShowCreateObject::Table => f.write_str("TABLE"),
             ShowCreateObject::Trigger => f.write_str("TRIGGER"),
+            ShowCreateObject::View => f.write_str("VIEW"),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3601,12 +3601,14 @@ impl<'a> Parser<'a> {
             Keyword::FUNCTION,
             Keyword::PROCEDURE,
             Keyword::EVENT,
+            Keyword::VIEW,
         ])? {
             Keyword::TABLE => Ok(ShowCreateObject::Table),
             Keyword::TRIGGER => Ok(ShowCreateObject::Trigger),
             Keyword::FUNCTION => Ok(ShowCreateObject::Function),
             Keyword::PROCEDURE => Ok(ShowCreateObject::Procedure),
             Keyword::EVENT => Ok(ShowCreateObject::Event),
+            Keyword::VIEW => Ok(ShowCreateObject::View),
             keyword => Err(ParserError::ParserError(format!(
                 "Unable to map keyword to ShowCreateObject: {:?}",
                 keyword

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -128,6 +128,7 @@ fn parse_show_create() {
         ShowCreateObject::Event,
         ShowCreateObject::Function,
         ShowCreateObject::Procedure,
+        ShowCreateObject::View,
     ] {
         assert_eq!(
             mysql_and_generic().verified_stmt(format!("SHOW CREATE {} myident", obj_type).as_str()),


### PR DESCRIPTION
Support for [show create view](https://dev.mysql.com/doc/refman/8.0/en/show-create-view.html).

This may be useful for https://github.com/apache/arrow-datafusion/issues/2857.