### PR TITLE
Boxed Query body to save some stack space

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -26,7 +26,7 @@ pub struct Query {
     /// WITH (common table expressions, or CTEs)
     pub with: Option<With>,
     /// SELECT or UNION / EXCEPT / INTERSECT
-    pub body: SetExpr,
+    pub body: Box<SetExpr>,
     /// ORDER BY
     pub order_by: Vec<OrderByExpr>,
     /// `LIMIT { <N> | ALL }`

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3207,7 +3207,7 @@ impl<'a> Parser<'a> {
         };
 
         if !self.parse_keyword(Keyword::INSERT) {
-            let body = self.parse_query_body(0)?;
+            let body = Box::new(self.parse_query_body(0)?);
 
             let order_by = if self.parse_keywords(&[Keyword::ORDER, Keyword::BY]) {
                 self.parse_comma_separated(Parser::parse_order_by_expr)?
@@ -3259,7 +3259,7 @@ impl<'a> Parser<'a> {
 
             Ok(Query {
                 with,
-                body: SetExpr::Insert(insert),
+                body: Box::new(SetExpr::Insert(insert)),
                 limit: None,
                 order_by: vec![],
                 offset: None,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -115,7 +115,7 @@ impl TestedDialects {
     /// Ensures that `sql` parses as a single [Select], and is not modified
     /// after a serialization round-trip.
     pub fn verified_only_select(&self, query: &str) -> Select {
-        match self.verified_query(query).body {
+        match *self.verified_query(query).body {
             SetExpr::Select(s) => *s,
             _ => panic!("Expected SetExpr::Select"),
         }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -85,7 +85,7 @@ fn parse_insert_values() {
                 for (index, column) in columns.iter().enumerate() {
                     assert_eq!(column, &Ident::new(expected_columns[index].clone()));
                 }
-                match &source.body {
+                match &*source.body {
                     SetExpr::Values(Values(values)) => assert_eq!(values.as_slice(), expected_rows),
                     _ => unreachable!(),
                 }
@@ -3976,7 +3976,7 @@ fn parse_offset() {
     assert_eq!(ast.offset, expect);
     let ast = verified_query("SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS) OFFSET 2 ROWS");
     assert_eq!(ast.offset, expect);
-    match ast.body {
+    match *ast.body {
         SetExpr::Select(s) => match only(s.from).relation {
             TableFactor::Derived { subquery, .. } => {
                 assert_eq!(subquery.offset, expect);
@@ -4070,7 +4070,7 @@ fn parse_fetch() {
         "SELECT foo FROM (SELECT * FROM bar FETCH FIRST 2 ROWS ONLY) FETCH FIRST 2 ROWS ONLY",
     );
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    match ast.body {
+    match *ast.body {
         SetExpr::Select(s) => match only(s.from).relation {
             TableFactor::Derived { subquery, .. } => {
                 assert_eq!(subquery.fetch, fetch_first_two_rows_only);
@@ -4088,7 +4088,7 @@ fn parse_fetch() {
         })
     );
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    match ast.body {
+    match *ast.body {
         SetExpr::Select(s) => match only(s.from).relation {
             TableFactor::Derived { subquery, .. } => {
                 assert_eq!(
@@ -4626,7 +4626,7 @@ fn parse_merge() {
                     lateral: false,
                     subquery: Box::new(Query {
                         with: None,
-                        body: SetExpr::Select(Box::new(Select {
+                        body: Box::new(SetExpr::Select(Box::new(Select {
                             distinct: false,
                             top: None,
                             projection: vec![SelectItem::Wildcard],
@@ -4648,7 +4648,7 @@ fn parse_merge() {
                             sort_by: vec![],
                             having: None,
                             qualify: None,
-                        })),
+                        }))),
                         order_by: vec![],
                         limit: None,
                         offset: None,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -313,7 +313,7 @@ fn parse_quote_identifiers_2() {
         mysql().verified_stmt(sql),
         Statement::Query(Box::new(Query {
             with: None,
-            body: SetExpr::Select(Box::new(Select {
+            body: Box::new(SetExpr::Select(Box::new(Select {
                 distinct: false,
                 top: None,
                 projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
@@ -330,7 +330,7 @@ fn parse_quote_identifiers_2() {
                 sort_by: vec![],
                 having: None,
                 qualify: None
-            })),
+            }))),
             order_by: vec![],
             limit: None,
             offset: None,
@@ -347,7 +347,7 @@ fn parse_quote_identifiers_3() {
         mysql().verified_stmt(sql),
         Statement::Query(Box::new(Query {
             with: None,
-            body: SetExpr::Select(Box::new(Select {
+            body: Box::new(SetExpr::Select(Box::new(Select {
                 distinct: false,
                 top: None,
                 projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
@@ -364,7 +364,7 @@ fn parse_quote_identifiers_3() {
                 sort_by: vec![],
                 having: None,
                 qualify: None
-            })),
+            }))),
             order_by: vec![],
             limit: None,
             offset: None,
@@ -392,7 +392,7 @@ fn parse_escaped_string() {
     let stmt = mysql().one_statement_parses_to(sql, "");
 
     match stmt {
-        Statement::Query(query) => match query.body {
+        Statement::Query(query) => match *query.body {
             SetExpr::Select(value) => {
                 let expr = expr_from_projection(only(&value.projection));
                 assert_eq!(
@@ -517,7 +517,7 @@ fn parse_simple_insert() {
             assert_eq!(
                 Box::new(Query {
                     with: None,
-                    body: SetExpr::Values(Values(vec![
+                    body: Box::new(SetExpr::Values(Values(vec![
                         vec![
                             Expr::Value(Value::SingleQuotedString("Test Some Inserts".to_string())),
                             Expr::Value(Value::Number("1".to_string(), false))
@@ -530,7 +530,7 @@ fn parse_simple_insert() {
                             Expr::Value(Value::SingleQuotedString("Test Entry 3".to_string())),
                             Expr::Value(Value::Number("3".to_string(), false))
                         ]
-                    ])),
+                    ]))),
                     order_by: vec![],
                     limit: None,
                     offset: None,
@@ -574,7 +574,7 @@ fn parse_insert_with_on_duplicate_update() {
             assert_eq!(
                 Box::new(Query {
                     with: None,
-                    body: SetExpr::Values(Values(vec![vec![
+                    body: Box::new(SetExpr::Values(Values(vec![vec![
                         Expr::Value(Value::SingleQuotedString("accounting_manager".to_string())),
                         Expr::Value(Value::SingleQuotedString(
                             "Some description about the group".to_string()
@@ -583,7 +583,7 @@ fn parse_insert_with_on_duplicate_update() {
                         Expr::Value(Value::Boolean(true)),
                         Expr::Value(Value::Boolean(true)),
                         Expr::Value(Value::Boolean(true)),
-                    ]])),
+                    ]]))),
                     order_by: vec![],
                     limit: None,
                     offset: None,
@@ -767,7 +767,7 @@ fn parse_substring_in_select() {
             assert_eq!(
                 Box::new(Query {
                     with: None,
-                    body: SetExpr::Select(Box::new(Select {
+                    body: Box::new(SetExpr::Select(Box::new(Select {
                         distinct: true,
                         top: None,
                         projection: vec![SelectItem::UnnamedExpr(Expr::Substring {
@@ -805,7 +805,7 @@ fn parse_substring_in_select() {
                         sort_by: vec![],
                         having: None,
                         qualify: None
-                    })),
+                    }))),
                     order_by: vec![],
                     limit: None,
                     offset: None,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -427,7 +427,7 @@ fn parse_update_set_from() {
                     lateral: false,
                     subquery: Box::new(Query {
                         with: None,
-                        body: SetExpr::Select(Box::new(Select {
+                        body: Box::new(SetExpr::Select(Box::new(Select {
                             distinct: false,
                             top: None,
                             projection: vec![
@@ -452,7 +452,7 @@ fn parse_update_set_from() {
                             sort_by: vec![],
                             having: None,
                             qualify: None
-                        })),
+                        }))),
                         order_by: vec![],
                         limit: None,
                         offset: None,
@@ -1042,7 +1042,7 @@ fn parse_prepare() {
                 Expr::Identifier("a2".into()),
                 Expr::Identifier("a3".into()),
             ]];
-            match &source.body {
+            match &*source.body {
                 SetExpr::Values(Values(values)) => assert_eq!(values.as_slice(), &expected_values),
                 _ => unreachable!(),
             }


### PR DESCRIPTION
Boxing `Query::body` reduced size of `Query` from 1312B to 592B.

In following test of standalone parser runs (7MB stack) allowed subquery nesting jumped from 239 to 286.
```bash
x=286 ; echo 'print("SELECT * FROM {}ttt{}".format("("*'$x',")"*'$x'))' | python3 > test.sql && cargo run --example cli --manifest-path Cargo.toml test.sql --snowflake
```

This makes significant difference when parsing "recursive queries" in environments with reduced stack size (e.g. like [tokio spawned threads](https://durch.github.io/rust-goauth/tokio/runtime/struct.Builder.html#:~:text=The%20default%20stack%20size%20for,to%20change%20in%20the%20future) - 2MB).
