### PR TITLE
Remove unnecessary `Box`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -783,7 +783,7 @@ pub enum Statement {
         partition_action: Option<AddDropSync>,
     },
     /// SELECT
-    Query(Box<Query>),
+    Query(Query),
     /// INSERT
     Insert {
         /// Only for Sqlite

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -782,7 +782,7 @@ pub enum Statement {
         repair: bool,
         partition_action: Option<AddDropSync>,
     },
-    /// SELECT
+    /// SELECT, VALUES
     Query(Query),
     /// INSERT
     Insert {

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -74,7 +74,7 @@ pub enum SetExpr {
     Select(Box<Select>),
     /// Parenthesized SELECT subquery, which may include more set operations
     /// in its body and an optional ORDER BY / LIMIT.
-    Query(Box<Query>),
+    Query(Query),
     /// UNION/EXCEPT/INTERSECT of two queries
     SetOperation {
         op: SetOperator,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -160,7 +160,7 @@ impl<'a> Parser<'a> {
                 Keyword::ANALYZE => Ok(self.parse_analyze()?),
                 Keyword::SELECT | Keyword::WITH | Keyword::VALUES => {
                     self.prev_token();
-                    Ok(Statement::Query(Box::new(self.parse_query()?)))
+                    Ok(Statement::Query(self.parse_query()?))
                 }
                 Keyword::TRUNCATE => Ok(self.parse_truncate()?),
                 Keyword::MSCK => Ok(self.parse_msck()?),
@@ -205,7 +205,7 @@ impl<'a> Parser<'a> {
             },
             Token::LParen => {
                 self.prev_token();
-                Ok(Statement::Query(Box::new(self.parse_query()?)))
+                Ok(Statement::Query(self.parse_query()?))
             }
             unexpected => self.expected("an SQL statement", unexpected),
         }
@@ -3429,7 +3429,7 @@ impl<'a> Parser<'a> {
             // CTEs are not allowed here, but the parser currently accepts them
             let subquery = self.parse_query()?;
             self.expect_token(&Token::RParen)?;
-            SetExpr::Query(Box::new(subquery))
+            SetExpr::Query(subquery)
         } else if self.parse_keyword(Keyword::VALUES) {
             SetExpr::Values(self.parse_values()?)
         } else {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -107,7 +107,7 @@ impl TestedDialects {
     /// after a serialization round-trip.
     pub fn verified_query(&self, sql: &str) -> Query {
         match self.verified_stmt(sql) {
-            Statement::Query(query) => *query,
+            Statement::Query(query) => query,
             _ => panic!("Expected Query"),
         }
     }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -312,7 +312,7 @@ fn parse_quote_identifiers_2() {
     let sql = "SELECT `quoted `` identifier`";
     assert_eq!(
         mysql().verified_stmt(sql),
-        Statement::Query(Box::new(Query {
+        Statement::Query(Query {
             with: None,
             body: Box::new(SetExpr::Select(Box::new(Select {
                 distinct: false,
@@ -337,7 +337,7 @@ fn parse_quote_identifiers_2() {
             offset: None,
             fetch: None,
             lock: None,
-        }))
+        })
     );
 }
 
@@ -346,7 +346,7 @@ fn parse_quote_identifiers_3() {
     let sql = "SELECT ```quoted identifier```";
     assert_eq!(
         mysql().verified_stmt(sql),
-        Statement::Query(Box::new(Query {
+        Statement::Query(Query {
             with: None,
             body: Box::new(SetExpr::Select(Box::new(Select {
                 distinct: false,
@@ -371,7 +371,7 @@ fn parse_quote_identifiers_3() {
             offset: None,
             fetch: None,
             lock: None,
-        }))
+        })
     );
 }
 
@@ -766,7 +766,7 @@ fn parse_substring_in_select() {
     ) {
         Statement::Query(query) => {
             assert_eq!(
-                Box::new(Query {
+                Query {
                     with: None,
                     body: Box::new(SetExpr::Select(Box::new(Select {
                         distinct: true,
@@ -812,7 +812,7 @@ fn parse_substring_in_select() {
                     offset: None,
                     fetch: None,
                     lock: None,
-                }),
+                },
                 query
             );
         }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1068,9 +1068,9 @@ fn parse_prepare() {
     };
     assert_eq!(
         sub_stmt,
-        Box::new(Statement::Query(Box::new(pg_and_generic().verified_query(
+        Box::new(Statement::Query(pg_and_generic().verified_query(
             "SELECT * FROM customers WHERE customers.id = a1"
-        ))))
+        )))
     );
 }
 


### PR DESCRIPTION
Previously, `Query` variant in enum `Statement` seemed to be used recursively, but this is not the case now.

