### PR TITLE
Support full `SHOW TABLES` syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1027,6 +1027,15 @@ pub enum Statement {
         table_name: ObjectName,
         filter: Option<ShowStatementFilter>,
     },
+    /// SHOW TABLES
+    ///
+    /// Note: this is a MySQL-specific statement.
+    ShowTables {
+        extended: bool,
+        full: bool,
+        db_name: Option<Ident>,
+        filter: Option<ShowStatementFilter>,
+    },
     /// USE
     ///
     /// Note: This is a MySQL-specific statement.
@@ -1854,6 +1863,26 @@ impl fmt::Display for Statement {
                     full = if *full { "FULL " } else { "" },
                     table_name = table_name,
                 )?;
+                if let Some(filter) = filter {
+                    write!(f, " {}", filter)?;
+                }
+                Ok(())
+            }
+            Statement::ShowTables {
+                extended,
+                full,
+                db_name,
+                filter,
+            } => {
+                write!(
+                    f,
+                    "SHOW {extended}{full}TABLES",
+                    extended = if *extended { "EXTENDED " } else { "" },
+                    full = if *full { "FULL " } else { "" },
+                )?;
+                if let Some(db_name) = db_name {
+                    write!(f, " FROM {}", db_name)?;
+                }
                 if let Some(filter) = filter {
                     write!(f, " {}", filter)?;
                 }


### PR DESCRIPTION
This PR adds support for MySQL-specific `SHOW TABLES` statement with full syntax support, as well as a related test.