### PR TITLE
Modifier support for Custom Datatype

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -130,6 +130,8 @@ pub enum DataType {
     Bytea,
     /// Custom type such as enums
     Custom(ObjectName),
+    /// Custom type with arguments
+    CustomWithArgs(ObjectName, Vec<String>),
     /// Arrays
     Array(Box<DataType>),
     /// Enums
@@ -218,6 +220,7 @@ impl fmt::Display for DataType {
             DataType::Bytea => write!(f, "BYTEA"),
             DataType::Array(ty) => write!(f, "{}[]", ty),
             DataType::Custom(ty) => write!(f, "{}", ty),
+            DataType::CustomWithArgs(ty, args) => write!(f, "{}({})", ty, args.join(", ")),
             DataType::Enum(vals) => {
                 write!(f, "ENUM(")?;
                 for (i, v) in vals.iter().enumerate() {

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -129,9 +129,7 @@ pub enum DataType {
     /// Bytea
     Bytea,
     /// Custom type such as enums
-    Custom(ObjectName),
-    /// Custom type with arguments
-    CustomWithArgs(ObjectName, Vec<String>),
+    Custom(ObjectName, Vec<String>),
     /// Arrays
     Array(Box<DataType>),
     /// Enums
@@ -219,8 +217,13 @@ impl fmt::Display for DataType {
             DataType::String => write!(f, "STRING"),
             DataType::Bytea => write!(f, "BYTEA"),
             DataType::Array(ty) => write!(f, "{}[]", ty),
-            DataType::Custom(ty) => write!(f, "{}", ty),
-            DataType::CustomWithArgs(ty, args) => write!(f, "{}({})", ty, args.join(", ")),
+            DataType::Custom(ty, args) => {
+                if args.is_empty() {
+                    write!(f, "{}", ty)
+                } else {
+                    write!(f, "{}({})", ty, args.join(", "))
+                }
+            }
             DataType::Enum(vals) => {
                 write!(f, "ENUM(")?;
                 for (i, v) in vals.iter().enumerate() {

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -217,11 +217,11 @@ impl fmt::Display for DataType {
             DataType::String => write!(f, "STRING"),
             DataType::Bytea => write!(f, "BYTEA"),
             DataType::Array(ty) => write!(f, "{}[]", ty),
-            DataType::Custom(ty, args) => {
-                if args.is_empty() {
+            DataType::Custom(ty, modifiers) => {
+                if modifiers.is_empty() {
                     write!(f, "{}", ty)
                 } else {
-                    write!(f, "{}({})", ty, args.join(", "))
+                    write!(f, "{}({})", ty, modifiers.join(", "))
                 }
             }
             DataType::Enum(vals) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3624,8 +3624,8 @@ impl<'a> Parser<'a> {
                 _ => {
                     self.prev_token();
                     let type_name = self.parse_object_name()?;
-                    if let Some(arguments) = self.parse_optional_type_arguments()? {
-                        Ok(DataType::Custom(type_name, arguments))
+                    if let Some(modifiers) = self.parse_optional_type_modifiers()? {
+                        Ok(DataType::Custom(type_name, modifiers))
                     } else {
                         Ok(DataType::Custom(type_name, vec![]))
                     }
@@ -3874,14 +3874,14 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn parse_optional_type_arguments(&mut self) -> Result<Option<Vec<String>>, ParserError> {
+    pub fn parse_optional_type_modifiers(&mut self) -> Result<Option<Vec<String>>, ParserError> {
         if self.consume_token(&Token::LParen) {
-            let mut args = Vec::new();
+            let mut modifiers = Vec::new();
             loop {
                 match self.next_token() {
-                    Token::Word(w) => args.push(w.to_string()),
-                    Token::Number(n, _) => args.push(n),
-                    Token::SingleQuotedString(s) => args.push(s),
+                    Token::Word(w) => modifiers.push(w.to_string()),
+                    Token::Number(n, _) => modifiers.push(n),
+                    Token::SingleQuotedString(s) => modifiers.push(s),
 
                     Token::Comma => {
                         continue;
@@ -3889,11 +3889,11 @@ impl<'a> Parser<'a> {
                     Token::RParen => {
                         break;
                     }
-                    unexpected => self.expected("type argument", unexpected)?,
+                    unexpected => self.expected("type modifiers", unexpected)?,
                 }
             }
 
-            Ok(Some(args))
+            Ok(Some(modifiers))
         } else {
             Ok(None)
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -412,7 +412,7 @@ impl<'a> Parser<'a> {
                 // name, resulting in `NOT 'a'` being recognized as a `TypedString` instead of
                 // an unary negation `NOT ('a' LIKE 'b')`. To solve this, we don't accept the
                 // `type 'string'` syntax for the custom data types at all.
-                DataType::Custom(..) => parser_err!("dummy"),
+                DataType::Custom(..) | DataType::CustomWithArgs(..) => parser_err!("dummy"),
                 data_type => Ok(Expr::TypedString {
                     data_type,
                     value: parser.parse_literal_string()?,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3882,14 +3882,17 @@ impl<'a> Parser<'a> {
                     Token::Word(w) => args.push(w.to_string()),
                     Token::Number(n, _) => args.push(n),
                     Token::SingleQuotedString(s) => args.push(s),
+
+                    Token::Comma => {
+                        continue;
+                    }
+                    Token::RParen => {
+                        break;
+                    }
                     unexpected => self.expected("type argument", unexpected)?,
                 }
-
-                if !self.consume_token(&Token::Comma) {
-                    break;
-                }
             }
-            self.expect_token(&Token::RParen)?;
+
             Ok(Some(args))
         } else {
             Ok(None)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -412,7 +412,7 @@ impl<'a> Parser<'a> {
                 // name, resulting in `NOT 'a'` being recognized as a `TypedString` instead of
                 // an unary negation `NOT ('a' LIKE 'b')`. To solve this, we don't accept the
                 // `type 'string'` syntax for the custom data types at all.
-                DataType::Custom(..) | DataType::CustomWithArgs(..) => parser_err!("dummy"),
+                DataType::Custom(..) => parser_err!("dummy"),
                 data_type => Ok(Expr::TypedString {
                     data_type,
                     value: parser.parse_literal_string()?,
@@ -3625,9 +3625,9 @@ impl<'a> Parser<'a> {
                     self.prev_token();
                     let type_name = self.parse_object_name()?;
                     if let Some(arguments) = self.parse_optional_type_arguments()? {
-                        Ok(DataType::CustomWithArgs(type_name, arguments))
+                        Ok(DataType::Custom(type_name, arguments))
                     } else {
-                        Ok(DataType::Custom(type_name))
+                        Ok(DataType::Custom(type_name, vec![]))
                     }
                 }
             },
@@ -5703,13 +5703,13 @@ mod tests {
             test_parse_data_type!(
                 dialect,
                 "GEOMETRY",
-                DataType::Custom(ObjectName(vec!["GEOMETRY".into()]),)
+                DataType::Custom(ObjectName(vec!["GEOMETRY".into()]), vec![])
             );
 
             test_parse_data_type!(
                 dialect,
                 "GEOMETRY(POINT)",
-                DataType::CustomWithArgs(
+                DataType::Custom(
                     ObjectName(vec!["GEOMETRY".into()]),
                     vec!["POINT".to_string()]
                 )
@@ -5718,7 +5718,7 @@ mod tests {
             test_parse_data_type!(
                 dialect,
                 "GEOMETRY(POINT, 4326)",
-                DataType::CustomWithArgs(
+                DataType::Custom(
                     ObjectName(vec!["GEOMETRY".into()]),
                     vec!["POINT".to_string(), "4326".to_string()]
                 )


### PR DESCRIPTION
In PostgreSQL/PostGIS, when creating tables with `geometry` or `geography` data type, additional modifiers are allowed. In [this example](https://postgis.net/docs/manual-3.3/using_postgis_dbmanagement.html#Create_Geography_Tables), we can specify `geography(POINT, 4269)` as data type, which indicates the column is geography point typed, and uses 4269 as its spatial reference system.

Back to sqlparser, at the moment we don't support `Custom` data type that comes with additional modifiers/arguments in form of `(..)`. This patch add support for that. Since these data can be in any form like an identifier, a number or a string, here I convert all of them into `String`. Suggestions are welcomed.

Edit: In PostGIS this is called type modifiers.