### PR TITLE
Adding DOUBLE PRECISION to data types, parsing it, and tests

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -67,8 +67,13 @@ pub enum DataType {
     UnsignedBigInt(Option<u64>),
     /// Floating point e.g. REAL
     Real,
-    /// Double e.g. DOUBLE PRECISION
+    /// Double
     Double,
+    /// Double PRECISION e.g. [standard], [postgresql]
+    ///
+    /// [standard]: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#approximate-numeric-type
+    /// [postgresql]: https://www.postgresql.org/docs/current/datatype-numeric.html
+    DoublePrecision,
     /// Boolean
     Boolean,
     /// Date
@@ -154,6 +159,7 @@ impl fmt::Display for DataType {
             }
             DataType::Real => write!(f, "REAL"),
             DataType::Double => write!(f, "DOUBLE"),
+            DataType::DoublePrecision => write!(f, "DOUBLE PRECISION"),
             DataType::Boolean => write!(f, "BOOLEAN"),
             DataType::Date => write!(f, "DATE"),
             DataType::Time => write!(f, "TIME"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3319,8 +3319,11 @@ impl<'a> Parser<'a> {
                 Keyword::FLOAT => Ok(DataType::Float(self.parse_optional_precision()?)),
                 Keyword::REAL => Ok(DataType::Real),
                 Keyword::DOUBLE => {
-                    let _ = self.parse_keyword(Keyword::PRECISION);
-                    Ok(DataType::Double)
+                    if self.parse_keyword(Keyword::PRECISION) {
+                        Ok(DataType::DoublePrecision)
+                    } else {
+                        Ok(DataType::Double)
+                    }
                 }
                 Keyword::TINYINT => {
                     let optional_precision = self.parse_optional_precision();
@@ -5210,5 +5213,19 @@ mod tests {
             let ast = parser.parse_query().unwrap();
             assert_eq!(ast.to_string(), sql.to_string());
         });
+    }
+
+    // TODO add tests for all data types? https://github.com/sqlparser-rs/sqlparser-rs/issues/2
+    #[test]
+    fn test_parse_data_type() {
+        test_parse_data_type("DOUBLE PRECISION", "DOUBLE PRECISION");
+        test_parse_data_type("DOUBLE", "DOUBLE");
+
+        fn test_parse_data_type(input: &str, expected: &str) {
+            all_dialects().run_parser_method(input, |parser| {
+                let data_type = parser.parse_data_type().unwrap().to_string();
+                assert_eq!(data_type, expected);
+            });
+        }
     }
 }


### PR DESCRIPTION
Adding DOUBLE PRECISION correct support([1](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#approximate-numeric-type)) ([2](https://www.postgresql.org/docs/current/datatype-numeric.html)). 

Since PostgreSQL doesn't accept `DOUBLE`, we should differentiate it from `DOUBLE PRECISION` when parsing it. More description is on the related issue ([3](https://github.com/sqlparser-rs/sqlparser-rs/issues/622))

[1] : https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#approximate-numeric-type
[2] : https://www.postgresql.org/docs/current/datatype-numeric.html
[3] : https://github.com/sqlparser-rs/sqlparser-rs/issues/622