### PR TITLE
Decimal precision and scale enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Cargo.lock
 # IDEs
 .idea
 .vscode
+*.iml

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -60,7 +60,7 @@ pub enum DataType {
     /// [Oracle]: https://docs.oracle.com/javadb/10.8.3.0/ref/rrefblob.html
     Blob(Option<u64>),
     /// Decimal type with optional precision and scale e.g. DECIMAL(10,2)
-    Decimal(Option<u64>, Option<u64>),
+    Decimal(ExactNumberInfo),
     /// Floating point with optional precision e.g. FLOAT(8)
     Float(Option<u64>),
     /// Tiny integer with optional display width e.g. TINYINT or TINYINT(3)
@@ -154,12 +154,8 @@ impl fmt::Display for DataType {
                 format_type_with_optional_length(f, "VARBINARY", size, false)
             }
             DataType::Blob(size) => format_type_with_optional_length(f, "BLOB", size, false),
-            DataType::Decimal(precision, scale) => {
-                if let Some(scale) = scale {
-                    write!(f, "NUMERIC({},{})", precision.unwrap(), scale)
-                } else {
-                    format_type_with_optional_length(f, "NUMERIC", precision, false)
-                }
+            DataType::Decimal(info) => {
+                write!(f, "NUMERIC{}", info)
             }
             DataType::Float(size) => format_type_with_optional_length(f, "FLOAT", size, false),
             DataType::TinyInt(zerofill) => {
@@ -293,6 +289,37 @@ impl fmt::Display for TimezoneInfo {
                 // must be aware of that. Check <https://www.postgresql.org/docs/14/datatype-datetime.html>
                 // for more information
                 write!(f, "TZ")
+            }
+        }
+    }
+}
+
+/// Additional information for `NUMERIC`, `DECIMAL`, and `DEC` data types
+/// following the 2016 [standard].
+///
+/// [standard]: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#datetime-type
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ExactNumberInfo {
+    /// No additional information e.g. `DECIMAL`
+    None,
+    /// Only precision information e.g. `DECIMAL(10)`
+    Precision(u64),
+    /// Precision and scale information e.g. `DECIMAL(10,2)`
+    PrecisionAndScale(u64, u64),
+}
+
+impl fmt::Display for ExactNumberInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExactNumberInfo::None => {
+                write!(f, "")
+            }
+            ExactNumberInfo::Precision(p) => {
+                write!(f, "({p})")
+            }
+            ExactNumberInfo::PrecisionAndScale(p, s) => {
+                write!(f, "({p},{s})")
             }
         }
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -29,6 +29,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 pub use self::data_type::DataType;
+pub use self::data_type::ExactNumberInfo;
 pub use self::data_type::TimezoneInfo;
 pub use self::ddl::{
     AlterColumnOperation, AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3467,10 +3467,9 @@ impl<'a> Parser<'a> {
                 Keyword::STRING => Ok(DataType::String),
                 Keyword::TEXT => Ok(DataType::Text),
                 Keyword::BYTEA => Ok(DataType::Bytea),
-                Keyword::NUMERIC | Keyword::DECIMAL | Keyword::DEC => {
-                    let (precision, scale) = self.parse_optional_precision_scale()?;
-                    Ok(DataType::Decimal(precision, scale))
-                }
+                Keyword::NUMERIC | Keyword::DECIMAL | Keyword::DEC => Ok(DataType::Decimal(
+                    self.parse_exact_number_optional_precision_scale()?,
+                )),
                 Keyword::ENUM => Ok(DataType::Enum(self.parse_string_values()?)),
                 Keyword::SET => Ok(DataType::Set(self.parse_string_values()?)),
                 Keyword::ARRAY => {
@@ -3681,6 +3680,28 @@ impl<'a> Parser<'a> {
             Ok((Some(n), scale))
         } else {
             Ok((None, None))
+        }
+    }
+
+    pub fn parse_exact_number_optional_precision_scale(
+        &mut self,
+    ) -> Result<ExactNumberInfo, ParserError> {
+        if self.consume_token(&Token::LParen) {
+            let precision = self.parse_literal_uint()?;
+            let scale = if self.consume_token(&Token::Comma) {
+                Some(self.parse_literal_uint()?)
+            } else {
+                None
+            };
+
+            self.expect_token(&Token::RParen)?;
+
+            match scale {
+                None => Ok(ExactNumberInfo::Precision(precision)),
+                Some(scale) => Ok(ExactNumberInfo::PrecisionAndScale(precision, scale)),
+            }
+        } else {
+            Ok(ExactNumberInfo::None)
         }
     }
 
@@ -5297,7 +5318,7 @@ mod tests {
 
     #[cfg(test)]
     mod test_parse_data_type {
-        use crate::ast::{DataType, TimezoneInfo};
+        use crate::ast::{DataType, ExactNumberInfo, TimezoneInfo};
         use crate::dialect::{AnsiDialect, GenericDialect};
         use crate::test_utils::TestedDialects;
 
@@ -5335,6 +5356,28 @@ mod tests {
             test_parse_data_type!(dialect, "CHAR VARYING(20)", DataType::CharVarying(Some(20)));
 
             test_parse_data_type!(dialect, "VARCHAR(20)", DataType::Varchar(Some(20)));
+        }
+
+        #[test]
+        fn test_ansii_exact_numeric_types() {
+            // Exact numeric types: <https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#exact-numeric-type>
+            let dialect = TestedDialects {
+                dialects: vec![Box::new(GenericDialect {}), Box::new(AnsiDialect {})],
+            };
+
+            test_parse_data_type!(dialect, "NUMERIC", DataType::Decimal(ExactNumberInfo::None));
+
+            test_parse_data_type!(
+                dialect,
+                "NUMERIC(2)",
+                DataType::Decimal(ExactNumberInfo::Precision(2))
+            );
+
+            test_parse_data_type!(
+                dialect,
+                "NUMERIC(2,10)",
+                DataType::Decimal(ExactNumberInfo::PrecisionAndScale(2, 10))
+            );
         }
 
         #[test]


### PR DESCRIPTION
Implementation of an enum to handle Decimal ([1](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#exact-numeric-type)) precision and scale, instead of options, for two reasons:
- An enum is easier to access and handle. Options need unwrap or errors even when you KNOW that an item should exist (e.g., `DATETIME (p,s)`, if `s` is some, necessarily `p` is some).
- Remove unwrap from our code. Even if they shouldn't happen, it's not nice to have unwraps as "certainty" handlers (that was happening when we printed stuff).

Since we already didn't accept `DECIMAL` data type only with scale, that doesn't change the behavior of anything.

[1] : https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#exact-numeric-type