### PR TITLE
Support National string literal with lower case `n`

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -387,7 +387,8 @@ impl<'a> Tokenizer<'a> {
                     }
                     Ok(Some(Token::Whitespace(Whitespace::Newline)))
                 }
-                'N' => {
+                // Snowflake uses lower case n for national string literal
+                n @ 'N' | n @ 'n' => {
                     chars.next(); // consume, to check the next char
                     match chars.peek() {
                         Some('\'') => {
@@ -397,7 +398,7 @@ impl<'a> Tokenizer<'a> {
                         }
                         _ => {
                             // regular identifier starting with an "N"
-                            let s = self.tokenize_word('N', chars);
+                            let s = self.tokenize_word(n, chars);
                             Ok(Some(Token::make_word(&s, None)))
                         }
                     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -387,7 +387,7 @@ impl<'a> Tokenizer<'a> {
                     }
                     Ok(Some(Token::Whitespace(Whitespace::Newline)))
                 }
-                // Snowflake uses lower case n for national string literal
+                // Redshift uses lower case n for national string literal
                 n @ 'N' | n @ 'n' => {
                     chars.next(); // consume, to check the next char
                     match chars.peek() {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2812,6 +2812,7 @@ fn parse_literal_string() {
     );
 
     one_statement_parses_to("SELECT x'deadBEEF'", "SELECT X'deadBEEF'");
+    one_statement_parses_to("SELECT n'national string'", "SELECT N'national string'");
 }
 
 #[test]


### PR DESCRIPTION
It's used by Snowflake