### PR TITLE
Support for INTERVAL inside window frames

### DIFF
--- a/sqlparser_bench/Cargo.toml
+++ b/sqlparser_bench/Cargo.toml
@@ -11,5 +11,5 @@ sqlparser = { path = "../" }
 criterion = "0.4"
 
 [[bench]]
-name = "sqlparser_bench"
 harness = false
+name = "sqlparser_bench"

--- a/sqlparser_bench/Cargo.toml
+++ b/sqlparser_bench/Cargo.toml
@@ -11,5 +11,5 @@ sqlparser = { path = "../" }
 criterion = "0.4"
 
 [[bench]]
-harness = false
 name = "sqlparser_bench"
+harness = false

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -880,9 +880,9 @@ pub enum WindowFrameBound {
     /// `CURRENT ROW`
     CurrentRow,
     /// `<N> PRECEDING` or `UNBOUNDED PRECEDING`
-    Preceding(Option<RangeBounds>),
+    Preceding(Option<Box<Expr>>),
     /// `<N> FOLLOWING` or `UNBOUNDED FOLLOWING`.
-    Following(Option<RangeBounds>),
+    Following(Option<Box<Expr>>),
 }
 
 impl fmt::Display for WindowFrameBound {
@@ -893,27 +893,6 @@ impl fmt::Display for WindowFrameBound {
             WindowFrameBound::Following(None) => f.write_str("UNBOUNDED FOLLOWING"),
             WindowFrameBound::Preceding(Some(n)) => write!(f, "{} PRECEDING", n),
             WindowFrameBound::Following(Some(n)) => write!(f, "{} FOLLOWING", n),
-        }
-    }
-}
-
-/// Specifies offset values in the [WindowFrameBound]'s `Preceding` and `Following`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum RangeBounds {
-    /// Number literal, e.g `1`, `1.1`
-    Number(String),
-    /// Interval, such as `INTERVAL '1 DAY' `
-    Interval(Expr),
-}
-
-impl fmt::Display for RangeBounds {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RangeBounds::Number(s) => write!(f, "{}", s),
-            RangeBounds::Interval(interval) => {
-                write!(f, "{}", interval)
-            }
         }
     }
 }
@@ -2691,7 +2670,7 @@ impl fmt::Display for CloseCursor {
 pub struct Function {
     pub name: ObjectName,
     pub args: Vec<FunctionArg>,
-    pub over: Option<Box<WindowSpec>>,
+    pub over: Option<WindowSpec>,
     // aggregate functions may specify eg `COUNT(DISTINCT x)`
     pub distinct: bool,
     // Some functions must be called without trailing parentheses, for example Postgres

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -206,73 +206,6 @@ impl fmt::Display for JsonOperator {
     }
 }
 
-/// INTERVAL literals, roughly in the following format:
-/// `INTERVAL '<value>' [ <leading_field> [ (<leading_precision>) ] ]
-/// [ TO <last_field> [ (<fractional_seconds_precision>) ] ]`,
-/// e.g. `INTERVAL '123:45.67' MINUTE(3) TO SECOND(2)`.
-///
-/// The parser does not validate the `<value>`, nor does it ensure
-/// that the `<leading_field>` units >= the units in `<last_field>`,
-/// so the user will have to reject intervals like `HOUR TO YEAR`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Interval {
-    pub value: Box<Expr>,
-    pub leading_field: Option<DateTimeField>,
-    pub leading_precision: Option<u64>,
-    pub last_field: Option<DateTimeField>,
-    /// The seconds precision can be specified in SQL source as
-    /// `INTERVAL '__' SECOND(_, x)` (in which case the `leading_field`
-    /// will be `Second` and the `last_field` will be `None`),
-    /// or as `__ TO SECOND(x)`.
-    pub fractional_seconds_precision: Option<u64>,
-}
-
-impl fmt::Display for Interval {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Interval {
-                value,
-                leading_field: Some(DateTimeField::Second),
-                leading_precision: Some(leading_precision),
-                last_field,
-                fractional_seconds_precision: Some(fractional_seconds_precision),
-            } => {
-                // When the leading field is SECOND, the parser guarantees that
-                // the last field is None.
-                assert!(last_field.is_none());
-                write!(
-                    f,
-                    "INTERVAL {} SECOND ({}, {})",
-                    value, leading_precision, fractional_seconds_precision
-                )
-            }
-            Interval {
-                value,
-                leading_field,
-                leading_precision,
-                last_field,
-                fractional_seconds_precision,
-            } => {
-                write!(f, "INTERVAL {}", value)?;
-                if let Some(leading_field) = leading_field {
-                    write!(f, " {}", leading_field)?;
-                }
-                if let Some(leading_precision) = leading_precision {
-                    write!(f, " ({})", leading_precision)?;
-                }
-                if let Some(last_field) = last_field {
-                    write!(f, " TO {}", last_field)?;
-                }
-                if let Some(fractional_seconds_precision) = fractional_seconds_precision {
-                    write!(f, " ({})", fractional_seconds_precision)?;
-                }
-                Ok(())
-            }
-        }
-    }
-}
-
 /// An SQL expression of any type.
 ///
 /// The parser does not distinguish between expressions of different types
@@ -478,8 +411,25 @@ pub enum Expr {
     ArrayIndex { obj: Box<Expr>, indexes: Vec<Expr> },
     /// An array expression e.g. `ARRAY[1, 2]`
     Array(Array),
-    /// INTERVAL literals, such as `INTERVAL '1 DAY'`
-    Interval(Interval),
+    /// INTERVAL literals, roughly in the following format:
+    /// `INTERVAL '<value>' [ <leading_field> [ (<leading_precision>) ] ]
+    /// [ TO <last_field> [ (<fractional_seconds_precision>) ] ]`,
+    /// e.g. `INTERVAL '123:45.67' MINUTE(3) TO SECOND(2)`.
+    ///
+    /// The parser does not validate the `<value>`, nor does it ensure
+    /// that the `<leading_field>` units >= the units in `<last_field>`,
+    /// so the user will have to reject intervals like `HOUR TO YEAR`.
+    Interval {
+        value: Box<Expr>,
+        leading_field: Option<DateTimeField>,
+        leading_precision: Option<u64>,
+        last_field: Option<DateTimeField>,
+        /// The seconds precision can be specified in SQL source as
+        /// `INTERVAL '__' SECOND(_, x)` (in which case the `leading_field`
+        /// will be `Second` and the `last_field` will be `None`),
+        /// or as `__ TO SECOND(x)`.
+        fractional_seconds_precision: Option<u64>,
+    },
 }
 
 impl fmt::Display for Expr {
@@ -792,8 +742,43 @@ impl fmt::Display for Expr {
             } => {
                 write!(f, "{} AT TIME ZONE '{}'", timestamp, time_zone)
             }
-            Expr::Interval(interval) => {
-                write!(f, "{}", interval)
+            Expr::Interval {
+                value,
+                leading_field: Some(DateTimeField::Second),
+                leading_precision: Some(leading_precision),
+                last_field,
+                fractional_seconds_precision: Some(fractional_seconds_precision),
+            } => {
+                // When the leading field is SECOND, the parser guarantees that
+                // the last field is None.
+                assert!(last_field.is_none());
+                write!(
+                    f,
+                    "INTERVAL {} SECOND ({}, {})",
+                    value, leading_precision, fractional_seconds_precision
+                )
+            }
+            Expr::Interval {
+                value,
+                leading_field,
+                leading_precision,
+                last_field,
+                fractional_seconds_precision,
+            } => {
+                write!(f, "INTERVAL {}", value)?;
+                if let Some(leading_field) = leading_field {
+                    write!(f, " {}", leading_field)?;
+                }
+                if let Some(leading_precision) = leading_precision {
+                    write!(f, " ({})", leading_precision)?;
+                }
+                if let Some(last_field) = last_field {
+                    write!(f, " TO {}", last_field)?;
+                }
+                if let Some(fractional_seconds_precision) = fractional_seconds_precision {
+                    write!(f, " ({})", fractional_seconds_precision)?;
+                }
+                Ok(())
             }
         }
     }
@@ -919,7 +904,7 @@ pub enum RangeBounds {
     /// Number literal, e.g `1`, `1.1`
     Number(String),
     /// Interval, such as `INTERVAL '1 DAY' `
-    Interval(Interval),
+    Interval(Expr),
 }
 
 impl fmt::Display for RangeBounds {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -620,7 +620,6 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
-        
         Ok(Expr::Function(Function {
             name,
             args,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -620,6 +620,7 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
+        
         Ok(Expr::Function(Function {
             name,
             args,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1555,7 +1555,7 @@ fn parse_select_qualify() {
             left: Box::new(Expr::Function(Function {
                 name: ObjectName(vec![Ident::new("ROW_NUMBER")]),
                 args: vec![],
-                over: Some(Box::new(WindowSpec {
+                over: Some(WindowSpec {
                     partition_by: vec![Expr::Identifier(Ident::new("p"))],
                     order_by: vec![OrderByExpr {
                         expr: Expr::Identifier(Ident::new("o")),
@@ -1563,7 +1563,7 @@ fn parse_select_qualify() {
                         nulls_first: None
                     }],
                     window_frame: None
-                })),
+                }),
                 distinct: false,
                 special: false
             })),
@@ -2868,7 +2868,7 @@ fn parse_window_functions() {
                sum(bar) OVER (ORDER BY a \
                RANGE BETWEEN INTERVAL '1' DAY PRECEDING AND INTERVAL '1 MONTH' FOLLOWING), \
                COUNT(*) OVER (ORDER BY a \
-               RANGE BETWEEN INTERVAL '1 DAYS' PRECEDING AND INTERVAL '1 DAY' FOLLOWING), \
+               RANGE BETWEEN INTERVAL '1 DAY' PRECEDING AND INTERVAL '1 DAY' FOLLOWING), \
                max(baz) OVER (ORDER BY a \
                ROWS UNBOUNDED PRECEDING), \
                sum(qux) OVER (ORDER BY a \
@@ -2880,7 +2880,7 @@ fn parse_window_functions() {
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("row_number")]),
             args: vec![],
-            over: Some(Box::new(WindowSpec {
+            over: Some(WindowSpec {
                 partition_by: vec![],
                 order_by: vec![OrderByExpr {
                     expr: Expr::Identifier(Ident::new("dt")),
@@ -2888,7 +2888,7 @@ fn parse_window_functions() {
                     nulls_first: None,
                 }],
                 window_frame: None,
-            })),
+            }),
             distinct: false,
             special: false,
         }),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3016,20 +3016,20 @@ fn parse_interval() {
     let sql = "SELECT INTERVAL '1-1' YEAR TO MONTH";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1-1")))),
             leading_field: Some(DateTimeField::Year),
             leading_precision: None,
             last_field: Some(DateTimeField::Month),
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '01:01.01' MINUTE (5) TO SECOND (5)";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
                 "01:01.01"
             )))),
@@ -3037,53 +3037,53 @@ fn parse_interval() {
             leading_precision: Some(5),
             last_field: Some(DateTimeField::Second),
             fractional_seconds_precision: Some(5),
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '1' SECOND (5, 4)";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1")))),
             leading_field: Some(DateTimeField::Second),
             leading_precision: Some(5),
             last_field: None,
             fractional_seconds_precision: Some(4),
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '10' HOUR";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL 5 DAY";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(number("5"))),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL 1 + 1 DAY";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Value(number("1"))),
                 op: BinaryOperator::Plus,
@@ -3093,27 +3093,27 @@ fn parse_interval() {
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '10' HOUR (1)";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: Some(1),
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 
     let sql = "SELECT INTERVAL '1 DAY'";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Interval(Interval {
+        &Expr::Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
                 "1 DAY"
             )))),
@@ -3121,7 +3121,7 @@ fn parse_interval() {
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
-        }),
+        },
         expr_from_projection(only(&select.projection)),
     );
 


### PR DESCRIPTION
# Support for INTERVAL Inside Window Frames

****Which issue does this PR close?****
Closes #631 by adding `INTERVAL` support inside window frames. Now we can parse queries such as

```sql
SELECT 
COUNT(*) OVER (ORDER BY ts RANGE BETWEEN  INTERVAL '1 DAY' PRECEDING AND INTERVAL '1 DAY' FOLLOWING) 
FROM t;
```

****Rationale for this change****

[Datafusion](https://github.com/synnada-ai/arrow-datafusion) now supports window frame queries with [PR #3570](https://github.com/apache/arrow-datafusion/pull/3570).  However, since window frame bound only emits `u64` values, we cannot run queries like the one above in Datafusion. If this PR merges, after some minor changes we would be able to run `RANGE` queries involving `INTERVAL` in Datafusion. The roadmap of Datafusion includes a [plan](https://github.com/apache/arrow-datafusion/issues/3571) to support different types for `WindowFrameBound`.
