### PR TITLE
Box `Query` in `Cte`

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -271,7 +271,7 @@ impl fmt::Display for With {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Cte {
     pub alias: TableAlias,
-    pub query: Query,
+    pub query: Box<Query>,
     pub from: Option<Ident>,
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3466,7 +3466,7 @@ impl<'a> Parser<'a> {
 
         let mut cte = if self.parse_keyword(Keyword::AS) {
             self.expect_token(&Token::LParen)?;
-            let query = self.parse_query()?;
+            let query = Box::new(self.parse_query()?);
             self.expect_token(&Token::RParen)?;
             let alias = TableAlias {
                 name,
@@ -3481,7 +3481,7 @@ impl<'a> Parser<'a> {
             let columns = self.parse_parenthesized_column_list(Optional)?;
             self.expect_keyword(Keyword::AS)?;
             self.expect_token(&Token::LParen)?;
-            let query = self.parse_query()?;
+            let query = Box::new(self.parse_query()?);
             self.expect_token(&Token::RParen)?;
             let alias = TableAlias { name, columns };
             Cte {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3760,7 +3760,7 @@ fn parse_recursive_cte() {
                 quote_style: None,
             }],
         },
-        query: cte_query,
+        query: Box::new(cte_query),
         from: None,
     };
     assert_eq!(with.cte_tables.first().unwrap(), &expected);


### PR DESCRIPTION
`Cte` is the only struct that has `Query` unboxed; all other instances are `Box`ed. I propose `Box`ing `Query` in `Cte` for the sake of interoperability and keeping things similar, thus the PR contains the proposed change.