### PR TITLE
feat: Support `LOCALTIME` and `LOCALTIMESTAMP` time functions

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -438,7 +438,11 @@ impl<'a> Parser<'a> {
                         special: true,
                     }))
                 }
-                Keyword::CURRENT_TIMESTAMP | Keyword::CURRENT_TIME | Keyword::CURRENT_DATE => {
+                Keyword::CURRENT_TIMESTAMP
+                | Keyword::CURRENT_TIME
+                | Keyword::CURRENT_DATE
+                | Keyword::LOCALTIME
+                | Keyword::LOCALTIMESTAMP => {
                     self.parse_time_functions(ObjectName(vec![w.to_ident()]))
                 }
                 Keyword::CASE => self.parse_case_expr(),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -5298,6 +5298,38 @@ fn parse_time_functions() {
 
     // Validating Parenthesis
     one_statement_parses_to("SELECT CURRENT_DATE", sql);
+
+    let sql = "SELECT LOCALTIME()";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("LOCALTIME")]),
+            args: vec![],
+            over: None,
+            distinct: false,
+            special: false,
+        }),
+        expr_from_projection(&select.projection[0])
+    );
+
+    // Validating Parenthesis
+    one_statement_parses_to("SELECT LOCALTIME", sql);
+
+    let sql = "SELECT LOCALTIMESTAMP()";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("LOCALTIMESTAMP")]),
+            args: vec![],
+            over: None,
+            distinct: false,
+            special: false,
+        }),
+        expr_from_projection(&select.projection[0])
+    );
+
+    // Validating Parenthesis
+    one_statement_parses_to("SELECT LOCALTIMESTAMP", sql);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for parsing `LOCALTIME` and `LOCALTIMESTAMP` without parentheses as a time function with no arguments (see https://www.postgresql.org/docs/14/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT). It also adds related tests.