### PR TITLE
Support `SHOW FUNCTIONS`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1147,9 +1147,7 @@ pub enum Statement {
     /// SHOW FUNCTIONS 
     ///
     /// Note: this is a Presto-specific statement.
-    ShowFunctions {
-        filter: Option<ShowStatementFilter>,
-    },
+    ShowFunctions { filter: Option<ShowStatementFilter> },
     /// SHOW <variable>
     ///
     /// Note: this is a PostgreSQL-specific statement.
@@ -2039,13 +2037,8 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::ShowFunctions {
-                filter,
-            } => {
-                write!(
-                    f,
-                    "SHOW FUNCTIONS",
-                )?;
+            Statement::ShowFunctions { filter } => {
+                write!(f, "SHOW FUNCTIONS")?;
                 if let Some(filter) = filter {
                     write!(f, " {}", filter)?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1144,6 +1144,12 @@ pub enum Statement {
     ///
     /// Note: this is a MySQL-specific statement.
     SetNamesDefault {},
+    /// SHOW FUNCTIONS 
+    ///
+    /// Note: this is a Presto-specific statement.
+    ShowFunctions {
+        filter: Option<ShowStatementFilter>,
+    },
     /// SHOW <variable>
     ///
     /// Note: this is a PostgreSQL-specific statement.
@@ -2028,6 +2034,18 @@ impl fmt::Display for Statement {
                 if let Some(db_name) = db_name {
                     write!(f, " FROM {}", db_name)?;
                 }
+                if let Some(filter) = filter {
+                    write!(f, " {}", filter)?;
+                }
+                Ok(())
+            }
+            Statement::ShowFunctions {
+                filter,
+            } => {
+                write!(
+                    f,
+                    "SHOW FUNCTIONS",
+                )?;
                 if let Some(filter) = filter {
                     write!(f, " {}", filter)?;
                 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -250,6 +250,7 @@ define_keywords!(
     FROM,
     FULL,
     FUNCTION,
+    FUNCTIONS,
     FUSION,
     GET,
     GLOBAL,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3947,13 +3947,9 @@ impl<'a> Parser<'a> {
         })
     }
 
-    pub fn parse_show_functions(
-        &mut self,
-    ) -> Result<Statement, ParserError> {
+    pub fn parse_show_functions(&mut self) -> Result<Statement, ParserError> {
         let filter = self.parse_show_statement_filter()?;
-        Ok(Statement::ShowFunctions {
-            filter,
-        })
+        Ok(Statement::ShowFunctions { filter })
     }
 
     pub fn parse_show_collation(&mut self) -> Result<Statement, ParserError> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3854,6 +3854,8 @@ impl<'a> Parser<'a> {
             Ok(self.parse_show_columns(extended, full)?)
         } else if self.parse_keyword(Keyword::TABLES) {
             Ok(self.parse_show_tables(extended, full)?)
+        } else if self.parse_keyword(Keyword::FUNCTIONS) {
+            Ok(self.parse_show_functions()?)
         } else if extended || full {
             Err(ParserError::ParserError(
                 "EXTENDED/FULL are not supported with this type of SHOW query".to_string(),
@@ -3941,6 +3943,15 @@ impl<'a> Parser<'a> {
             extended,
             full,
             db_name,
+            filter,
+        })
+    }
+
+    pub fn parse_show_functions(
+        &mut self,
+    ) -> Result<Statement, ParserError> {
+        let filter = self.parse_show_statement_filter()?;
+        Ok(Statement::ShowFunctions {
             filter,
         })
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -5569,3 +5569,13 @@ fn parse_cursor() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn parse_show_functions() {
+    assert_eq!(
+        mysql_and_generic().verified_stmt("SHOW FUNCTIONS LIKE 'pattern'"),
+        Statement::ShowFunctions {
+            filter: Some(ShowStatementFilter::Like("pattern".into())),
+        }
+    );
+}

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -5573,7 +5573,7 @@ fn parse_cursor() {
 #[test]
 fn parse_show_functions() {
     assert_eq!(
-        mysql_and_generic().verified_stmt("SHOW FUNCTIONS LIKE 'pattern'"),
+        verified_stmt("SHOW FUNCTIONS LIKE 'pattern'"),
         Statement::ShowFunctions {
             filter: Some(ShowStatementFilter::Like("pattern".into())),
         }


### PR DESCRIPTION
Add support for the Trino-specific `SHOW FUNCTIONS` statement (https://trino.io/docs/current/sql/show-functions.html?highlight=show).

I've used `SHOW COLUMNS` as the template.

There doesn't appear to be any Trino or Presto-specific sections in the code to align this too.

Relates to issue https://github.com/sqlparser-rs/sqlparser-rs/issues/616 , although I wouldn't say this resolves that issue.
