### PR TITLE
Support for newer versions of cargo-release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ pretty_assertions = "1"
 # Instruct `cargo release` to not run `cargo publish` locally:
 # https://github.com/sunng87/cargo-release/blob/master/docs/reference.md#config-fields
 # See docs/releasing.md for details.
-disable-publish = true
+publish = false


### PR DESCRIPTION
Replacing old-dated flag ([1](https://github.com/crate-ci/cargo-release/releases/tag/v0.19.0)) to be able to support newer versions of cargo-publish.

[1] : https://github.com/crate-ci/cargo-release/releases/tag/v0.19.0
Resolves: https://github.com/sqlparser-rs/sqlparser-rs/issues/596 (@andygrove)