### PR TITLE
Fixing alter table multi partition

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -52,7 +52,7 @@ pub enum AlterTableOperation {
     /// Add Partitions
     AddPartitions {
         if_not_exists: bool,
-        new_partitions: Vec<Expr>,
+        new_partitions: Vec<Partition>,
     },
     DropPartitions {
         partitions: Vec<Expr>,
@@ -91,8 +91,8 @@ impl fmt::Display for AlterTableOperation {
                 new_partitions,
             } => write!(
                 f,
-                "ADD{ine} PARTITION ({})",
-                display_comma_separated(new_partitions),
+                "ADD{ine} {}",
+                display_separated(new_partitions, " "),
                 ine = if *if_not_exists { " IF NOT EXISTS" } else { "" }
             ),
             AlterTableOperation::AddConstraint(c) => write!(f, "ADD {}", c),
@@ -451,5 +451,22 @@ impl fmt::Display for ReferentialAction {
             ReferentialAction::NoAction => "NO ACTION",
             ReferentialAction::SetDefault => "SET DEFAULT",
         })
+    }
+}
+
+/// PARTITION statement used in ALTER TABLE et al. such as in Hive SQL
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Partition {
+    pub partitions: Vec<Expr>,
+}
+
+impl fmt::Display for Partition {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "PARTITION ({})",
+            display_comma_separated(&self.partitions)
+        )
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 
 pub use self::data_type::DataType;
 pub use self::ddl::{
-    AlterColumnOperation, AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef,
+    AlterColumnOperation, AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef, Partition,
     ReferentialAction, TableConstraint,
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -16,6 +16,10 @@ use crate::dialect::Dialect;
 pub struct GenericDialect;
 
 impl Dialect for GenericDialect {
+    fn is_delimited_identifier_start(&self, ch: char) -> bool {
+        ch == '"' || ch == '`'
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         ('a'..='z').contains(&ch)
             || ('A'..='Z').contains(&ch)

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -57,7 +57,7 @@ pub trait Dialect: Debug + Any {
     /// MySQL, MS SQL, and sqlite). You can accept one of characters listed
     /// in `Word::matching_end_quote` here
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
-        ch == '"'
+        ch == '"' || ch == '`'
     }
     /// Determine if quoted characters are proper for identifier
     fn is_proper_identifier_inside_quotes(&self, mut _chars: Peekable<Chars<'_>>) -> bool {

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -57,7 +57,7 @@ pub trait Dialect: Debug + Any {
     /// MySQL, MS SQL, and sqlite). You can accept one of characters listed
     /// in `Word::matching_end_quote` here
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
-        ch == '"' || ch == '`'
+        ch == '"'
     }
     /// Determine if quoted characters are proper for identifier
     fn is_proper_identifier_inside_quotes(&self, mut _chars: Peekable<Chars<'_>>) -> bool {

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -131,6 +131,12 @@ fn test_add_partition() {
 }
 
 #[test]
+fn test_add_multiple_partitions() {
+    let add = "ALTER TABLE db.table ADD IF NOT EXISTS PARTITION (`a` = 'asdf', `b` = 2) PARTITION (`a` = 'asdh', `b` = 3)";
+    hive().verified_stmt(add);
+}
+
+#[test]
 fn test_drop_partition() {
     let drop = "ALTER TABLE db.table DROP PARTITION (a = 1)";
     hive().verified_stmt(drop);

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -29,6 +29,25 @@ fn parse_table_create() {
     hive().verified_stmt(iof);
 }
 
+fn generic() -> TestedDialects {
+    TestedDialects {
+        dialects: vec![Box::new(GenericDialect {})]
+    }
+}
+
+#[test]
+fn parse_describe() {
+    let describe = r#"DESCRIBE namespace.`table`"#;
+    hive().verified_stmt(describe);
+    generic().verified_stmt(describe);
+}
+
+#[test]
+fn parse_describe() {
+    let describe = r#"DESCRIBE namespace.`table`"#;
+    hive().verified_stmt(describe);
+}
+
 #[test]
 fn parse_insert_overwrite() {
     let insert_partitions = r#"INSERT OVERWRITE TABLE db.new_table PARTITION (a = '1', b) SELECT a, b, c FROM db.table"#;
@@ -258,12 +277,8 @@ fn parse_create_function() {
         _ => unreachable!(),
     }
 
-    let generic = TestedDialects {
-        dialects: vec![Box::new(GenericDialect {})],
-    };
-
     assert_eq!(
-        generic.parse_sql_statements(sql).unwrap_err(),
+        generic().parse_sql_statements(sql).unwrap_err(),
         ParserError::ParserError(
             "Expected an object type after CREATE, found: FUNCTION".to_string()
         )


### PR DESCRIPTION
Fixes examples like this:

```sql
ALTER TABLE `database`.`table` ADD IF NOT EXISTS PARTITION (`hour` = '2020-12-24T17') PARTITION (`hour` = '2020-12-24T18') PARTITION (`hour` = '2020-12-24T19')
```

This includes the backtick commit by necessity but we can merge them all at once or the backtick commit separately, your choice.