### PR TITLE
insert: do not always detect parens after table name as projection

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3652,7 +3652,10 @@ impl<'a> Parser<'a> {
         &mut self,
         optional: IsOptional,
     ) -> Result<Vec<Ident>, ParserError> {
-        if self.consume_token(&Token::LParen) {
+        if self.peek_token() == Token::LParen
+            && self.peek_nth_token(1) != Token::make_keyword("SELECT")
+        {
+            self.expect_token(&Token::LParen)?;
             let cols = self.parse_comma_separated(Parser::parse_identifier)?;
             self.expect_token(&Token::RParen)?;
             Ok(cols)


### PR DESCRIPTION
Before this PR, query

```
INSERT INTO s.table_a (SELECT col1, col2 FROM s_two.table_x WHERE condition IS TRUE AND condition_2 IS FALSE GROUP BY col2, col1)
```

fails because parser always assumes that left paren starts a projection list.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>