### PR TITLE
Fix parsing CLOB, BINARY, VARBINARY, BLOB data type

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3142,6 +3142,10 @@ impl<'a> Parser<'a> {
                         Ok(DataType::Char(self.parse_optional_precision()?))
                     }
                 }
+                Keyword::CLOB => Ok(DataType::Clob(self.parse_precision()?)),
+                Keyword::BINARY => Ok(DataType::Binary(self.parse_precision()?)),
+                Keyword::VARBINARY => Ok(DataType::Varbinary(self.parse_precision()?)),
+                Keyword::BLOB => Ok(DataType::Blob(self.parse_precision()?)),
                 Keyword::UUID => Ok(DataType::Uuid),
                 Keyword::DATE => Ok(DataType::Date),
                 Keyword::DATETIME => Ok(DataType::Datetime),
@@ -3353,6 +3357,13 @@ impl<'a> Parser<'a> {
         } else {
             self.expected("a list of columns in parentheses", self.peek_token())
         }
+    }
+
+    pub fn parse_precision(&mut self) -> Result<u64, ParserError> {
+        self.expect_token(&Token::LParen)?;
+        let n = self.parse_literal_uint()?;
+        self.expect_token(&Token::RParen)?;
+        Ok(n)
     }
 
     pub fn parse_optional_precision(&mut self) -> Result<Option<u64>, ParserError> {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1647,6 +1647,46 @@ fn parse_cast() {
         },
         expr_from_projection(only(&select.projection))
     );
+
+    let sql = "SELECT CAST(id AS CLOB(50)) FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Cast {
+            expr: Box::new(Expr::Identifier(Ident::new("id"))),
+            data_type: DataType::Clob(50)
+        },
+        expr_from_projection(only(&select.projection))
+    );
+
+    let sql = "SELECT CAST(id AS BINARY(50)) FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Cast {
+            expr: Box::new(Expr::Identifier(Ident::new("id"))),
+            data_type: DataType::Binary(50)
+        },
+        expr_from_projection(only(&select.projection))
+    );
+
+    let sql = "SELECT CAST(id AS VARBINARY(50)) FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Cast {
+            expr: Box::new(Expr::Identifier(Ident::new("id"))),
+            data_type: DataType::Varbinary(50)
+        },
+        expr_from_projection(only(&select.projection))
+    );
+
+    let sql = "SELECT CAST(id AS BLOB(50)) FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Cast {
+            expr: Box::new(Expr::Identifier(Ident::new("id"))),
+            data_type: DataType::Blob(50)
+        },
+        expr_from_projection(only(&select.projection))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Related Issue
Resolves #518 

## Description
Parse error occurs for `CLOB`, `BINARY`, `VARBINARY`, and `BLOB` data types though they are included as variants for data type & keywords in sqlparser. Since all these 4 data types contain (non-optional) u64 value, added `parse_precision` fn. 