### PR TITLE
Correct order of arguments in  `LIMIT x,y` , restrict to MySql and generic dialects

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3761,7 +3761,7 @@ impl<'a> Parser<'a> {
                     offset = Some(self.parse_offset()?)
                 }
 
-                if dialect_of!(self is MySqlDialect)
+                if dialect_of!(self is GenericDialect | MySqlDialect)
                     && limit.is_some()
                     && offset.is_none()
                     && self.consume_token(&Token::Comma)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -24,6 +24,9 @@ use core::fmt;
 
 use log::debug;
 
+use IsLateral::*;
+use IsOptional::*;
+
 use crate::ast::*;
 use crate::dialect::*;
 use crate::keywords::{self, Keyword};
@@ -57,14 +60,10 @@ pub enum IsOptional {
     Mandatory,
 }
 
-use IsOptional::*;
-
 pub enum IsLateral {
     Lateral,
     NotLateral,
 }
-
-use IsLateral::*;
 
 pub enum WildcardExpr {
     Expr(Expr),
@@ -3763,24 +3762,17 @@ impl<'a> Parser<'a> {
                 }
 
                 if dialect_of!(self is MySqlDialect)
+                    && limit.is_some()
                     && offset.is_none()
                     && self.consume_token(&Token::Comma)
                 {
                     // MySQL style LIMIT x,y => LIMIT y OFFSET x.
                     // Check <https://dev.mysql.com/doc/refman/8.0/en/select.html> for more details.
-                    match limit {
-                        None => {
-                            offset = None;
-                        }
-                        Some(expr) => {
-                            offset = Some(Offset {
-                                value: expr.clone(),
-                                rows: OffsetRows::None,
-                            })
-                        }
-                    }
-                    // MySQL doesn't support the ALL clause, so I must parse only the expression.
-                    limit = Some(self.parse_expr()?)
+                    offset = Some(Offset {
+                        value: limit.unwrap(),
+                        rows: OffsetRows::None,
+                    });
+                    limit = Some(self.parse_expr()?);
                 }
             }
 
@@ -5213,8 +5205,9 @@ impl Word {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::test_utils::{all_dialects, TestedDialects};
+
+    use super::*;
 
     #[test]
     fn test_prev_index() {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1594,14 +1594,6 @@ fn parse_limit_accepts_all() {
 }
 
 #[test]
-fn parse_limit_my_sql_syntax() {
-    one_statement_parses_to(
-        "SELECT id, fname, lname FROM customer LIMIT 5, 10",
-        "SELECT id, fname, lname FROM customer LIMIT 5 OFFSET 10",
-    );
-}
-
-#[test]
 fn parse_cast() {
     let sql = "SELECT CAST(id AS BIGINT) FROM customer";
     let select = verified_only_select(sql);

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1067,7 +1067,7 @@ fn parse_set_names() {
 
 #[test]
 fn parse_limit_my_sql_syntax() {
-    mysql().one_statement_parses_to(
+    mysql_and_generic().one_statement_parses_to(
         "SELECT id, fname, lname FROM customer LIMIT 5, 10",
         "SELECT id, fname, lname FROM customer LIMIT 10 OFFSET 5",
     );

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1065,6 +1065,14 @@ fn parse_set_names() {
     assert_eq!(stmt, Statement::SetNamesDefault {});
 }
 
+#[test]
+fn parse_limit_my_sql_syntax() {
+    mysql().one_statement_parses_to(
+        "SELECT id, fname, lname FROM customer LIMIT 5, 10",
+        "SELECT id, fname, lname FROM customer LIMIT 10 OFFSET 5",
+    );
+}
+
 fn mysql() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],


### PR DESCRIPTION
Fixing MySQL `LIMIT x, y` syntax([1](https://dev.mysql.com/doc/refman/8.0/en/select.html)).

There's no much info to add besides that. MySQL syntax expects `LIMIT x,y` as if it were `LIMIT y OFFSET x`, but we were converting it to `LIMIT x OFFSET y`.

```sql
SELECT id FROM tb LIMIT 5,3

--- is the same as

SELECT id FROM tb LIMIT 3 OFFSET 5
```

[1] : https://dev.mysql.com/doc/refman/8.0/en/select.html
Resolves: https://github.com/sqlparser-rs/sqlparser-rs/pull/613