### PR TITLE
Replace the two booleans from 'SET ROLE' with a single enum `ContextModifier`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4113,14 +4113,19 @@ impl<'a> Parser<'a> {
         if let Some(Keyword::HIVEVAR) = modifier {
             self.expect_token(&Token::Colon)?;
         } else if self.parse_keyword(Keyword::ROLE) {
+            let context_modifier = match modifier {
+                Some(keyword) if keyword == Keyword::LOCAL => ContextModifier::Local,
+                Some(keyword) if keyword == Keyword::SESSION => ContextModifier::Session,
+                _ => ContextModifier::None,
+            };
+
             let role_name = if self.parse_keyword(Keyword::NONE) {
                 None
             } else {
                 Some(self.parse_identifier()?)
             };
             return Ok(Statement::SetRole {
-                local: modifier == Some(Keyword::LOCAL),
-                session: modifier == Some(Keyword::SESSION),
+                context_modifier,
                 role_name,
             });
         }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -902,41 +902,44 @@ fn parse_set() {
 
 #[test]
 fn parse_set_role() {
-    let stmt = pg_and_generic().verified_stmt("SET SESSION ROLE NONE");
+    let query = "SET SESSION ROLE NONE";
+    let stmt = pg_and_generic().verified_stmt(query);
     assert_eq!(
         stmt,
         Statement::SetRole {
-            local: false,
-            session: true,
+            context_modifier: ContextModifier::Session,
             role_name: None,
         }
     );
+    assert_eq!(query, stmt.to_string());
 
-    let stmt = pg_and_generic().verified_stmt("SET LOCAL ROLE \"rolename\"");
+    let query = "SET LOCAL ROLE \"rolename\"";
+    let stmt = pg_and_generic().verified_stmt(query);
     assert_eq!(
         stmt,
         Statement::SetRole {
-            local: true,
-            session: false,
+            context_modifier: ContextModifier::Local,
             role_name: Some(Ident {
                 value: "rolename".to_string(),
                 quote_style: Some('\"'),
             }),
         }
     );
+    assert_eq!(query, stmt.to_string());
 
-    let stmt = pg_and_generic().verified_stmt("SET ROLE 'rolename'");
+    let query = "SET ROLE 'rolename'";
+    let stmt = pg_and_generic().verified_stmt(query);
     assert_eq!(
         stmt,
         Statement::SetRole {
-            local: false,
-            session: false,
+            context_modifier: ContextModifier::None,
             role_name: Some(Ident {
                 value: "rolename".to_string(),
                 quote_style: Some('\''),
             }),
         }
     );
+    assert_eq!(query, stmt.to_string());
 }
 
 #[test]


### PR DESCRIPTION
This way, we don't rely on the parser to have valid structures for that statement, as the structure itself is valid.

Postgresql doesn't allow both to be present ([1](https://www.postgresql.org/docs/current/sql-set-role.html)), so there's no meaning in having a structure that allows both. Also, ANSI ([2](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#set-role-statement)) and a lot of other dialects support that command, so having the comment PostgreSQL specific doesn't make sense.

@alamb This is ready for review. Also, do you know why the coverage is so weird? Like, a lot of enum matches is not covered, even though their interior is

[1] : https://www.postgresql.org/docs/current/sql-set-role.html
[2] : https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#set-role-statement