### PR TITLE
create table: support CLONE syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -863,6 +863,7 @@ pub enum Statement {
         query: Option<Box<Query>>,
         without_rowid: bool,
         like: Option<ObjectName>,
+        clone: Option<ObjectName>,
         engine: Option<String>,
         default_charset: Option<String>,
         collation: Option<String>,
@@ -1484,6 +1485,7 @@ impl fmt::Display for Statement {
                 query,
                 without_rowid,
                 like,
+                clone,
                 default_charset,
                 engine,
                 collation,
@@ -1520,7 +1522,7 @@ impl fmt::Display for Statement {
                         write!(f, ", ")?;
                     }
                     write!(f, "{})", display_comma_separated(constraints))?;
-                } else if query.is_none() && like.is_none() {
+                } else if query.is_none() && like.is_none() && clone.is_none() {
                     // PostgreSQL allows `CREATE TABLE t ();`, but requires empty parens
                     write!(f, " ()")?;
                 }
@@ -1533,6 +1535,11 @@ impl fmt::Display for Statement {
                 if let Some(l) = like {
                     write!(f, " LIKE {}", l)?;
                 }
+
+                if let Some(c) = clone {
+                    write!(f, " CLONE {}", c)?;
+                }
+
                 match hive_distribution {
                     HiveDistributionStyle::PARTITIONED { columns } => {
                         write!(f, " PARTITIONED BY ({})", display_comma_separated(columns))?;

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -126,6 +126,7 @@ define_keywords!(
     CHAR_LENGTH,
     CHECK,
     CLOB,
+    CLONE,
     CLOSE,
     CLUSTER,
     COALESCE,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1774,6 +1774,7 @@ impl<'a> Parser<'a> {
             query: None,
             without_rowid: false,
             like: None,
+            clone: None,
             default_charset: None,
             engine: None,
             collation: None,
@@ -2064,6 +2065,13 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
+
+        let clone = if self.parse_keyword(Keyword::CLONE) {
+            self.parse_object_name().ok()
+        } else {
+            None
+        };
+
         // parse optional column list (schema)
         let (columns, constraints) = self.parse_columns()?;
 
@@ -2147,6 +2155,7 @@ impl<'a> Parser<'a> {
             query,
             without_rowid,
             like,
+            clone,
             engine,
             default_charset,
             collation,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1993,6 +1993,18 @@ fn parse_create_table_with_options() {
 }
 
 #[test]
+fn parse_create_table_clone() {
+    let sql = "CREATE OR REPLACE TABLE a CLONE a_tmp";
+    match verified_stmt(sql) {
+        Statement::CreateTable { name, clone, .. } => {
+            assert_eq!(ObjectName(vec![Ident::new("a")]), name);
+            assert_eq!(Some(ObjectName(vec![(Ident::new("a_tmp"))])), clone)
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_create_table_trailing_comma() {
     let sql = "CREATE TABLE foo (bar int,)";
     all_dialects().one_statement_parses_to(sql, "CREATE TABLE foo (bar INT)");


### PR DESCRIPTION
[Snowflake](https://docs.snowflake.com/en/sql-reference/sql/create-table.html), [Databricks](https://docs.databricks.com/spark/latest/spark-sql/language-manual/delta-clone.html), [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_clone_statement) support CREATE TABLE CLONE statement.


Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>