### PR TITLE
[postgres] Add support for custom binary operators

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -33,7 +33,7 @@ pub use self::ddl::{
     AlterColumnOperation, AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef,
     ReferentialAction, TableConstraint,
 };
-pub use self::operator::{BinaryOperator, UnaryOperator};
+pub use self::operator::{BinaryOperator, PGCustomOperator, UnaryOperator};
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, LateralView, LockType, Offset, OffsetRows,
     OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, TableAlias,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -33,7 +33,7 @@ pub use self::ddl::{
     AlterColumnOperation, AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef,
     ReferentialAction, TableConstraint,
 };
-pub use self::operator::{BinaryOperator, PGCustomOperator, UnaryOperator};
+pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, LateralView, LockType, Offset, OffsetRows,
     OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, TableAlias,

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -12,6 +12,8 @@
 
 use core::fmt;
 
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -13,7 +13,7 @@
 use core::fmt;
 
 #[cfg(not(feature = "std"))]
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -86,41 +86,59 @@ pub enum BinaryOperator {
     PGRegexIMatch,
     PGRegexNotMatch,
     PGRegexNotIMatch,
+    PGCustomBinaryOperator(PGCustomOperator),
+}
+
+/// PostgreSQL-specific custom operator.
+///
+/// See [CREATE OPERATOR](https://www.postgresql.org/docs/current/sql-createoperator.html) for more information.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PGCustomOperator {
+    pub schema: Option<String>,
+    pub name: String,
 }
 
 impl fmt::Display for BinaryOperator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(match self {
-            BinaryOperator::Plus => "+",
-            BinaryOperator::Minus => "-",
-            BinaryOperator::Multiply => "*",
-            BinaryOperator::Divide => "/",
-            BinaryOperator::Modulo => "%",
-            BinaryOperator::StringConcat => "||",
-            BinaryOperator::Gt => ">",
-            BinaryOperator::Lt => "<",
-            BinaryOperator::GtEq => ">=",
-            BinaryOperator::LtEq => "<=",
-            BinaryOperator::Spaceship => "<=>",
-            BinaryOperator::Eq => "=",
-            BinaryOperator::NotEq => "<>",
-            BinaryOperator::And => "AND",
-            BinaryOperator::Or => "OR",
-            BinaryOperator::Xor => "XOR",
-            BinaryOperator::Like => "LIKE",
-            BinaryOperator::NotLike => "NOT LIKE",
-            BinaryOperator::ILike => "ILIKE",
-            BinaryOperator::NotILike => "NOT ILIKE",
-            BinaryOperator::BitwiseOr => "|",
-            BinaryOperator::BitwiseAnd => "&",
-            BinaryOperator::BitwiseXor => "^",
-            BinaryOperator::PGBitwiseXor => "#",
-            BinaryOperator::PGBitwiseShiftLeft => "<<",
-            BinaryOperator::PGBitwiseShiftRight => ">>",
-            BinaryOperator::PGRegexMatch => "~",
-            BinaryOperator::PGRegexIMatch => "~*",
-            BinaryOperator::PGRegexNotMatch => "!~",
-            BinaryOperator::PGRegexNotIMatch => "!~*",
-        })
+        match self {
+            BinaryOperator::Plus => f.write_str("+"),
+            BinaryOperator::Minus => f.write_str("-"),
+            BinaryOperator::Multiply => f.write_str("*"),
+            BinaryOperator::Divide => f.write_str("/"),
+            BinaryOperator::Modulo => f.write_str("%"),
+            BinaryOperator::StringConcat => f.write_str("||"),
+            BinaryOperator::Gt => f.write_str(">"),
+            BinaryOperator::Lt => f.write_str("<"),
+            BinaryOperator::GtEq => f.write_str(">="),
+            BinaryOperator::LtEq => f.write_str("<="),
+            BinaryOperator::Spaceship => f.write_str("<=>"),
+            BinaryOperator::Eq => f.write_str("="),
+            BinaryOperator::NotEq => f.write_str("<>"),
+            BinaryOperator::And => f.write_str("AND"),
+            BinaryOperator::Or => f.write_str("OR"),
+            BinaryOperator::Xor => f.write_str("XOR"),
+            BinaryOperator::Like => f.write_str("LIKE"),
+            BinaryOperator::NotLike => f.write_str("NOT LIKE"),
+            BinaryOperator::ILike => f.write_str("ILIKE"),
+            BinaryOperator::NotILike => f.write_str("NOT ILIKE"),
+            BinaryOperator::BitwiseOr => f.write_str("|"),
+            BinaryOperator::BitwiseAnd => f.write_str("&"),
+            BinaryOperator::BitwiseXor => f.write_str("^"),
+            BinaryOperator::PGBitwiseXor => f.write_str("#"),
+            BinaryOperator::PGBitwiseShiftLeft => f.write_str("<<"),
+            BinaryOperator::PGBitwiseShiftRight => f.write_str(">>"),
+            BinaryOperator::PGRegexMatch => f.write_str("~"),
+            BinaryOperator::PGRegexIMatch => f.write_str("~*"),
+            BinaryOperator::PGRegexNotMatch => f.write_str("!~"),
+            BinaryOperator::PGRegexNotIMatch => f.write_str("!~*"),
+            BinaryOperator::PGCustomBinaryOperator(ref custom_operator) => {
+                write!(f, "OPERATOR(")?;
+                if let Some(ref schema) = custom_operator.schema {
+                    write!(f, "{}.", schema)?;
+                }
+                write!(f, "{})", custom_operator.name)
+            }
+        }
     }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -358,6 +358,7 @@ define_keywords!(
     ON,
     ONLY,
     OPEN,
+    OPERATOR,
     OPTION,
     OR,
     ORC,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1160,7 +1160,6 @@ impl<'a> Parser<'a> {
                 }
                 Keyword::XOR => Some(BinaryOperator::Xor),
                 Keyword::OPERATOR if dialect_of!(self is PostgreSqlDialect) => {
-                    debug!("parsing custom operator");
                     self.expect_token(&Token::LParen)?;
                     let token_1 = self.peek_nth_token(1);
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1159,7 +1159,7 @@ impl<'a> Parser<'a> {
                     }
                 }
                 Keyword::XOR => Some(BinaryOperator::Xor),
-                Keyword::OPERATOR if dialect_of!(self is PostgreSqlDialect) => {
+                Keyword::OPERATOR if dialect_of!(self is PostgreSqlDialect | GenericDialect) => {
                     self.expect_token(&Token::LParen)?;
                     let token_1 = self.peek_nth_token(1);
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1564,3 +1564,42 @@ fn parse_fetch() {
     pg_and_generic()
         .verified_stmt("FETCH BACKWARD ALL IN \"SQL_CUR0x7fa44801bc00\" INTO \"new_table\"");
 }
+
+#[test]
+fn parse_custom_operator() {
+    // operator with a schema
+    let sql = r#"SELECT * FROM events WHERE relname OPERATOR(pg_catalog.~) '^(table)$'"#;
+    let select = pg().verified_only_select(sql);
+    assert_eq!(
+        select.selection,
+        Some(Expr::BinaryOp {
+            left: Box::new(Expr::Identifier(Ident {
+                value: "relname".into(),
+                quote_style: None,
+            })),
+            op: BinaryOperator::PGCustomBinaryOperator(PGCustomOperator {
+                schema: Some("pg_catalog".into()),
+                name: "~".into(),
+            }),
+            right: Box::new(Expr::Value(Value::SingleQuotedString("^(table)$".into())))
+        })
+    );
+
+    // custom operator without a schema
+    let sql = r#"SELECT * FROM events WHERE relname OPERATOR(~) '^(table)$'"#;
+    let select = pg().verified_only_select(sql);
+    assert_eq!(
+        select.selection,
+        Some(Expr::BinaryOp {
+            left: Box::new(Expr::Identifier(Ident {
+                value: "relname".into(),
+                quote_style: None,
+            })),
+            op: BinaryOperator::PGCustomBinaryOperator(PGCustomOperator {
+                schema: None,
+                name: "~".into(),
+            }),
+            right: Box::new(Expr::Value(Value::SingleQuotedString("^(table)$".into())))
+        })
+    );
+}


### PR DESCRIPTION
More details about operators in general are at: https://www.postgresql.org/docs/current/sql-createoperator.html. This patch attempts to parse `SELECT` queries that reference an operator using `OPERATOR(<optional_schema>.<operator_name>)` syntax. Tests added in the patch illustrate a common use-case of this feature.

This is a PostgreSQL extension. There are no provisions for user-defined operators in the SQL standard.