### PR TITLE
Support for `SIMILAR TO` syntax, change `Like` and `ILike` to `Expr` variants, allow escape char for like/ilike

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,5 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -268,6 +270,27 @@ pub enum Expr {
         op: BinaryOperator,
         right: Box<Expr>,
     },
+    /// LIKE
+    Like {
+        negated: bool,
+        expr: Box<Expr>,
+        pattern: Box<Value>,
+        escape_char: Option<char>,
+    },
+    /// ILIKE (case-insensitive LIKE)
+    ILike {
+        negated: bool,
+        expr: Box<Expr>,
+        pattern: Box<Value>,
+        escape_char: Option<char>,
+    },
+    /// SIMILAR TO regex
+    SimilarTo {
+        negated: bool,
+        expr: Box<Expr>,
+        pattern: Box<Value>,
+        escape_char: Option<char>,
+    },
     /// Any operation e.g. `1 ANY (1)` or `foo > ANY(bar)`, It will be wrapped in the right side of BinaryExpr
     AnyOp(Box<Expr>),
     /// ALL operation e.g. `1 ALL (1)` or `foo > ALL(bar)`, It will be wrapped in the right side of BinaryExpr
@@ -438,6 +461,72 @@ impl fmt::Display for Expr {
                 high
             ),
             Expr::BinaryOp { left, op, right } => write!(f, "{} {} {}", left, op, right),
+            Expr::Like {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+            } => match escape_char {
+                Some(ch) => write!(
+                    f,
+                    "{} {}LIKE {} ESCAPE '{}'",
+                    expr,
+                    if *negated { "NOT " } else { "" },
+                    pattern,
+                    ch
+                ),
+                _ => write!(
+                    f,
+                    "{} {}LIKE {}",
+                    expr,
+                    if *negated { "NOT " } else { "" },
+                    pattern
+                ),
+            },
+            Expr::ILike {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+            } => match escape_char {
+                Some(ch) => write!(
+                    f,
+                    "{} {}ILIKE {} ESCAPE '{}'",
+                    expr,
+                    if *negated { "NOT " } else { "" },
+                    pattern,
+                    ch
+                ),
+                _ => write!(
+                    f,
+                    "{} {}ILIKE {}",
+                    expr,
+                    if *negated { "NOT " } else { "" },
+                    pattern
+                ),
+            },
+            Expr::SimilarTo {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+            } => match escape_char {
+                Some(ch) => write!(
+                    f,
+                    "{} {}SIMILAR TO {} ESCAPE '{}'",
+                    expr,
+                    if *negated { "NOT " } else { "" },
+                    pattern,
+                    ch
+                ),
+                _ => write!(
+                    f,
+                    "{} {}SIMILAR TO {}",
+                    expr,
+                    if *negated { "NOT " } else { "" },
+                    pattern
+                ),
+            },
             Expr::AnyOp(expr) => write!(f, "ANY({})", expr),
             Expr::AllOp(expr) => write!(f, "ALL({})", expr),
             Expr::UnaryOp { op, expr } => {

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -76,10 +78,6 @@ pub enum BinaryOperator {
     And,
     Or,
     Xor,
-    Like,
-    NotLike,
-    ILike,
-    NotILike,
     BitwiseOr,
     BitwiseAnd,
     BitwiseXor,
@@ -116,10 +114,6 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::And => f.write_str("AND"),
             BinaryOperator::Or => f.write_str("OR"),
             BinaryOperator::Xor => f.write_str("XOR"),
-            BinaryOperator::Like => f.write_str("LIKE"),
-            BinaryOperator::NotLike => f.write_str("NOT LIKE"),
-            BinaryOperator::ILike => f.write_str("ILIKE"),
-            BinaryOperator::NotILike => f.write_str("NOT ILIKE"),
             BinaryOperator::BitwiseOr => f.write_str("|"),
             BinaryOperator::BitwiseAnd => f.write_str("&"),
             BinaryOperator::BitwiseXor => f.write_str("^"),

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,5 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -899,6 +899,22 @@ fn parse_like() {
             select.selection.unwrap()
         );
 
+        // Test with escape char
+        let sql = &format!(
+            "SELECT * FROM customers WHERE name {}LIKE '%a' ESCAPE '\\'",
+            if negated { "NOT " } else { "" }
+        );
+        let select = verified_only_select(sql);
+        assert_eq!(
+            Expr::Like {
+                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                negated,
+                pattern: Box::new(Value::SingleQuotedString("%a".to_string())),
+                escape_char: Some('\\')
+            },
+            select.selection.unwrap()
+        );
+
         // This statement tests that LIKE and NOT LIKE have the same precedence.
         // This was previously mishandled (#81).
         let sql = &format!(
@@ -938,7 +954,23 @@ fn parse_ilike() {
             select.selection.unwrap()
         );
 
-        // This statement tests that LIKE and NOT LIKE have the same precedence.
+        // Test with escape char
+        let sql = &format!(
+            "SELECT * FROM customers WHERE name {}ILIKE '%a' ESCAPE '^'",
+            if negated { "NOT " } else { "" }
+        );
+        let select = verified_only_select(sql);
+        assert_eq!(
+            Expr::ILike {
+                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                negated,
+                pattern: Box::new(Value::SingleQuotedString("%a".to_string())),
+                escape_char: Some('^')
+            },
+            select.selection.unwrap()
+        );
+
+        // This statement tests that ILIKE and NOT ILIKE have the same precedence.
         // This was previously mishandled (#81).
         let sql = &format!(
             "SELECT * FROM customers WHERE name {}ILIKE '%a' IS NULL",
@@ -963,6 +995,22 @@ fn parse_ilike() {
 fn parse_similar_to() {
     fn chk(negated: bool) {
         let sql = &format!(
+            "SELECT * FROM customers WHERE name {}SIMILAR TO '%a'",
+            if negated { "NOT " } else { "" }
+        );
+        let select = verified_only_select(sql);
+        assert_eq!(
+            Expr::SimilarTo {
+                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                negated,
+                pattern: Box::new(Value::SingleQuotedString("%a".to_string())),
+                escape_char: None
+            },
+            select.selection.unwrap()
+        );
+
+        // Test with escape char
+        let sql = &format!(
             "SELECT * FROM customers WHERE name {}SIMILAR TO '%a' ESCAPE '\\'",
             if negated { "NOT " } else { "" }
         );
@@ -977,8 +1025,7 @@ fn parse_similar_to() {
             select.selection.unwrap()
         );
 
-        // This statement tests that LIKE and NOT LIKE have the same precedence.
-        // This was previously mishandled (#81).
+        // This statement tests that SIMILAR TO and NOT SIMILAR TO have the same precedence.
         let sql = &format!(
             "SELECT * FROM customers WHERE name {}SIMILAR TO '%a' ESCAPE '\\' IS NULL",
             if negated { "NOT " } else { "" }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -894,7 +894,7 @@ fn parse_like() {
         assert_eq!(
             Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
-                negated: negated,
+                negated,
                 pattern: Box::new(Value::SingleQuotedString("%a".to_string())),
                 escape_char: None
             },
@@ -911,7 +911,7 @@ fn parse_like() {
         assert_eq!(
             Expr::IsNull(Box::new(Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
-                negated: negated,
+                negated,
                 pattern: Box::new(Value::SingleQuotedString("%a".to_string())),
                 escape_char: None
             })),
@@ -933,7 +933,7 @@ fn parse_ilike() {
         assert_eq!(
             Expr::ILike {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
-                negated: negated,
+                negated,
                 pattern: Box::new(Value::SingleQuotedString("%a".to_string())),
                 escape_char: None
             },
@@ -950,7 +950,7 @@ fn parse_ilike() {
         assert_eq!(
             Expr::IsNull(Box::new(Expr::ILike {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
-                negated: negated,
+                negated,
                 pattern: Box::new(Value::SingleQuotedString("%a".to_string())),
                 escape_char: None
             })),
@@ -972,7 +972,7 @@ fn parse_similar_to() {
         assert_eq!(
             Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
-                negated: negated,
+                negated,
                 pattern: Box::new(Value::SingleQuotedString("%a".to_string())),
                 escape_char: Some('\\')
             },
@@ -989,7 +989,7 @@ fn parse_similar_to() {
         assert_eq!(
             Expr::IsNull(Box::new(Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
-                negated: negated,
+                negated,
                 pattern: Box::new(Value::SingleQuotedString("%a".to_string())),
                 escape_char: Some('\\')
             })),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1,5 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
This pr adds support for the `similar to` sql operator syntax and also adds support to provide escape char to the `[Not] like/ilike` operators. 