### PR TITLE
645 New schema name structure

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1299,7 +1299,8 @@ pub enum Statement {
     Rollback { chain: bool },
     /// CREATE SCHEMA
     CreateSchema {
-        schema_name: ObjectName,
+        /// `<schema name> | AUTHORIZATION <schema authorization identifier>  | <schema name>  AUTHORIZATION <schema authorization identifier>`
+        schema_name: SchemaName,
         if_not_exists: bool,
     },
     /// CREATE DATABASE
@@ -3270,6 +3271,36 @@ impl fmt::Display for CreateFunctionUsing {
             CreateFunctionUsing::Jar(uri) => write!(f, "JAR '{uri}'"),
             CreateFunctionUsing::File(uri) => write!(f, "FILE '{uri}'"),
             CreateFunctionUsing::Archive(uri) => write!(f, "ARCHIVE '{uri}'"),
+        }
+    }
+}
+
+/// Schema possible naming variants ([1]).
+///
+/// [1]: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#schema-definition
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum SchemaName {
+    /// Only schema name specified: `<schema name>`.
+    Simple(ObjectName),
+    /// Only authorization identifier specified: `AUTHORIZATION <schema authorization identifier>`.
+    UnnamedAuthorization(Ident),
+    /// Both schema name and authorization identifier specified: `<schema name>  AUTHORIZATION <schema authorization identifier>`.
+    NamedAuthorization(ObjectName, Ident),
+}
+
+impl fmt::Display for SchemaName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SchemaName::Simple(name) => {
+                write!(f, "{name}")
+            }
+            SchemaName::UnnamedAuthorization(authorization) => {
+                write!(f, "AUTHORIZATION {authorization}")
+            }
+            SchemaName::NamedAuthorization(name, authorization) => {
+                write!(f, "{name} AUTHORIZATION {authorization}")
+            }
         }
     }
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2134,6 +2134,30 @@ fn parse_create_schema() {
 }
 
 #[test]
+fn parse_create_schema_with_authorization() {
+    let sql = "CREATE SCHEMA AUTHORIZATION Y";
+
+    match verified_stmt(sql) {
+        Statement::CreateSchema { schema_name, .. } => {
+            assert_eq!(schema_name.to_string(), "AUTHORIZATION Y".to_owned())
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_schema_with_name_and_authorization() {
+    let sql = "CREATE SCHEMA X AUTHORIZATION Y";
+
+    match verified_stmt(sql) {
+        Statement::CreateSchema { schema_name, .. } => {
+            assert_eq!(schema_name.to_string(), "X AUTHORIZATION Y".to_owned())
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_drop_schema() {
     let sql = "DROP SCHEMA X";
 


### PR DESCRIPTION
Adding support for `AUTHORIZATION` on `CREATE SCHEMA` ([1](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#schema-definition), [2](https://www.postgresql.org/docs/current/sql-createschema.html)) using a new enum structure. I used that structure because it makes it easier to validate and handle than Options. The other possible approach was:

```rust
pub enum Statement {
//...
    CreateSchema {
        schema_name: Option<ObjectName>,
        authorization_name: Option<Ident>
        if_not_exists: bool,
    },
//...
}
```

But it has a few problems:
1. It's harder to parse
2. We can't have both false, but that structure would allow that
3. It's harder for the caller to know what's happening.

[1] : https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#schema-definition
[2] : https://www.postgresql.org/docs/current/sql-createschema.html
Resolves: https://github.com/sqlparser-rs/sqlparser-rs/issues/645