### PR TITLE
Add `IS NOT TRUE`, `IS NOT FALSE`, and `IS [NOT] UNKNOWN`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -227,12 +227,20 @@ pub enum Expr {
     CompositeAccess { expr: Box<Expr>, key: Ident },
     /// `IS FALSE` operator
     IsFalse(Box<Expr>),
+    /// `IS NOT FALSE` operator
+    IsNotFalse(Box<Expr>),
     /// `IS TRUE` operator
     IsTrue(Box<Expr>),
+    /// `IS NOT TRUE` operator
+    IsNotTrue(Box<Expr>),
     /// `IS NULL` operator
     IsNull(Box<Expr>),
     /// `IS NOT NULL` operator
     IsNotNull(Box<Expr>),
+    /// `IS UNKNOWN` operator
+    IsUnknown(Box<Expr>),
+    /// `IS NOT UNKNOWN` operator
+    IsNotUnknown(Box<Expr>),
     /// `IS DISTINCT FROM` operator
     IsDistinctFrom(Box<Expr>, Box<Expr>),
     /// `IS NOT DISTINCT FROM` operator
@@ -412,9 +420,13 @@ impl fmt::Display for Expr {
             }
             Expr::CompoundIdentifier(s) => write!(f, "{}", display_separated(s, ".")),
             Expr::IsTrue(ast) => write!(f, "{} IS TRUE", ast),
+            Expr::IsNotTrue(ast) => write!(f, "{} IS NOT TRUE", ast),
             Expr::IsFalse(ast) => write!(f, "{} IS FALSE", ast),
+            Expr::IsNotFalse(ast) => write!(f, "{} IS NOT FALSE", ast),
             Expr::IsNull(ast) => write!(f, "{} IS NULL", ast),
             Expr::IsNotNull(ast) => write!(f, "{} IS NOT NULL", ast),
+            Expr::IsUnknown(ast) => write!(f, "{} IS UNKNOWN", ast),
+            Expr::IsNotUnknown(ast) => write!(f, "{} IS NOT UNKNOWN", ast),
             Expr::InList {
                 expr,
                 list,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1255,8 +1255,16 @@ impl<'a> Parser<'a> {
                         Ok(Expr::IsNotNull(Box::new(expr)))
                     } else if self.parse_keywords(&[Keyword::TRUE]) {
                         Ok(Expr::IsTrue(Box::new(expr)))
+                    } else if self.parse_keywords(&[Keyword::NOT, Keyword::TRUE]) {
+                        Ok(Expr::IsNotTrue(Box::new(expr)))
                     } else if self.parse_keywords(&[Keyword::FALSE]) {
                         Ok(Expr::IsFalse(Box::new(expr)))
+                    } else if self.parse_keywords(&[Keyword::NOT, Keyword::FALSE]) {
+                        Ok(Expr::IsNotFalse(Box::new(expr)))
+                    } else if self.parse_keywords(&[Keyword::UNKNOWN]) {
+                        Ok(Expr::IsUnknown(Box::new(expr)))
+                    } else if self.parse_keywords(&[Keyword::NOT, Keyword::UNKNOWN]) {
+                        Ok(Expr::IsNotUnknown(Box::new(expr)))
                     } else if self.parse_keywords(&[Keyword::DISTINCT, Keyword::FROM]) {
                         let expr2 = self.parse_expr()?;
                         Ok(Expr::IsDistinctFrom(Box::new(expr), Box::new(expr2)))


### PR DESCRIPTION
Closes #582

Previously, sqlparser did not support "is not true," "is not false," "is unknown," and "is not unknown," so I have added them here.