### PR TITLE
Adding mediumint support

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -53,6 +53,14 @@ pub enum DataType {
     SmallInt(Option<u64>),
     /// Unsigned small integer with optional display width e.g. SMALLINT UNSIGNED or SMALLINT(5) UNSIGNED
     UnsignedSmallInt(Option<u64>),
+    /// MySQL medium integer ([1]) with optional display width e.g. MEDIUMINT or MEDIUMINT(5)
+    ///
+    /// [1]: https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
+    MediumInt(Option<u64>),
+    /// Unsigned medium integer ([1]) with optional display width e.g. MEDIUMINT UNSIGNED or MEDIUMINT(5) UNSIGNED
+    ///
+    /// [1]: https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
+    UnsignedMediumInt(Option<u64>),
     /// Integer with optional display width e.g. INT or INT(11)
     Int(Option<u64>),
     /// Integer with optional display width e.g. INTEGER or INTEGER(11)
@@ -135,6 +143,12 @@ impl fmt::Display for DataType {
             }
             DataType::UnsignedSmallInt(zerofill) => {
                 format_type_with_optional_length(f, "SMALLINT", zerofill, true)
+            }
+            DataType::MediumInt(zerofill) => {
+                format_type_with_optional_length(f, "MEDIUMINT", zerofill, false)
+            }
+            DataType::UnsignedMediumInt(zerofill) => {
+                format_type_with_optional_length(f, "MEDIUMINT", zerofill, true)
             }
             DataType::Int(zerofill) => format_type_with_optional_length(f, "INT", zerofill, false),
             DataType::UnsignedInt(zerofill) => {

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -325,6 +325,7 @@ define_keywords!(
     MATCHED,
     MATERIALIZED,
     MAX,
+    MEDIUMINT,
     MEMBER,
     MERGE,
     METADATA,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3338,6 +3338,14 @@ impl<'a> Parser<'a> {
                         Ok(DataType::SmallInt(optional_precision?))
                     }
                 }
+                Keyword::MEDIUMINT => {
+                    let optional_precision = self.parse_optional_precision();
+                    if self.parse_keyword(Keyword::UNSIGNED) {
+                        Ok(DataType::UnsignedMediumInt(optional_precision?))
+                    } else {
+                        Ok(DataType::MediumInt(optional_precision?))
+                    }
+                }
                 Keyword::INT => {
                     let optional_precision = self.parse_optional_precision();
                     if self.parse_keyword(Keyword::UNSIGNED) {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1624,6 +1624,11 @@ fn parse_cast() {
     );
 
     one_statement_parses_to(
+        "SELECT CAST(id AS MEDIUMINT) FROM customer",
+        "SELECT CAST(id AS MEDIUMINT) FROM customer",
+    );
+
+    one_statement_parses_to(
         "SELECT CAST(id AS BIGINT) FROM customer",
         "SELECT CAST(id AS BIGINT) FROM customer",
     );

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -552,7 +552,7 @@ fn parse_escaped_string() {
 
 #[test]
 fn parse_create_table_with_minimum_display_width() {
-    let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3), bar_smallint SMALLINT(5), bar_int INT(11), bar_bigint BIGINT(20))";
+    let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3), bar_smallint SMALLINT(5), bar_mediumint MEDIUMINT(6), bar_int INT(11), bar_bigint BIGINT(20))";
     match mysql().verified_stmt(sql) {
         Statement::CreateTable { name, columns, .. } => {
             assert_eq!(name.to_string(), "foo");
@@ -567,6 +567,12 @@ fn parse_create_table_with_minimum_display_width() {
                     ColumnDef {
                         name: Ident::new("bar_smallint"),
                         data_type: DataType::SmallInt(Some(5)),
+                        collation: None,
+                        options: vec![],
+                    },
+                    ColumnDef {
+                        name: Ident::new("bar_mediumint"),
+                        data_type: DataType::MediumInt(Some(6)),
                         collation: None,
                         options: vec![],
                     },
@@ -592,7 +598,7 @@ fn parse_create_table_with_minimum_display_width() {
 
 #[test]
 fn parse_create_table_unsigned() {
-    let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3) UNSIGNED, bar_smallint SMALLINT(5) UNSIGNED, bar_int INT(11) UNSIGNED, bar_bigint BIGINT(20) UNSIGNED)";
+    let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3) UNSIGNED, bar_smallint SMALLINT(5) UNSIGNED, bar_mediumint MEDIUMINT(13) UNSIGNED, bar_int INT(11) UNSIGNED, bar_bigint BIGINT(20) UNSIGNED)";
     match mysql().verified_stmt(sql) {
         Statement::CreateTable { name, columns, .. } => {
             assert_eq!(name.to_string(), "foo");
@@ -607,6 +613,12 @@ fn parse_create_table_unsigned() {
                     ColumnDef {
                         name: Ident::new("bar_smallint"),
                         data_type: DataType::UnsignedSmallInt(Some(5)),
+                        collation: None,
+                        options: vec![],
+                    },
+                    ColumnDef {
+                        name: Ident::new("bar_mediumint"),
+                        data_type: DataType::UnsignedMediumInt(Some(13)),
                         collation: None,
                         options: vec![],
                     },


### PR DESCRIPTION
Adding MySQ's mediumint support([1](https://dev.mysql.com/doc/refman/8.0/en/integer-types.html))

Other INT types are already supported (e.g., MySQL's BIGINT), so adding `MEDIUMINT` should be a problem...

[1] : https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
Resolves: https://github.com/sqlparser-rs/sqlparser-rs/issues/625