### PR TITLE
Support optional precision in `VARBINARY` and `BINARY`

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -35,10 +35,16 @@ pub enum DataType {
     Uuid,
     /// Large character object e.g. CLOB(1000)
     Clob(u64),
-    /// Fixed-length binary type e.g. BINARY(10)
-    Binary(u64),
-    /// Variable-length binary type e.g. VARBINARY(10)
-    Varbinary(u64),
+    /// Fixed-length binary type with optional length e.g.  [standard], [MS SQL Server]
+    ///
+    /// [standard]: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#binary-string-type
+    /// [MS SQL Server]: https://learn.microsoft.com/pt-br/sql/t-sql/data-types/binary-and-varbinary-transact-sql?view=sql-server-ver16
+    Binary(Option<u64>),
+    /// Variable-length binary with optional length type e.g. [standard], [MS SQL Server]
+    ///
+    /// [standard]: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#binary-string-type
+    /// [MS SQL Server]: https://learn.microsoft.com/pt-br/sql/t-sql/data-types/binary-and-varbinary-transact-sql?view=sql-server-ver16
+    Varbinary(Option<u64>),
     /// Large binary object e.g. BLOB(1000)
     Blob(u64),
     /// Decimal type with optional precision and scale e.g. DECIMAL(10,2)
@@ -126,8 +132,10 @@ impl fmt::Display for DataType {
             }
             DataType::Uuid => write!(f, "UUID"),
             DataType::Clob(size) => write!(f, "CLOB({})", size),
-            DataType::Binary(size) => write!(f, "BINARY({})", size),
-            DataType::Varbinary(size) => write!(f, "VARBINARY({})", size),
+            DataType::Binary(size) => format_type_with_optional_length(f, "BINARY", size, false),
+            DataType::Varbinary(size) => {
+                format_type_with_optional_length(f, "VARBINARY", size, false)
+            }
             DataType::Blob(size) => write!(f, "BLOB({})", size),
             DataType::Decimal(precision, scale) => {
                 if let Some(scale) = scale {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3404,8 +3404,8 @@ impl<'a> Parser<'a> {
                     }
                 }
                 Keyword::CLOB => Ok(DataType::Clob(self.parse_precision()?)),
-                Keyword::BINARY => Ok(DataType::Binary(self.parse_precision()?)),
-                Keyword::VARBINARY => Ok(DataType::Varbinary(self.parse_precision()?)),
+                Keyword::BINARY => Ok(DataType::Binary(self.parse_optional_precision()?)),
+                Keyword::VARBINARY => Ok(DataType::Varbinary(self.parse_optional_precision()?)),
                 Keyword::BLOB => Ok(DataType::Blob(self.parse_precision()?)),
                 Keyword::UUID => Ok(DataType::Uuid),
                 Keyword::DATE => Ok(DataType::Date),
@@ -5260,6 +5260,10 @@ mod tests {
     fn test_parse_data_type() {
         test_parse_data_type("DOUBLE PRECISION", "DOUBLE PRECISION");
         test_parse_data_type("DOUBLE", "DOUBLE");
+        test_parse_data_type("VARBINARY", "VARBINARY");
+        test_parse_data_type("VARBINARY(20)", "VARBINARY(20)");
+        test_parse_data_type("BINARY", "BINARY");
+        test_parse_data_type("BINARY(20)", "BINARY(20)");
 
         fn test_parse_data_type(input: &str, expected: &str) {
             all_dialects().run_parser_method(input, |parser| {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1670,7 +1670,7 @@ fn parse_cast() {
     assert_eq!(
         &Expr::Cast {
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
-            data_type: DataType::Binary(50)
+            data_type: DataType::Binary(Some(50))
         },
         expr_from_projection(only(&select.projection))
     );
@@ -1680,7 +1680,7 @@ fn parse_cast() {
     assert_eq!(
         &Expr::Cast {
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
-            data_type: DataType::Varbinary(50)
+            data_type: DataType::Varbinary(Some(50))
         },
         expr_from_projection(only(&select.projection))
     );


### PR DESCRIPTION
Adding optional precision for `BINARY` and `VARBINARY`([1](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#binary-string-type)),([2](https://learn.microsoft.com/pt-br/sql/t-sql/data-types/binary-and-varbinary-transact-sql?view=sql-server-ver16))

[1] : https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#binary-string-type
[2] : https://learn.microsoft.com/pt-br/sql/t-sql/data-types/binary-and-varbinary-transact-sql?view=sql-server-ver16
Resolves: https://github.com/sqlparser-rs/sqlparser-rs/issues/636
Fixes: https://github.com/sqlparser-rs/sqlparser-rs/pull/618

@alamb first one. 2 more to come :D