### PR TITLE
Distinguish between `CHAR VARYING`, `CHARACTER VARYING`, and `CHARACTER` data types, differentiating them from `VARCHAR` and `CHAR`

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -25,8 +25,14 @@ use super::value::escape_single_quote_string;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DataType {
-    /// Fixed-length character type e.g. CHAR(10)
+    /// Fixed-length character type e.g. CHARACTER(10)
+    Character(Option<u64>),
+    /// Fixed-length char type e.g. CHAR(10)
     Char(Option<u64>),
+    /// Character varying type e.g. CHARACTER VARYING(10)
+    CharacterVarying(Option<u64>),
+    /// Char varying type e.g. CHAR VARYING(10)
+    CharVarying(Option<u64>),
     /// Variable-length character type e.g. VARCHAR(10)
     Varchar(Option<u64>),
     /// Variable-length character type e.g. NVARCHAR(10)
@@ -127,10 +133,17 @@ pub enum DataType {
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            DataType::Character(size) => {
+                format_type_with_optional_length(f, "CHARACTER", size, false)
+            }
             DataType::Char(size) => format_type_with_optional_length(f, "CHAR", size, false),
-            DataType::Varchar(size) => {
+            DataType::CharacterVarying(size) => {
                 format_type_with_optional_length(f, "CHARACTER VARYING", size, false)
             }
+            DataType::CharVarying(size) => {
+                format_type_with_optional_length(f, "CHAR VARYING", size, false)
+            }
+            DataType::Varchar(size) => format_type_with_optional_length(f, "VARCHAR", size, false),
             DataType::Nvarchar(size) => {
                 format_type_with_optional_length(f, "NVARCHAR", size, false)
             }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1850,7 +1850,7 @@ fn parse_create_table() {
     let ast = one_statement_parses_to(
         sql,
         "CREATE TABLE uk_cities (\
-         name CHARACTER VARYING(100) NOT NULL, \
+         name VARCHAR(100) NOT NULL, \
          lat DOUBLE NULL, \
          lng DOUBLE, \
          constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), \
@@ -2312,7 +2312,7 @@ fn parse_create_external_table() {
     let ast = one_statement_parses_to(
         sql,
         "CREATE EXTERNAL TABLE uk_cities (\
-         name CHARACTER VARYING(100) NOT NULL, \
+         name VARCHAR(100) NOT NULL, \
          lat DOUBLE NULL, \
          lng DOUBLE) \
          STORED AS TEXTFILE LOCATION '/tmp/example.csv'",
@@ -2382,7 +2382,7 @@ fn parse_create_or_replace_external_table() {
     let ast = one_statement_parses_to(
         sql,
         "CREATE OR REPLACE EXTERNAL TABLE uk_cities (\
-         name CHARACTER VARYING(100) NOT NULL) \
+         name VARCHAR(100) NOT NULL) \
          STORED AS TEXTFILE LOCATION '/tmp/example.csv'",
     );
     match ast {
@@ -2435,7 +2435,7 @@ fn parse_create_external_table_lowercase() {
     let ast = one_statement_parses_to(
         sql,
         "CREATE EXTERNAL TABLE uk_cities (\
-         name CHARACTER VARYING(100) NOT NULL, \
+         name VARCHAR(100) NOT NULL, \
          lat DOUBLE NULL, \
          lng DOUBLE) \
          STORED AS PARQUET LOCATION '/tmp/example.csv'",

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -74,7 +74,7 @@ fn parse_create_table_with_defaults() {
                     },
                     ColumnDef {
                         name: "first_name".into(),
-                        data_type: DataType::Varchar(Some(45)),
+                        data_type: DataType::CharacterVarying(Some(45)),
                         collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
@@ -83,7 +83,7 @@ fn parse_create_table_with_defaults() {
                     },
                     ColumnDef {
                         name: "last_name".into(),
-                        data_type: DataType::Varchar(Some(45)),
+                        data_type: DataType::CharacterVarying(Some(45)),
                         collation: Some(ObjectName(vec![Ident::with_quote('"', "es_ES")])),
                         options: vec![ColumnOptionDef {
                             name: None,
@@ -92,7 +92,7 @@ fn parse_create_table_with_defaults() {
                     },
                     ColumnDef {
                         name: "email".into(),
-                        data_type: DataType::Varchar(Some(50)),
+                        data_type: DataType::CharacterVarying(Some(50)),
                         collation: None,
                         options: vec![],
                     },


### PR DESCRIPTION
Adding support for `CHAR VARYING`, `CHARACTER VARYING`, and `CHARACTER` data types, differentiating them from `VARCHAR` and `CHAR`, which were mistakenly considered the same ([1](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#character-string-type)).

The precision is optional to support PostgreSQL's syntax ([2](https://www.postgresql.org/docs/current/datatype-character.html)).

Also, adding tests to start resolving https://github.com/sqlparser-rs/sqlparser-rs/issues/2, but that's a WIP.

[1] : https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#character-string-type
[2] : https://www.postgresql.org/docs/current/datatype-character.html
Resolves: https://github.com/sqlparser-rs/sqlparser-rs/issues/647