### PR TITLE
Support `TRIM` from with optional expr and FROM expr

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -337,7 +337,8 @@ pub enum Expr {
     Trim {
         expr: Box<Expr>,
         // ([BOTH | LEADING | TRAILING], <expr>)
-        trim_where: Option<(TrimWhereField, Box<Expr>)>,
+        trim_where: Option<TrimWhereField>,
+        trim_what: Option<Box<Expr>>,
     },
     /// `expr COLLATE collation`
     Collate {
@@ -629,10 +630,16 @@ impl fmt::Display for Expr {
             }
             Expr::IsDistinctFrom(a, b) => write!(f, "{} IS DISTINCT FROM {}", a, b),
             Expr::IsNotDistinctFrom(a, b) => write!(f, "{} IS NOT DISTINCT FROM {}", a, b),
-            Expr::Trim { expr, trim_where } => {
+            Expr::Trim {
+                expr,
+                trim_where,
+                trim_what,
+            } => {
                 write!(f, "TRIM(")?;
-                if let Some((ident, trim_char)) = trim_where {
+                if let (Some(ident), Some(trim_char)) = (trim_where, trim_what) {
                     write!(f, "{} {} FROM {}", ident, trim_char, expr)?;
+                } else if let Some(trim_char) = trim_what {
+                    write!(f, "{} FROM {}", trim_char, expr)?;
                 } else {
                     write!(f, "{}", expr)?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -331,12 +331,12 @@ pub enum Expr {
         substring_from: Option<Box<Expr>>,
         substring_for: Option<Box<Expr>>,
     },
-    /// TRIM([BOTH | LEADING | TRAILING] <expr> [FROM <expr>])\
+    /// TRIM([BOTH | LEADING | TRAILING] [<expr> FROM] <expr>)\
     /// Or\
     /// TRIM(<expr>)
     Trim {
         expr: Box<Expr>,
-        // ([BOTH | LEADING | TRAILING], <expr>)
+        // ([BOTH | LEADING | TRAILING]
         trim_where: Option<TrimWhereField>,
         trim_what: Option<Box<Expr>>,
     },
@@ -636,9 +636,10 @@ impl fmt::Display for Expr {
                 trim_what,
             } => {
                 write!(f, "TRIM(")?;
-                if let (Some(ident), Some(trim_char)) = (trim_where, trim_what) {
-                    write!(f, "{} {} FROM {}", ident, trim_char, expr)?;
-                } else if let Some(trim_char) = trim_what {
+                if let Some(ident) = trim_where {
+                    write!(f, "{} ", ident)?;
+                }
+                if let Some(trim_char) = trim_what {
                     write!(f, "{} FROM {}", trim_char, expr)?;
                 } else {
                     write!(f, "{}", expr)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -874,25 +874,17 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// TRIM (WHERE 'text' FROM 'text')\
+    /// TRIM ([WHERE] ['text' FROM] 'text')\
     /// TRIM ('text')
     pub fn parse_trim_expr(&mut self) -> Result<Expr, ParserError> {
         self.expect_token(&Token::LParen)?;
+        let mut trim_where = None;
         if let Token::Word(word) = self.peek_token() {
             if [Keyword::BOTH, Keyword::LEADING, Keyword::TRAILING]
                 .iter()
                 .any(|d| word.keyword == *d)
             {
-                let trim_where = self.parse_trim_where()?;
-                let trim_what = self.parse_expr()?;
-                self.expect_keyword(Keyword::FROM)?;
-                let expr = self.parse_expr()?;
-                self.expect_token(&Token::RParen)?;
-                return Ok(Expr::Trim {
-                    expr: Box::new(expr),
-                    trim_where: Some(trim_where),
-                    trim_what: Some(Box::new(trim_what)),
-                });
+                trim_where = Some(self.parse_trim_where()?);
             }
         }
         let expr = self.parse_expr()?;
@@ -902,14 +894,14 @@ impl<'a> Parser<'a> {
             self.expect_token(&Token::RParen)?;
             Ok(Expr::Trim {
                 expr: Box::new(expr),
-                trim_where: None,
+                trim_where,
                 trim_what: Some(trim_what),
             })
         } else {
             self.expect_token(&Token::RParen)?;
             Ok(Expr::Trim {
                 expr: Box::new(expr),
-                trim_where: None,
+                trim_where,
                 trim_what: None,
             })
         }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3933,6 +3933,10 @@ fn parse_trim() {
         "SELECT TRIM('xyz' FROM 'xyzfooxyz')",
     );
     one_statement_parses_to("SELECT TRIM('   foo   ')", "SELECT TRIM('   foo   ')");
+    one_statement_parses_to(
+        "SELECT TRIM(LEADING '   foo   ')",
+        "SELECT TRIM(LEADING '   foo   ')",
+    );
 
     assert_eq!(
         ParserError::ParserError("Expected ), found: 'xyz'".to_owned()),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3928,6 +3928,10 @@ fn parse_trim() {
         "SELECT TRIM(TRAILING 'xyz' FROM 'xyzfooxyz')",
     );
 
+    one_statement_parses_to(
+        "SELECT TRIM('xyz' FROM 'xyzfooxyz')",
+        "SELECT TRIM('xyz' FROM 'xyzfooxyz')",
+    );
     one_statement_parses_to("SELECT TRIM('   foo   ')", "SELECT TRIM('   foo   ')");
 
     assert_eq!(


### PR DESCRIPTION
Fixes #568 
The objective of this pr is to allow specifying the chars from expr syntax for the trim expression even without specifying a trim where flag. 

- [x] Update trim expr members, not tying the trimWhere option to the trim_what option
- [x] Update parsing logic to handle cases with no trim flag but trim_char
- [x] Add tests