### PR TITLE
delete: add using clause, possibility of using aliases

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -828,7 +828,9 @@ pub enum Statement {
     /// DELETE
     Delete {
         /// FROM
-        table_name: ObjectName,
+        table_name: TableFactor,
+        /// USING (Snowflake, Postgres)
+        using: Option<TableFactor>,
         /// WHERE
         selection: Option<Expr>,
     },
@@ -1395,9 +1397,13 @@ impl fmt::Display for Statement {
             }
             Statement::Delete {
                 table_name,
+                using,
                 selection,
             } => {
                 write!(f, "DELETE FROM {}", table_name)?;
+                if let Some(using) = using {
+                    write!(f, " USING {}", using)?;
+                }
                 if let Some(selection) = selection {
                     write!(f, " WHERE {}", selection)?;
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3132,7 +3132,12 @@ impl<'a> Parser<'a> {
 
     pub fn parse_delete(&mut self) -> Result<Statement, ParserError> {
         self.expect_keyword(Keyword::FROM)?;
-        let table_name = self.parse_object_name()?;
+        let table_name = self.parse_table_factor()?;
+        let using = if self.parse_keyword(Keyword::USING) {
+            Some(self.parse_table_factor()?)
+        } else {
+            None
+        };
         let selection = if self.parse_keyword(Keyword::WHERE) {
             Some(self.parse_expr()?)
         } else {
@@ -3141,6 +3146,7 @@ impl<'a> Parser<'a> {
 
         Ok(Statement::Delete {
             table_name,
+            using,
             selection,
         })
     }


### PR DESCRIPTION
[PostgreSQL](https://www.postgresql.org/docs/current/sql-delete.html) and [MySQL](https://dev.mysql.com/doc/refman/8.0/en/delete.html) have possibility of using aliases in `DELETE` statements.

PostgreSQL and [Snowflake](https://docs.snowflake.com/en/sql-reference/sql/delete.html) have `USING` clause. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>