### PR TITLE
Support expressions in `LIMIT`/`OFFSET`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4402,13 +4402,13 @@ impl<'a> Parser<'a> {
         if self.parse_keyword(Keyword::ALL) {
             Ok(None)
         } else {
-            Ok(Some(Expr::Value(self.parse_number_value()?)))
+            Ok(Some(self.parse_expr()?))
         }
     }
 
     /// Parse an OFFSET clause
     pub fn parse_offset(&mut self) -> Result<Offset, ParserError> {
-        let value = Expr::Value(self.parse_number_value()?);
+        let value = self.parse_expr()?;
         let rows = if self.parse_keyword(Keyword::ROW) {
             OffsetRows::Row
         } else if self.parse_keyword(Keyword::ROWS) {


### PR DESCRIPTION
`LIMIT` and `OFFSET` allow usage of complex expressions, such as `1+2`, or placeholders for prepared statements, whereas sqlparser only accepts numbers. This PR adds support for any kind of expression in `LIMIT` and `OFFSET`, and adds related tests.