### PR TITLE
support "set time zone to 'some-timezone'"

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3774,7 +3774,7 @@ impl<'a> Parser<'a> {
             });
         }
 
-        let variable = if self.parse_keywords(&vec![Keyword::TIME, Keyword::ZONE]) {
+        let variable = if self.parse_keywords(&[Keyword::TIME, Keyword::ZONE]) {
             ObjectName(vec!["TIMEZONE".into()])
         } else {
             self.parse_object_name()?

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3774,7 +3774,12 @@ impl<'a> Parser<'a> {
             });
         }
 
-        let variable = self.parse_object_name()?;
+        let variable = if self.parse_keywords(&vec![Keyword::TIME, Keyword::ZONE]) {
+            ObjectName(vec!["TIMEZONE".into()])
+        } else {
+            self.parse_object_name()?
+        };
+
         if variable.to_string().eq_ignore_ascii_case("NAMES")
             && dialect_of!(self is MySqlDialect | GenericDialect)
         {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4665,7 +4665,7 @@ fn parse_set_transaction() {
 
 #[test]
 fn parse_set_variable() {
-    match verified_stmt("SET SOMETHING = 1") {
+    match verified_stmt("SET SOMETHING = '1'") {
         Statement::SetVariable {
             local,
             hivevar,
@@ -4675,12 +4675,15 @@ fn parse_set_variable() {
             assert!(!local);
             assert!(!hivevar);
             assert_eq!(variable, ObjectName(vec!["SOMETHING".into()]));
-            assert_eq!(value, vec![Expr::Value(Value::Number("1".into(), false))]);
+            assert_eq!(
+                value,
+                vec![Expr::Value(Value::SingleQuotedString("1".into()))]
+            );
         }
         _ => unreachable!(),
     }
 
-    one_statement_parses_to("SET SOMETHING TO 1", "SET SOMETHING = 1");
+    one_statement_parses_to("SET SOMETHING TO '1'", "SET SOMETHING = '1'");
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4664,6 +4664,49 @@ fn parse_set_transaction() {
 }
 
 #[test]
+fn parse_set_variable() {
+    match verified_stmt("SET SOMETHING = 1") {
+        Statement::SetVariable {
+            local,
+            hivevar,
+            variable,
+            value,
+        } => {
+            assert!(!local);
+            assert!(!hivevar);
+            assert_eq!(variable, ObjectName(vec!["SOMETHING".into()]));
+            assert_eq!(value, vec![Expr::Value(Value::Number("1".into(), false))]);
+        }
+        _ => unreachable!(),
+    }
+
+    one_statement_parses_to("SET SOMETHING TO 1", "SET SOMETHING = 1");
+}
+
+#[test]
+fn parse_set_time_zone() {
+    match verified_stmt("SET TIMEZONE = 'UTC'") {
+        Statement::SetVariable {
+            local,
+            hivevar,
+            variable,
+            value,
+        } => {
+            assert!(!local);
+            assert!(!hivevar);
+            assert_eq!(variable, ObjectName(vec!["TIMEZONE".into()]));
+            assert_eq!(
+                value,
+                vec![Expr::Value(Value::SingleQuotedString("UTC".into()))]
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    one_statement_parses_to("SET TIME ZONE TO 'UTC'", "SET TIMEZONE = 'UTC'");
+}
+
+#[test]
 fn parse_commit() {
     match verified_stmt("COMMIT") {
         Statement::Commit { chain: false } => (),


### PR DESCRIPTION
close #303 

sqlparser-rs original only supports `SET TIMEZONE = 'some-timezone'` now.
there're many dbs support both `TIMEZONE` and `TIME ZONE` in the SET statement (e.g. postgresql, pyspark, ...)

this pr is to enable `SET TIMEZONE = 'some-timezone'`