### PR TITLE
Implement --quiet option for cli example

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -21,22 +21,31 @@ use sqlparser::dialect::*;
 use sqlparser::parser::Parser;
 
 fn main() {
-    SimpleLogger::new().init().unwrap();
-
     let filename = std::env::args().nth(1).expect(
         r#"
 No arguments provided!
 
 Usage:
-$ cargo run --example cli FILENAME.sql [--dialectname]
+$ cargo run --example cli FILENAME.sql [--dialectname] [--quiet]
 
 To print the parse results as JSON:
-$ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
+$ cargo run --features json_example --example cli FILENAME.sql [--dialectname] [--quiet]
+
+Pass --quiet to emit only the parse results.
 
 "#,
     );
 
-    let dialect: Box<dyn Dialect> = match std::env::args().nth(2).unwrap_or_default().as_ref() {
+    let mut optional_args = std::env::args().skip(2).collect::<Vec<_>>();
+
+    let quiet = if let Some(pos) = optional_args.iter().position(|a| *a == "--quiet") {
+        optional_args.remove(pos);
+        true
+    } else {
+        false
+    };
+
+    let dialect: Box<dyn Dialect> = match optional_args.first().unwrap_or(&"".into()).as_ref() {
         "--ansi" => Box::new(AnsiDialect {}),
         "--bigquery" => Box::new(BigQueryDialect {}),
         "--postgres" => Box::new(PostgreSqlDialect {}),
@@ -49,7 +58,13 @@ $ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
         s => panic!("Unexpected parameter: {}", s),
     };
 
-    println!("Parsing from file '{}' using {:?}", &filename, dialect);
+    if !quiet {
+        SimpleLogger::new().init().unwrap();
+    }
+
+    if !quiet {
+        println!("Parsing from file '{}' using {:?}", &filename, dialect);
+    }
     let contents = fs::read_to_string(&filename)
         .unwrap_or_else(|_| panic!("Unable to read the file {}", &filename));
     let without_bom = if contents.chars().next().unwrap() as u64 != 0xfeff {
@@ -62,23 +77,30 @@ $ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
     let parse_result = Parser::parse_sql(&*dialect, without_bom);
     match parse_result {
         Ok(statements) => {
-            println!(
-                "Round-trip:\n'{}'",
-                statements
-                    .iter()
-                    .map(std::string::ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            );
+            if !quiet {
+                println!(
+                    "Round-trip:\n'{}'",
+                    statements
+                        .iter()
+                        .map(std::string::ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                );
+            }
 
             if cfg!(feature = "json_example") {
                 #[cfg(feature = "json_example")]
                 {
-                    let serialized = serde_json::to_string_pretty(&statements).unwrap();
-                    println!("Serialized as JSON:\n{}", serialized);
+                    if !quiet {
+                        println!("Serialized as JSON:");
+                    }
+                    println!("{}", serde_json::to_string_pretty(&statements).unwrap());
                 }
             } else {
-                println!("Parse results:\n{:#?}", statements);
+                if !quiet {
+                    println!("Parse results:");
+                }
+                println!("{:#?}", statements);
             }
 
             std::process::exit(0);


### PR DESCRIPTION
Not sure if there's any interest in this, or if this is the best flag name - but this allows `--quiet` to be passed to the `cli` example target so that it can be composed with other programs in a rudimentary way without writing a custom wrapper around sqlparser-rs.

For example, you could pipe the parsed AST into `jq` or some other JSON-expecting program:
```
$ cargo run --release --features json_example --example cli "$filename" --quiet | jq 'map(keys)[][]' -rc
Drop
CreateTable
Insert
Drop
```