### PR TITLE
Add support for `AT TIME ZONE`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -285,6 +285,11 @@ pub enum Expr {
         expr: Box<Expr>,
         data_type: DataType,
     },
+    /// AT a timestamp to a different timezone e.g. `FROM_UNIXTIME(0) AT TIME ZONE 'UTC-06:00'`
+    AtTimeZone {
+        timestamp: Box<Expr>,
+        time_zone: String,
+    },
     /// EXTRACT(DateTimeField FROM <expr>)
     Extract {
         field: DateTimeField,
@@ -561,6 +566,12 @@ impl fmt::Display for Expr {
             }
             Expr::CompositeAccess { expr, key } => {
                 write!(f, "{}.{}", expr, key)
+            }
+            Expr::AtTimeZone {
+                timestamp,
+                time_zone,
+            } => {
+                write!(f, "{} AT TIME ZONE '{}'", timestamp, time_zone)
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -883,9 +883,17 @@ impl<'a> Parser<'a> {
     /// Parses an array expression `[ex1, ex2, ..]`
     /// if `named` is `true`, came from an expression like  `ARRAY[ex1, ex2]`
     pub fn parse_array_expr(&mut self, named: bool) -> Result<Expr, ParserError> {
-        let exprs = self.parse_comma_separated(Parser::parse_expr)?;
-        self.expect_token(&Token::RBracket)?;
-        Ok(Expr::Array(Array { elem: exprs, named }))
+        if self.peek_token() == Token::RBracket {
+            let _ = self.next_token();
+            Ok(Expr::Array(Array {
+                elem: vec![],
+                named,
+            }))
+        } else {
+            let exprs = self.parse_comma_separated(Parser::parse_expr)?;
+            self.expect_token(&Token::RBracket)?;
+            Ok(Expr::Array(Array { elem: exprs, named }))
+        }
     }
 
     /// Parse a SQL LISTAGG expression, e.g. `LISTAGG(...) WITHIN GROUP (ORDER BY ...)`.

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2791,6 +2791,65 @@ fn parse_literal_interval() {
 }
 
 #[test]
+fn parse_at_timezone() {
+    let zero = Expr::Value(number("0"));
+    let sql = "SELECT FROM_UNIXTIME(0) AT TIME ZONE 'UTC-06:00' FROM t";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::AtTimeZone {
+            timestamp: Box::new(Expr::Function(Function {
+                name: ObjectName(vec![Ident {
+                    value: "FROM_UNIXTIME".to_string(),
+                    quote_style: None
+                }]),
+                args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(zero.clone()))],
+                over: None,
+                distinct: false
+            })),
+            time_zone: "UTC-06:00".to_string()
+        },
+        expr_from_projection(only(&select.projection)),
+    );
+
+    let sql = r#"SELECT DATE_FORMAT(FROM_UNIXTIME(0) AT TIME ZONE 'UTC-06:00', '%Y-%m-%dT%H') AS "hour" FROM t"#;
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &SelectItem::ExprWithAlias {
+            expr: Expr::Function(Function {
+                name: ObjectName(vec![Ident {
+                    value: "DATE_FORMAT".to_string(),
+                    quote_style: None,
+                },],),
+                args: vec![
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::AtTimeZone {
+                        timestamp: Box::new(Expr::Function(Function {
+                            name: ObjectName(vec![Ident {
+                                value: "FROM_UNIXTIME".to_string(),
+                                quote_style: None,
+                            },],),
+                            args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(zero,),),],
+                            over: None,
+                            distinct: false,
+                        },)),
+                        time_zone: "UTC-06:00".to_string(),
+                    },),),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        Value::SingleQuotedString("%Y-%m-%dT%H".to_string(),),
+                    ),),),
+                ],
+                over: None,
+                distinct: false,
+            },),
+            alias: Ident {
+                value: "hour".to_string(),
+                quote_style: Some('"',),
+            },
+        },
+        only(&select.projection),
+    );
+}
+
+#[test]
 fn parse_simple_math_expr_plus() {
     let sql = "SELECT a + b, 2 + a, 2.5 + a, a_f + b_f, 2 + a_f, 2.5 + a_f FROM c";
     verified_only_select(sql);

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1228,6 +1228,16 @@ fn parse_array_index_expr() {
         },
         expr_from_projection(only(&select.projection)),
     );
+
+    let sql = "SELECT ARRAY[]";
+    let select = pg_and_generic().verified_only_select(sql);
+    assert_eq!(
+        &Expr::Array(sqlparser::ast::Array {
+            elem: vec![],
+            named: true
+        }),
+        expr_from_projection(only(&select.projection)),
+    );
 }
 
 #[test]


### PR DESCRIPTION
Builds off #532, this time to add support for `AT TIME ZONE` which appears in multiple SQL dialects including Athena/Presto and MSSQL. There may be others, I haven't bothered to check. I can rebase if #532 gets merged first.

This one was a bit harder. The precedence value is pure guessery: "uhhhh kinda looks like `BETWEEN`?"

All tests passed locally 🤞