### PR TITLE
Support `SHOW COLUMNS FROM tbl FROM db`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3732,10 +3732,16 @@ impl<'a> Parser<'a> {
         let full = self.parse_keyword(Keyword::FULL);
         self.expect_one_of_keywords(&[Keyword::COLUMNS, Keyword::FIELDS])?;
         self.expect_one_of_keywords(&[Keyword::FROM, Keyword::IN])?;
-        let table_name = self.parse_object_name()?;
-        // MySQL also supports FROM <database> here. In other words, MySQL
-        // allows both FROM <table> FROM <database> and FROM <database>.<table>,
-        // while we only support the latter for now.
+        let object_name = self.parse_object_name()?;
+        let table_name = match self.parse_one_of_keywords(&[Keyword::FROM, Keyword::IN]) {
+            Some(_) => {
+                let db_name = vec![self.parse_identifier()?];
+                let ObjectName(table_name) = object_name;
+                let object_name = db_name.into_iter().chain(table_name.into_iter()).collect();
+                ObjectName(object_name)
+            }
+            None => object_name,
+        };
         let filter = self.parse_show_statement_filter()?;
         Ok(Statement::ShowColumns {
             extended,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -110,12 +110,10 @@ fn parse_show_columns() {
         .one_statement_parses_to("SHOW COLUMNS IN mytable", "SHOW COLUMNS FROM mytable");
     mysql_and_generic()
         .one_statement_parses_to("SHOW FIELDS IN mytable", "SHOW COLUMNS FROM mytable");
-
-    // unhandled things are truly unhandled
-    match mysql_and_generic().parse_sql_statements("SHOW COLUMNS FROM mytable FROM mydb") {
-        Err(_) => {}
-        Ok(val) => panic!("unexpected successful parse: {:?}", val),
-    }
+    mysql_and_generic().one_statement_parses_to(
+        "SHOW COLUMNS FROM mytable FROM mydb",
+        "SHOW COLUMNS FROM mydb.mytable",
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for `SHOW COLUMNS FROM tbl [FROM db]` alternative MySQL syntax. Previously only `SHOW COLUMNS FROM [db.]tbl` syntax was supported.
There are no changes to AST, so no breakage for dependents is expected.