### PR TITLE
[postgres] Support `ABORT` and `END`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -192,7 +192,11 @@ impl<'a> Parser<'a> {
                 Keyword::BEGIN => Ok(self.parse_begin()?),
                 Keyword::SAVEPOINT => Ok(self.parse_savepoint()?),
                 Keyword::COMMIT => Ok(self.parse_commit()?),
+                Keyword::END if dialect_of!(self is PostgreSqlDialect) => Ok(self.parse_commit()?),
                 Keyword::ROLLBACK => Ok(self.parse_rollback()?),
+                Keyword::ABORT if dialect_of!(self is PostgreSqlDialect) => {
+                    Ok(self.parse_rollback()?)
+                }
                 Keyword::ASSERT => Ok(self.parse_assert()?),
                 // `PREPARE`, `EXECUTE` and `DEALLOCATE` are Postgres-specific
                 // syntaxes. They are used for Postgres prepared statement.

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1739,3 +1739,25 @@ fn parse_custom_operator() {
         })
     );
 }
+
+#[test]
+fn parse_abort() {
+    match pg().verified_stmt("ROLLBACK") {
+        Statement::Rollback { chain: false } => (),
+        _ => unreachable!(),
+    }
+    pg().one_statement_parses_to("ABORT", "ROLLBACK");
+    pg().one_statement_parses_to("ABORT WORK", "ROLLBACK");
+    pg().one_statement_parses_to("ABORT TRANSACTION", "ROLLBACK");
+}
+
+#[test]
+fn parse_end() {
+    match pg().verified_stmt("COMMIT") {
+        Statement::Commit { chain: false } => (),
+        _ => unreachable!(),
+    }
+    pg().one_statement_parses_to("END", "COMMIT");
+    pg().one_statement_parses_to("END WORK", "COMMIT");
+    pg().one_statement_parses_to("END TRANSACTION", "COMMIT");
+}


### PR DESCRIPTION
From https://www.postgresql.org/docs/current/sql-abort.html

> `ABORT` rolls back the current transaction and causes all the updates made by the transaction to be discarded. This command is identical in behavior to the standard SQL command `ROLLBACK`, and is present only for historical reasons.

From https://www.postgresql.org/docs/current/sql-end.html

> `END` commits the current transaction. All changes made by the transaction become visible to others and are guaranteed to be durable if a crash occurs. This command is a PostgreSQL extension that is equivalent to `COMMIT`.
