### PR TITLE
Support PostgreSQL array subquery constructor

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -376,6 +376,8 @@ pub enum Expr {
     /// A parenthesized subquery `(SELECT ...)`, used in expression like
     /// `SELECT (subquery) AS x` or `WHERE (subquery) = x`
     Subquery(Box<Query>),
+    /// An array subquery constructor, e.g. `SELECT ARRAY(SELECT 1 UNION SELECT 2)`
+    ArraySubquery(Box<Query>),
     /// The `LISTAGG` function `SELECT LISTAGG(...) WITHIN GROUP (ORDER BY ...)`
     ListAgg(ListAgg),
     /// The `GROUPING SETS` expr.
@@ -573,6 +575,7 @@ impl fmt::Display for Expr {
                 subquery
             ),
             Expr::Subquery(s) => write!(f, "({})", s),
+            Expr::ArraySubquery(s) => write!(f, "ARRAY({})", s),
             Expr::ListAgg(listagg) => write!(f, "{}", listagg),
             Expr::GroupingSets(sets) => {
                 write!(f, "GROUPING SETS (")?;

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -122,6 +122,25 @@ fn parse_array_expr() {
 }
 
 #[test]
+fn parse_array_fn() {
+    let sql = "SELECT array(x1, x2) FROM foo";
+    let select = clickhouse().verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("array")]),
+            args: vec![
+                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(Ident::new("x1")))),
+                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(Ident::new("x2")))),
+            ],
+            over: None,
+            distinct: false,
+            special: false,
+        }),
+        expr_from_projection(only(&select.projection))
+    );
+}
+
+#[test]
 fn parse_kill() {
     let stmt = clickhouse().verified_stmt("KILL MUTATION 5");
     assert_eq!(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2597,7 +2597,7 @@ fn parse_bad_constraint() {
 
 #[test]
 fn parse_scalar_function_in_projection() {
-    let names = vec!["sqrt", "array", "foo"];
+    let names = vec!["sqrt", "foo"];
 
     for function_name in names {
         // like SELECT sqrt(id) FROM foo


### PR DESCRIPTION
This PR adds support for PostgreSQL array subquery constructor (e.g. `SELECT ARRAY(SELECT 1 UNION SELECT 2)`), as well as a related test.