### PR TITLE
649 Adding soundex expression for all dialects

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -429,6 +429,11 @@ pub enum Expr {
         /// or as `__ TO SECOND(x)`.
         fractional_seconds_precision: Option<u64>,
     },
+    /// Soundex expression e.g. SOUNDEX('Hello'). Check [MySQL], [MS SQL Server].
+    ///
+    /// [MySQL]: https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_soundex
+    /// [MS SQL Server]: https://learn.microsoft.com/pt-br/sql/t-sql/functions/soundex-transact-sql?view=sql-server-ver16
+    Soundex(Box<Expr>),
 }
 
 impl fmt::Display for Expr {
@@ -778,6 +783,9 @@ impl fmt::Display for Expr {
                     write!(f, " ({})", fractional_seconds_precision)?;
                 }
                 Ok(())
+            }
+            Expr::Soundex(value) => {
+                write!(f, "SOUNDEX({})", value)
             }
         }
     }
@@ -3371,5 +3379,14 @@ mod tests {
             vec![Expr::Identifier(Ident::new("d"))],
         ]);
         assert_eq!("CUBE (a, (b, c), d)", format!("{}", cube));
+    }
+
+    #[test]
+    fn test_soundex_display() {
+        let soundex = Expr::Soundex(Box::new(Expr::Value(Value::SingleQuotedString(
+            "Potato".to_string(),
+        ))));
+
+        assert_eq!("SOUNDEX('Potato')", format!("{}", soundex))
     }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -487,6 +487,7 @@ define_keywords!(
     SNAPSHOT,
     SOME,
     SORT,
+    SOUNDEX,
     SPECIFIC,
     SPECIFICTYPE,
     SQL,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -469,7 +469,7 @@ impl<'a> Parser<'a> {
                     self.parse_array_subquery()
                 }
                 Keyword::NOT => self.parse_not(),
-                Keyword::SOUNDEX => self.parse_soundex(),
+                Keyword::SOUNDEX => self.parse_soundex_expr(),
                 // Here `w` is a word, check if it's a part of a multi-part
                 // identifier, a function call, or a simple identifier:
                 _ => match self.peek_token() {
@@ -1097,7 +1097,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn parse_soundex(&mut self) -> Result<Expr, ParserError> {
+    pub fn parse_soundex_expr(&mut self) -> Result<Expr, ParserError> {
         self.expect_token(&Token::LParen)?;
         let expr = self.parse_expr()?;
         self.expect_token(&Token::RParen)?;


### PR DESCRIPTION
Adding `SOUNDEX` expression parsing. As mentioned in the issue, there are A LOT of dialects that implement the almost same structure for Soundex, and, therefore, there's no reason for me to restrict the dialect that is parsing, as at least 5 of them have it.

Common Soundex expressions:
```sql
SELECT SOUNDEX('Hello');

SELECT * FROM tb WHERE SOUNDEX(id) = SOUNDEX('Hello');
```

Resolves: https://github.com/sqlparser-rs/sqlparser-rs/issues/649