### PR TITLE
Support `USE db`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1012,6 +1012,10 @@ pub enum Statement {
         table_name: ObjectName,
         filter: Option<ShowStatementFilter>,
     },
+    /// USE
+    ///
+    /// Note: This is a MySQL-specific statement.
+    Use { db_name: Ident },
     /// `{ BEGIN [ TRANSACTION | WORK ] | START TRANSACTION } ...`
     StartTransaction { modes: Vec<TransactionMode> },
     /// `SET TRANSACTION ...`
@@ -1812,6 +1816,10 @@ impl fmt::Display for Statement {
                 if let Some(filter) = filter {
                     write!(f, " {}", filter)?;
                 }
+                Ok(())
+            }
+            Statement::Use { db_name } => {
+                write!(f, "USE {}", db_name)?;
                 Ok(())
             }
             Statement::StartTransaction { modes } => {

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -535,6 +535,7 @@ define_keywords!(
     UPDATE,
     UPPER,
     USAGE,
+    USE,
     USER,
     USING,
     UUID,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -177,6 +177,7 @@ impl<'a> Parser<'a> {
                 Keyword::CLOSE => Ok(self.parse_close()?),
                 Keyword::SET => Ok(self.parse_set()?),
                 Keyword::SHOW => Ok(self.parse_show()?),
+                Keyword::USE => Ok(self.parse_use()?),
                 Keyword::GRANT => Ok(self.parse_grant()?),
                 Keyword::REVOKE => Ok(self.parse_revoke()?),
                 Keyword::START => Ok(self.parse_start_transaction()?),
@@ -3761,6 +3762,11 @@ impl<'a> Parser<'a> {
         } else {
             Ok(None)
         }
+    }
+
+    pub fn parse_use(&mut self) -> Result<Statement, ParserError> {
+        let db_name = self.parse_identifier()?;
+        Ok(Statement::Use { db_name })
     }
 
     pub fn parse_table_and_joins(&mut self) -> Result<TableWithJoins, ParserError> {

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -141,6 +141,16 @@ fn parse_show_create() {
 }
 
 #[test]
+fn parse_use() {
+    assert_eq!(
+        mysql_and_generic().verified_stmt("USE mydb"),
+        Statement::Use {
+            db_name: Ident::new("mydb")
+        }
+    );
+}
+
+#[test]
 fn parse_create_table_auto_increment() {
     let sql = "CREATE TABLE foo (bar INT PRIMARY KEY AUTO_INCREMENT)";
     match mysql().verified_stmt(sql) {


### PR DESCRIPTION
This PR adds support for MySQL-specific `USE db` statement, as well as a related test.