### PR TITLE
feat: Support parsing MySQL show variables

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -996,6 +996,10 @@ pub enum Statement {
     ///
     /// Note: this is a PostgreSQL-specific statement.
     ShowVariable { variable: Vec<Ident> },
+    /// SHOW VARIABLES
+    ///
+    /// Note: this is a MySQL-specific statement.
+    ShowVariables { filter: Option<ShowStatementFilter> },
     /// SHOW CREATE TABLE
     ///
     /// Note: this is a MySQL-specific statement.
@@ -1784,6 +1788,13 @@ impl fmt::Display for Statement {
                 write!(f, "SHOW")?;
                 if !variable.is_empty() {
                     write!(f, " {}", display_separated(variable, " "))?;
+                }
+                Ok(())
+            }
+            Statement::ShowVariables { filter } => {
+                write!(f, "SHOW VARIABLES")?;
+                if filter.is_some() {
+                    write!(f, " {}", filter.as_ref().unwrap())?;
                 }
                 Ok(())
             }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -543,6 +543,7 @@ define_keywords!(
     VALUE_OF,
     VARBINARY,
     VARCHAR,
+    VARIABLES,
     VARYING,
     VAR_POP,
     VAR_SAMP,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3694,6 +3694,13 @@ impl<'a> Parser<'a> {
             Ok(self.parse_show_columns()?)
         } else if self.parse_one_of_keywords(&[Keyword::CREATE]).is_some() {
             Ok(self.parse_show_create()?)
+        } else if self.parse_keyword(Keyword::VARIABLES)
+            && dialect_of!(self is MySqlDialect | GenericDialect)
+        {
+            // TODO: Support GLOBAL|SESSION
+            Ok(Statement::ShowVariables {
+                filter: self.parse_show_statement_filter()?,
+            })
         } else {
             Ok(Statement::ShowVariable {
                 variable: self.parse_identifiers()?,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -821,6 +821,13 @@ fn parse_substring_in_select() {
 }
 
 #[test]
+fn parse_show_variables() {
+    mysql_and_generic().verified_stmt("SHOW VARIABLES");
+    mysql_and_generic().verified_stmt("SHOW VARIABLES LIKE 'admin%'");
+    mysql_and_generic().verified_stmt("SHOW VARIABLES WHERE value = '3306'");
+}
+
+#[test]
 fn parse_kill() {
     let stmt = mysql_and_generic().verified_stmt("KILL CONNECTION 5");
     assert_eq!(


### PR DESCRIPTION
Hello!

```
SHOW [GLOBAL | SESSION] VARIABLES
    [LIKE 'pattern' | WHERE expr]
```

Thanks