### PR TITLE
Create table builder structure

### DIFF
--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -1,0 +1,197 @@
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec, vec::Vec};
+
+use crate::ast::{
+    ColumnDef, FileFormat, HiveDistributionStyle, HiveFormat, ObjectName, OnCommit, Query,
+    SqlOption, Statement, TableConstraint,
+};
+
+pub struct CreateTableBuilder {
+    pub or_replace: bool,
+    pub temporary: bool,
+    pub external: bool,
+    pub global: Option<bool>,
+    pub if_not_exists: bool,
+    pub name: ObjectName,
+    pub columns: Vec<ColumnDef>,
+    pub constraints: Vec<TableConstraint>,
+    pub hive_distribution: HiveDistributionStyle,
+    pub hive_formats: Option<HiveFormat>,
+    pub table_properties: Vec<SqlOption>,
+    pub with_options: Vec<SqlOption>,
+    pub file_format: Option<FileFormat>,
+    pub location: Option<String>,
+    pub query: Option<Box<Query>>,
+    pub without_rowid: bool,
+    pub like: Option<ObjectName>,
+    pub clone: Option<ObjectName>,
+    pub engine: Option<String>,
+    pub default_charset: Option<String>,
+    pub collation: Option<String>,
+    pub on_commit: Option<OnCommit>,
+    pub on_cluster: Option<String>,
+}
+
+impl CreateTableBuilder {
+    pub fn new(name: ObjectName) -> Self {
+        CreateTableBuilder {
+            or_replace: false,
+            temporary: false,
+            external: false,
+            global: None,
+            if_not_exists: false,
+            name,
+            columns: vec![],
+            constraints: vec![],
+            hive_distribution: HiveDistributionStyle::NONE,
+            hive_formats: None,
+            table_properties: vec![],
+            with_options: vec![],
+            file_format: None,
+            location: None,
+            query: None,
+            without_rowid: false,
+            like: None,
+            clone: None,
+            engine: None,
+            default_charset: None,
+            collation: None,
+            on_commit: None,
+            on_cluster: None,
+        }
+    }
+    pub fn or_replace(mut self, or_replace: bool) -> Self {
+        self.or_replace = or_replace;
+        self
+    }
+
+    pub fn temporary(mut self, temporary: bool) -> Self {
+        self.temporary = temporary;
+        self
+    }
+
+    pub fn external(mut self, external: bool) -> Self {
+        self.external = external;
+        self
+    }
+
+    pub fn global(mut self, global: Option<bool>) -> Self {
+        self.global = global;
+        self
+    }
+
+    pub fn if_not_exists(mut self, if_not_exists: bool) -> Self {
+        self.if_not_exists = if_not_exists;
+        self
+    }
+
+    pub fn columns(mut self, columns: Vec<ColumnDef>) -> Self {
+        self.columns = columns;
+        self
+    }
+
+    pub fn constraints(mut self, constraints: Vec<TableConstraint>) -> Self {
+        self.constraints = constraints;
+        self
+    }
+
+    pub fn hive_distribution(mut self, hive_distribution: HiveDistributionStyle) -> Self {
+        self.hive_distribution = hive_distribution;
+        self
+    }
+
+    pub fn hive_formats(mut self, hive_formats: Option<HiveFormat>) -> Self {
+        self.hive_formats = hive_formats;
+        self
+    }
+
+    pub fn table_properties(mut self, table_properties: Vec<SqlOption>) -> Self {
+        self.table_properties = table_properties;
+        self
+    }
+
+    pub fn with_options(mut self, with_options: Vec<SqlOption>) -> Self {
+        self.with_options = with_options;
+        self
+    }
+    pub fn file_format(mut self, file_format: Option<FileFormat>) -> Self {
+        self.file_format = file_format;
+        self
+    }
+    pub fn location(mut self, location: Option<String>) -> Self {
+        self.location = location;
+        self
+    }
+
+    pub fn query(mut self, query: Option<Box<Query>>) -> Self {
+        self.query = query;
+        self
+    }
+    pub fn without_rowid(mut self, without_rowid: bool) -> Self {
+        self.without_rowid = without_rowid;
+        self
+    }
+
+    pub fn like(mut self, like: Option<ObjectName>) -> Self {
+        self.like = like;
+        self
+    }
+
+    pub fn clone(mut self, clone: Option<ObjectName>) -> Self {
+        self.clone = clone;
+        self
+    }
+
+    pub fn engine(mut self, engine: Option<String>) -> Self {
+        self.engine = engine;
+        self
+    }
+
+    pub fn default_charset(mut self, default_charset: Option<String>) -> Self {
+        self.default_charset = default_charset;
+        self
+    }
+
+    pub fn collation(mut self, collation: Option<String>) -> Self {
+        self.collation = collation;
+        self
+    }
+
+    pub fn on_commit(mut self, on_commit: Option<OnCommit>) -> Self {
+        self.on_commit = on_commit;
+        self
+    }
+
+    pub fn on_cluster(mut self, on_cluster: Option<String>) -> Self {
+        self.on_cluster = on_cluster;
+        self
+    }
+
+    pub fn build(self) -> Statement {
+        Statement::CreateTable {
+            or_replace: self.or_replace,
+            temporary: self.temporary,
+            external: self.external,
+            global: self.global,
+            if_not_exists: self.if_not_exists,
+            name: self.name,
+            columns: self.columns,
+            constraints: self.constraints,
+            hive_distribution: self.hive_distribution,
+            hive_formats: self.hive_formats,
+            table_properties: self.table_properties,
+            with_options: self.with_options,
+            file_format: self.file_format,
+            location: self.location,
+            query: self.query,
+            without_rowid: self.without_rowid,
+            like: self.like,
+            clone: self.clone,
+            engine: self.engine,
+            default_charset: self.default_charset,
+            collation: self.collation,
+            on_commit: self.on_commit,
+            on_cluster: self.on_cluster,
+        }
+    }
+}

--- a/src/ast/helpers/mod.rs
+++ b/src/ast/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod stmt_create_table;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -13,6 +13,7 @@
 //! SQL Abstract Syntax Tree (AST) types
 mod data_type;
 mod ddl;
+pub mod helpers;
 mod operator;
 mod query;
 mod value;

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -11,8 +11,6 @@
 // limitations under the License.
 
 #[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
 use alloc::string::String;
 use core::fmt;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,6 +27,7 @@ use log::debug;
 use IsLateral::*;
 use IsOptional::*;
 
+use crate::ast::helpers::CreateTableBuilder;
 use crate::ast::*;
 use crate::dialect::*;
 use crate::keywords::{self, Keyword};
@@ -2032,31 +2033,18 @@ impl<'a> Parser<'a> {
         };
         let location = hive_formats.location.clone();
         let table_properties = self.parse_options(Keyword::TBLPROPERTIES)?;
-        Ok(Statement::CreateTable {
-            name: table_name,
-            columns,
-            constraints,
-            hive_distribution,
-            hive_formats: Some(hive_formats),
-            with_options: vec![],
-            table_properties,
-            or_replace,
-            if_not_exists,
-            external: true,
-            global: None,
-            temporary: false,
-            file_format,
-            location,
-            query: None,
-            without_rowid: false,
-            like: None,
-            clone: None,
-            default_charset: None,
-            engine: None,
-            collation: None,
-            on_commit: None,
-            on_cluster: None,
-        })
+        Ok(CreateTableBuilder::new(table_name)
+            .columns(columns)
+            .constraints(constraints)
+            .hive_distribution(hive_distribution)
+            .hive_formats(Some(hive_formats))
+            .table_properties(table_properties)
+            .or_replace(or_replace)
+            .if_not_exists(if_not_exists)
+            .external(true)
+            .file_format(file_format)
+            .location(location)
+            .build())
     }
 
     pub fn parse_file_format(&mut self) -> Result<FileFormat, ParserError> {
@@ -2667,31 +2655,27 @@ impl<'a> Parser<'a> {
                 None
             };
 
-        Ok(Statement::CreateTable {
-            name: table_name,
-            temporary,
-            columns,
-            constraints,
-            with_options,
-            table_properties,
-            or_replace,
-            if_not_exists,
-            hive_distribution,
-            hive_formats: Some(hive_formats),
-            external: false,
-            global,
-            file_format: None,
-            location: None,
-            query,
-            without_rowid,
-            like,
-            clone,
-            engine,
-            default_charset,
-            collation,
-            on_commit,
-            on_cluster,
-        })
+        Ok(CreateTableBuilder::new(table_name)
+            .temporary(temporary)
+            .columns(columns)
+            .constraints(constraints)
+            .with_options(with_options)
+            .table_properties(table_properties)
+            .or_replace(or_replace)
+            .if_not_exists(if_not_exists)
+            .hive_distribution(hive_distribution)
+            .hive_formats(Some(hive_formats))
+            .global(global)
+            .query(query)
+            .without_rowid(without_rowid)
+            .like(like)
+            .clone(clone)
+            .engine(engine)
+            .default_charset(default_charset)
+            .collation(collation)
+            .on_commit(on_commit)
+            .on_cluster(on_cluster)
+            .build())
     }
 
     pub fn parse_columns(&mut self) -> Result<(Vec<ColumnDef>, Vec<TableConstraint>), ParserError> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,7 +27,7 @@ use log::debug;
 use IsLateral::*;
 use IsOptional::*;
 
-use crate::ast::helpers::CreateTableBuilder;
+use crate::ast::helpers::stmt_create_table::CreateTableBuilder;
 use crate::ast::*;
 use crate::dialect::*;
 use crate::keywords::{self, Keyword};
@@ -2669,7 +2669,7 @@ impl<'a> Parser<'a> {
             .query(query)
             .without_rowid(without_rowid)
             .like(like)
-            .clone(clone)
+            .clone_clause(clone)
             .engine(engine)
             .default_charset(default_charset)
             .collation(collation)

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -15,7 +15,7 @@
 /// on this module, as it will change without notice.
 //
 // Integration tests (i.e. everything under `tests/`) import this
-// via `tests/test_utils/mod.rs`.
+// via `tests/test_utils/helpers`.
 
 #[cfg(not(feature = "std"))]
 use alloc::{


### PR DESCRIPTION
Proposal of usage of a `CreateTableBuilder` structure, instead of the pure create table that we've been using right now.

This has 2 benefits:
- We can reduce calls anywhere the statement isn't meant to be "complete", i.e., when some parts are certain to be a default value.
- Callers can switch between the current statement to this structure, so they don't need to move an enum, a struct instead.

@alamb @nickolay what do you think? 

I know this resembles https://github.com/sqlparser-rs/sqlparser-rs/pull/315#issuecomment-1259597684 but, instead of replacing our current API, we can give the upstream the possibility of creating the struct, moving it with more ease around the code. If you think that's OK, I'll add a `TryFrom<Statement>` for this (or maybe just a convert method), and expand that going from the biggest statement to the smallest.