### PR TITLE
Patch for supporting backticks in GenericDialect

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -57,7 +57,7 @@ pub trait Dialect: Debug + Any {
     /// MySQL, MS SQL, and sqlite). You can accept one of characters listed
     /// in `Word::matching_end_quote` here
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
-        ch == '"'
+        ch == '"' || ch == '`'
     }
     /// Determine if quoted characters are proper for identifier
     fn is_proper_identifier_inside_quotes(&self, mut _chars: Peekable<Chars<'_>>) -> bool {

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -29,6 +29,19 @@ fn parse_table_create() {
     hive().verified_stmt(iof);
 }
 
+fn generic() -> TestedDialects {
+    TestedDialects {
+        dialects: vec![Box::new(GenericDialect {})]
+    }
+}
+
+#[test]
+fn parse_describe() {
+    let describe = r#"DESCRIBE namespace.`table`"#;
+    hive().verified_stmt(describe);
+    generic().verified_stmt(describe);
+}
+
 #[test]
 fn parse_insert_overwrite() {
     let insert_partitions = r#"INSERT OVERWRITE TABLE db.new_table PARTITION (a = '1', b) SELECT a, b, c FROM db.table"#;
@@ -258,12 +271,8 @@ fn parse_create_function() {
         _ => unreachable!(),
     }
 
-    let generic = TestedDialects {
-        dialects: vec![Box::new(GenericDialect {})],
-    };
-
     assert_eq!(
-        generic.parse_sql_statements(sql).unwrap_err(),
+        generic().parse_sql_statements(sql).unwrap_err(),
         ParserError::ParserError(
             "Expected an object type after CREATE, found: FUNCTION".to_string()
         )


### PR DESCRIPTION
This was needed for the Athena SQL parsing I've been doing.

Fixes #632 632