### PR TITLE
feat: Parse special keywords as functions (current_user, user, etc)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2292,20 +2292,27 @@ pub struct Function {
     pub over: Option<WindowSpec>,
     // aggregate functions may specify eg `COUNT(DISTINCT x)`
     pub distinct: bool,
+    pub special: bool,
 }
 
 impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}({}{})",
-            self.name,
-            if self.distinct { "DISTINCT " } else { "" },
-            display_comma_separated(&self.args),
-        )?;
-        if let Some(o) = &self.over {
-            write!(f, " OVER ({})", o)?;
+        if self.special {
+            write!(f, "{}", self.name)?;
+        } else {
+            write!(
+                f,
+                "{}({}{})",
+                self.name,
+                if self.distinct { "DISTINCT " } else { "" },
+                display_comma_separated(&self.args),
+            )?;
+
+            if let Some(o) = &self.over {
+                write!(f, " OVER ({})", o)?;
+            }
         }
+
         Ok(())
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2292,6 +2292,8 @@ pub struct Function {
     pub over: Option<WindowSpec>,
     // aggregate functions may specify eg `COUNT(DISTINCT x)`
     pub distinct: bool,
+    // Some functions must be called without trailing parentheses, for example Postgres
+    // do it for current_catalog, current_schema, etc. This flags is used for formatting.
     pub special: bool,
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -421,6 +421,20 @@ impl<'a> Parser<'a> {
                     self.prev_token();
                     Ok(Expr::Value(self.parse_value()?))
                 }
+                Keyword::CURRENT_CATALOG
+                | Keyword::CURRENT_USER
+                | Keyword::SESSION_USER
+                | Keyword::USER
+                    if dialect_of!(self is PostgreSqlDialect | GenericDialect) =>
+                {
+                    Ok(Expr::Function(Function {
+                        name: ObjectName(vec![w.to_ident()]),
+                        args: vec![],
+                        over: None,
+                        distinct: false,
+                        special: true,
+                    }))
+                }
                 Keyword::CURRENT_TIMESTAMP | Keyword::CURRENT_TIME | Keyword::CURRENT_DATE => {
                     self.parse_time_functions(ObjectName(vec![w.to_ident()]))
                 }
@@ -598,6 +612,7 @@ impl<'a> Parser<'a> {
             args,
             over,
             distinct,
+            special: false,
         }))
     }
 
@@ -612,6 +627,7 @@ impl<'a> Parser<'a> {
             args,
             over: None,
             distinct: false,
+            special: false,
         }))
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -572,6 +572,7 @@ fn parse_select_count_wildcard() {
             args: vec![FunctionArg::Unnamed(FunctionArgExpr::Wildcard)],
             over: None,
             distinct: false,
+            special: false,
         }),
         expr_from_projection(only(&select.projection))
     );
@@ -590,6 +591,7 @@ fn parse_select_count_distinct() {
             }))],
             over: None,
             distinct: true,
+            special: false,
         }),
         expr_from_projection(only(&select.projection))
     );
@@ -1414,6 +1416,7 @@ fn parse_select_having() {
                 args: vec![FunctionArg::Unnamed(FunctionArgExpr::Wildcard)],
                 over: None,
                 distinct: false,
+                special: false,
             })),
             op: BinaryOperator::Gt,
             right: Box::new(Expr::Value(number("1")))
@@ -1445,7 +1448,8 @@ fn parse_select_qualify() {
                     }],
                     window_frame: None
                 }),
-                distinct: false
+                distinct: false,
+                special: false
             })),
             op: BinaryOperator::Eq,
             right: Box::new(Expr::Value(number("1")))
@@ -2532,6 +2536,7 @@ fn parse_scalar_function_in_projection() {
                 ))],
                 over: None,
                 distinct: false,
+                special: false,
             }),
             expr_from_projection(only(&select.projection))
         );
@@ -2610,6 +2615,7 @@ fn parse_named_argument_function() {
             ],
             over: None,
             distinct: false,
+            special: false,
         }),
         expr_from_projection(only(&select.projection))
     );
@@ -2643,6 +2649,7 @@ fn parse_window_functions() {
                 window_frame: None,
             }),
             distinct: false,
+            special: false,
         }),
         expr_from_projection(&select.projection[0])
     );
@@ -2906,7 +2913,8 @@ fn parse_at_timezone() {
                 }]),
                 args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(zero.clone()))],
                 over: None,
-                distinct: false
+                distinct: false,
+                special: false,
             })),
             time_zone: "UTC-06:00".to_string()
         },
@@ -2932,6 +2940,7 @@ fn parse_at_timezone() {
                             args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(zero,),),],
                             over: None,
                             distinct: false,
+                            special: false
                         },)),
                         time_zone: "UTC-06:00".to_string(),
                     },),),
@@ -2941,6 +2950,7 @@ fn parse_at_timezone() {
                 ],
                 over: None,
                 distinct: false,
+                special: false
             },),
             alias: Ident {
                 value: "hour".to_string(),
@@ -2976,6 +2986,7 @@ fn parse_table_function() {
                 )))],
                 over: None,
                 distinct: false,
+                special: false,
             });
             assert_eq!(expr, expected_expr);
             assert_eq!(alias, table_alias("a"))
@@ -3148,6 +3159,7 @@ fn parse_delimited_identifiers() {
             args: vec![],
             over: None,
             distinct: false,
+            special: false,
         }),
         expr_from_projection(&select.projection[1]),
     );
@@ -5125,6 +5137,7 @@ fn parse_time_functions() {
             args: vec![],
             over: None,
             distinct: false,
+            special: false,
         }),
         expr_from_projection(&select.projection[0])
     );
@@ -5140,6 +5153,7 @@ fn parse_time_functions() {
             args: vec![],
             over: None,
             distinct: false,
+            special: false,
         }),
         expr_from_projection(&select.projection[0])
     );
@@ -5155,6 +5169,7 @@ fn parse_time_functions() {
             args: vec![],
             over: None,
             distinct: false,
+            special: false,
         }),
         expr_from_projection(&select.projection[0])
     );

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -611,7 +611,8 @@ fn parse_insert_with_on_duplicate_update() {
                                 Expr::Identifier(Ident::new("description"))
                             ))],
                             over: None,
-                            distinct: false
+                            distinct: false,
+                            special: false,
                         })
                     },
                     Assignment {
@@ -622,7 +623,8 @@ fn parse_insert_with_on_duplicate_update() {
                                 Expr::Identifier(Ident::new("perm_create"))
                             ))],
                             over: None,
-                            distinct: false
+                            distinct: false,
+                            special: false,
                         })
                     },
                     Assignment {
@@ -633,7 +635,8 @@ fn parse_insert_with_on_duplicate_update() {
                                 Expr::Identifier(Ident::new("perm_read"))
                             ))],
                             over: None,
-                            distinct: false
+                            distinct: false,
+                            special: false,
                         })
                     },
                     Assignment {
@@ -644,7 +647,8 @@ fn parse_insert_with_on_duplicate_update() {
                                 Expr::Identifier(Ident::new("perm_update"))
                             ))],
                             over: None,
-                            distinct: false
+                            distinct: false,
+                            special: false,
                         })
                     },
                     Assignment {
@@ -655,7 +659,8 @@ fn parse_insert_with_on_duplicate_update() {
                                 Expr::Identifier(Ident::new("perm_delete"))
                             ))],
                             over: None,
-                            distinct: false
+                            distinct: false,
+                            special: false,
                         })
                     },
                 ])),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1400,6 +1400,7 @@ fn test_composite_value() {
                 )))],
                 over: None,
                 distinct: false,
+                special: false
             }))))
         }),
         select.projection[0]
@@ -1540,6 +1541,52 @@ fn parse_declare() {
     pg_and_generic()
         .verified_stmt("DECLARE \"SQL_CUR0x7fa44801bc00\" NO SCROLL CURSOR FOR SELECT 1");
     pg_and_generic().verified_stmt("DECLARE \"SQL_CUR0x7fa44801bc00\" BINARY INSENSITIVE SCROLL CURSOR WITH HOLD FOR SELECT * FROM table_name LIMIT 2222");
+}
+
+#[test]
+fn parse_current_functions() {
+    let sql = "SELECT CURRENT_CATALOG, CURRENT_USER, SESSION_USER, USER";
+    let select = pg_and_generic().verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("CURRENT_CATALOG")]),
+            args: vec![],
+            over: None,
+            distinct: false,
+            special: true,
+        }),
+        expr_from_projection(&select.projection[0])
+    );
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("CURRENT_USER")]),
+            args: vec![],
+            over: None,
+            distinct: false,
+            special: true,
+        }),
+        expr_from_projection(&select.projection[1])
+    );
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("SESSION_USER")]),
+            args: vec![],
+            over: None,
+            distinct: false,
+            special: true,
+        }),
+        expr_from_projection(&select.projection[2])
+    );
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("USER")]),
+            args: vec![],
+            over: None,
+            distinct: false,
+            special: true,
+        }),
+        expr_from_projection(&select.projection[3])
+    );
 }
 
 #[test]

--- a/tests/sqpparser_clickhouse.rs
+++ b/tests/sqpparser_clickhouse.rs
@@ -51,6 +51,7 @@ fn parse_map_access_expr() {
                     ],
                     over: None,
                     distinct: false,
+                    special: false,
                 })],
             })],
             into: None,
@@ -85,7 +86,8 @@ fn parse_map_access_expr() {
                                 ))),
                             ],
                             over: None,
-                            distinct: false
+                            distinct: false,
+                            special: false,
                         })]
                     }),
                     op: BinaryOperator::NotEq,


### PR DESCRIPTION
Hello!

> Note: current_catalog, current_schema, current_user, session_user, and user have special syntactic status in SQL: they must be called without trailing parentheses. (In PostgreSQL, parentheses can optionally be used with current_schema, but not with the others.)

https://www.postgresql.org/docs/9.1/functions-info.html


Thanks