### PR TITLE
Support `DISTINCT` for SetOperator

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -32,8 +32,8 @@ pub use self::ddl::{
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, LateralView, LockType, Offset, OffsetRows,
-    OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, TableAlias,
-    TableFactor, TableWithJoins, Top, Values, With,
+    OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, SetOperatorOption,
+    TableAlias, TableFactor, TableWithJoins, Top, Values, With,
 };
 pub use self::value::{DateTimeField, TrimWhereField, Value};
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -32,7 +32,7 @@ pub use self::ddl::{
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, LateralView, LockType, Offset, OffsetRows,
-    OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, SetOperatorOption,
+    OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, SetQualifier,
     TableAlias, TableFactor, TableWithJoins, Top, Values, With,
 };
 pub use self::value::{DateTimeField, TrimWhereField, Value};

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -32,7 +32,7 @@ pub use self::ddl::{
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, LateralView, LockType, Offset, OffsetRows,
-    OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, SetQualifier,
+    OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier,
     TableAlias, TableFactor, TableWithJoins, Top, Values, With,
 };
 pub use self::value::{DateTimeField, TrimWhereField, Value};

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -67,18 +67,18 @@ impl fmt::Display for Query {
 /// Options for SetOperator
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum SetQualifier {
+pub enum SetQuantifier {
     All,
     Distinct,
     None,
 }
 
-impl fmt::Display for SetQualifier {
+impl fmt::Display for SetQuantifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            SetQualifier::All => write!(f, "ALL"),
-            SetQualifier::Distinct => write!(f, "DISTINCT"),
-            SetQualifier::None => write!(f, ""),
+            SetQuantifier::All => write!(f, "ALL"),
+            SetQuantifier::Distinct => write!(f, "DISTINCT"),
+            SetQuantifier::None => write!(f, ""),
         }
     }
 }
@@ -97,7 +97,7 @@ pub enum SetExpr {
     /// UNION/EXCEPT/INTERSECT of two queries
     SetOperation {
         op: SetOperator,
-        set_qualifier: SetQualifier,
+        set_quantifier: SetQuantifier,
         left: Box<SetExpr>,
         right: Box<SetExpr>,
     },
@@ -117,12 +117,12 @@ impl fmt::Display for SetExpr {
                 left,
                 right,
                 op,
-                set_qualifier,
+                set_quantifier,
             } => {
                 write!(f, "{} {}", left, op)?;
-                match set_qualifier {
-                    SetQualifier::All | SetQualifier::Distinct => write!(f, " {}", set_qualifier)?,
-                    SetQualifier::None => write!(f, "{}", set_qualifier)?,
+                match set_quantifier {
+                    SetQuantifier::All | SetQuantifier::Distinct => write!(f, " {}", set_quantifier)?,
+                    SetQuantifier::None => write!(f, "{}", set_quantifier)?,
                 }
                 write!(f, " {}", right)?;
                 Ok(())

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -121,7 +121,9 @@ impl fmt::Display for SetExpr {
             } => {
                 write!(f, "{} {}", left, op)?;
                 match set_quantifier {
-                    SetQuantifier::All | SetQuantifier::Distinct => write!(f, " {}", set_quantifier)?,
+                    SetQuantifier::All | SetQuantifier::Distinct => {
+                        write!(f, " {}", set_quantifier)?
+                    }
                     SetQuantifier::None => write!(f, "{}", set_quantifier)?,
                 }
                 write!(f, " {}", right)?;

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -133,7 +133,7 @@ impl fmt::Display for SetOperator {
 }
 
 /// A quantifier for [SetOperator].
-// TODO: Restrict some dialects to parse, specific SetQuantifier.
+// TODO: Restrict parsing specific SetQuantifier in some specific dialects.
 // For example, BigQuery does not support `DISTINCT` for `EXCEPT` and `INTERSECT`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -64,25 +64,6 @@ impl fmt::Display for Query {
     }
 }
 
-/// Options for SetOperator
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum SetQuantifier {
-    All,
-    Distinct,
-    None,
-}
-
-impl fmt::Display for SetQuantifier {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            SetQuantifier::All => write!(f, "ALL"),
-            SetQuantifier::Distinct => write!(f, "DISTINCT"),
-            SetQuantifier::None => write!(f, ""),
-        }
-    }
-}
-
 /// A node in a tree, representing a "query body" expression, roughly:
 /// `SELECT ... [ {UNION|EXCEPT|INTERSECT} SELECT ...]`
 #[allow(clippy::large_enum_variant)]
@@ -151,6 +132,26 @@ impl fmt::Display for SetOperator {
     }
 }
 
+/// A quantifier for [SetOperator].
+// TODO: Restrict some dialects to parse, specific SetQuantifier.
+// For example, BigQuery does not support `DISTINCT` for `EXCEPT` and `INTERSECT`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum SetQuantifier {
+    All,
+    Distinct,
+    None,
+}
+
+impl fmt::Display for SetQuantifier {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SetQuantifier::All => write!(f, "ALL"),
+            SetQuantifier::Distinct => write!(f, "DISTINCT"),
+            SetQuantifier::None => write!(f, ""),
+        }
+    }
+}
 /// A restricted variant of `SELECT` (without CTEs/`ORDER BY`), which may
 /// appear either as the only body item of a `Query`, or as an operand
 /// to a set operation like `UNION`.

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -64,6 +64,23 @@ impl fmt::Display for Query {
     }
 }
 
+/// Options for SetOperator
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum SetOperatorOption {
+    All,
+    Distinct,
+}
+
+impl fmt::Display for SetOperatorOption {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SetOperatorOption::All => write!(f, " ALL"),
+            SetOperatorOption::Distinct => write!(f, " DISTINCT"),
+        }
+    }
+}
+
 /// A node in a tree, representing a "query body" expression, roughly:
 /// `SELECT ... [ {UNION|EXCEPT|INTERSECT} SELECT ...]`
 #[allow(clippy::large_enum_variant)]
@@ -78,7 +95,7 @@ pub enum SetExpr {
     /// UNION/EXCEPT/INTERSECT of two queries
     SetOperation {
         op: SetOperator,
-        all: bool,
+        op_option: Option<SetOperatorOption>,
         left: Box<SetExpr>,
         right: Box<SetExpr>,
     },
@@ -98,10 +115,14 @@ impl fmt::Display for SetExpr {
                 left,
                 right,
                 op,
-                all,
+                op_option,
             } => {
-                let all_str = if *all { " ALL" } else { "" };
-                write!(f, "{} {}{} {}", left, op, all_str, right)
+                write!(f, "{} {}", left, op)?;
+                if let Some(ref o) = op_option {
+                    write!(f, "{}", o)?;
+                }
+                write!(f, " {}", right)?;
+                Ok(())
             }
         }
     }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -67,16 +67,16 @@ impl fmt::Display for Query {
 /// Options for SetOperator
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum SetOperatorOption {
+pub enum SetQualifier {
     All,
     Distinct,
 }
 
-impl fmt::Display for SetOperatorOption {
+impl fmt::Display for SetQualifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            SetOperatorOption::All => write!(f, " ALL"),
-            SetOperatorOption::Distinct => write!(f, " DISTINCT"),
+            SetQualifier::All => write!(f, "ALL"),
+            SetQualifier::Distinct => write!(f, "DISTINCT"),
         }
     }
 }
@@ -95,7 +95,7 @@ pub enum SetExpr {
     /// UNION/EXCEPT/INTERSECT of two queries
     SetOperation {
         op: SetOperator,
-        op_option: Option<SetOperatorOption>,
+        set_qualifier: Option<SetQualifier>,
         left: Box<SetExpr>,
         right: Box<SetExpr>,
     },
@@ -115,11 +115,11 @@ impl fmt::Display for SetExpr {
                 left,
                 right,
                 op,
-                op_option,
+                set_qualifier,
             } => {
                 write!(f, "{} {}", left, op)?;
-                if let Some(ref o) = op_option {
-                    write!(f, "{}", o)?;
+                if let Some(ref sq) = set_qualifier {
+                    write!(f, " {}", sq)?;
                 }
                 write!(f, " {}", right)?;
                 Ok(())

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -70,6 +70,7 @@ impl fmt::Display for Query {
 pub enum SetQualifier {
     All,
     Distinct,
+    None
 }
 
 impl fmt::Display for SetQualifier {
@@ -77,6 +78,7 @@ impl fmt::Display for SetQualifier {
         match self {
             SetQualifier::All => write!(f, "ALL"),
             SetQualifier::Distinct => write!(f, "DISTINCT"),
+            SetQualifier::None => write!(f, ""),
         }
     }
 }
@@ -95,7 +97,7 @@ pub enum SetExpr {
     /// UNION/EXCEPT/INTERSECT of two queries
     SetOperation {
         op: SetOperator,
-        set_qualifier: Option<SetQualifier>,
+        set_qualifier: SetQualifier,
         left: Box<SetExpr>,
         right: Box<SetExpr>,
     },
@@ -118,8 +120,9 @@ impl fmt::Display for SetExpr {
                 set_qualifier,
             } => {
                 write!(f, "{} {}", left, op)?;
-                if let Some(ref sq) = set_qualifier {
-                    write!(f, " {}", sq)?;
+                match set_qualifier {
+                    SetQualifier::All | SetQualifier::Distinct => write!(f, " {}", set_qualifier)?,
+                    SetQualifier::None => write!(f, "{}", set_qualifier)?,
                 }
                 write!(f, " {}", right)?;
                 Ok(())

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -70,7 +70,7 @@ impl fmt::Display for Query {
 pub enum SetQualifier {
     All,
     Distinct,
-    None
+    None,
 }
 
 impl fmt::Display for SetQualifier {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4173,11 +4173,11 @@ impl<'a> Parser<'a> {
                 break;
             }
             self.next_token(); // skip past the set operator
-            let set_qualifier = self.parse_set_operator_option(&op);
+            let set_quantifier = self.parse_set_operator_option(&op);
             expr = SetExpr::SetOperation {
                 left: Box::new(expr),
                 op: op.unwrap(),
-                set_qualifier,
+                set_quantifier,
                 right: Box::new(self.parse_query_body(next_precedence)?),
             };
         }
@@ -4194,27 +4194,27 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn parse_set_operator_option(&mut self, op: &Option<SetOperator>) -> SetQualifier {
+    pub fn parse_set_operator_option(&mut self, op: &Option<SetOperator>) -> SetQuantifier {
         match op {
             Some(SetOperator::Union) => {
                 if self.parse_keyword(Keyword::ALL) {
-                    SetQualifier::All
+                    SetQuantifier::All
                 } else if self.parse_keyword(Keyword::DISTINCT) {
-                    SetQualifier::Distinct
+                    SetQuantifier::Distinct
                 } else {
-                    SetQualifier::None
+                    SetQuantifier::None
                 }
             }
             Some(SetOperator::Except) | Some(SetOperator::Intersect) => {
                 if self.parse_keyword(Keyword::ALL) {
-                    SetQualifier::All
+                    SetQuantifier::All
                 } else if self.parse_keyword(Keyword::DISTINCT) {
-                    SetQualifier::Distinct
+                    SetQuantifier::Distinct
                 } else {
-                    SetQualifier::None
+                    SetQuantifier::None
                 }
             }
-            _ => SetQualifier::None,
+            _ => SetQuantifier::None,
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4176,7 +4176,7 @@ impl<'a> Parser<'a> {
             expr = SetExpr::SetOperation {
                 left: Box::new(expr),
                 op: op.unwrap(),
-                all: self.parse_keyword(Keyword::ALL),
+                op_option: self.parse_set_operator_option(),
                 right: Box::new(self.parse_query_body(next_precedence)?),
             };
         }
@@ -4191,6 +4191,17 @@ impl<'a> Parser<'a> {
             Token::Word(w) if w.keyword == Keyword::INTERSECT => Some(SetOperator::Intersect),
             _ => None,
         }
+    }
+
+    pub fn parse_set_operator_option(&mut self) -> Option<SetOperatorOption> {
+        let op_option = if self.parse_keyword(Keyword::ALL) {
+            Some(SetOperatorOption::All)
+        } else if self.parse_keyword(Keyword::DISTINCT) {
+            Some(SetOperatorOption::Distinct)
+        } else {
+            None
+        };
+        op_option
     }
 
     /// Parse a restricted `SELECT` statement (no CTEs / `UNION` / `ORDER BY`),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4194,17 +4194,12 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn parse_set_operator_option(
-        &mut self,
-        op: &Option<SetOperator>,
-    ) -> SetQualifier {
+    pub fn parse_set_operator_option(&mut self, op: &Option<SetOperator>) -> SetQualifier {
         match op {
             Some(SetOperator::Union) => {
                 if self.parse_keyword(Keyword::ALL) {
                     SetQualifier::All
-                } else if self.parse_keyword(Keyword::DISTINCT)
-                    && dialect_of!(self is MySqlDialect | BigQueryDialect)
-                {
+                } else if self.parse_keyword(Keyword::DISTINCT) {
                     SetQualifier::Distinct
                 } else {
                     SetQualifier::None
@@ -4213,6 +4208,8 @@ impl<'a> Parser<'a> {
             Some(SetOperator::Except) | Some(SetOperator::Intersect) => {
                 if self.parse_keyword(Keyword::ALL) {
                     SetQualifier::All
+                } else if self.parse_keyword(Keyword::DISTINCT) {
+                    SetQualifier::Distinct
                 } else {
                     SetQualifier::None
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4173,11 +4173,11 @@ impl<'a> Parser<'a> {
                 break;
             }
             self.next_token(); // skip past the set operator
-            let op_option = self.parse_set_operator_option(&op);
+            let set_qualifier = self.parse_set_operator_option(&op);
             expr = SetExpr::SetOperation {
                 left: Box::new(expr),
                 op: op.unwrap(),
-                op_option,
+                set_qualifier,
                 right: Box::new(self.parse_query_body(next_precedence)?),
             };
         }
@@ -4197,29 +4197,29 @@ impl<'a> Parser<'a> {
     pub fn parse_set_operator_option(
         &mut self,
         op: &Option<SetOperator>,
-    ) -> Option<SetOperatorOption> {
+    ) -> Option<SetQualifier> {
         match op {
             Some(SetOperator::Union) => {
                 if self.parse_keyword(Keyword::ALL) {
-                    Some(SetOperatorOption::All)
+                    Some(SetQualifier::All)
                 } else if self.parse_keyword(Keyword::DISTINCT)
                     && dialect_of!(self is MySqlDialect | BigQueryDialect)
                 {
-                    Some(SetOperatorOption::Distinct)
+                    Some(SetQualifier::Distinct)
                 } else {
                     None
                 }
             }
             Some(SetOperator::Except) => {
                 if self.parse_keyword(Keyword::ALL) {
-                    Some(SetOperatorOption::All)
+                    Some(SetQualifier::All)
                 } else {
                     None
                 }
             }
             Some(SetOperator::Intersect) => {
                 if self.parse_keyword(Keyword::ALL) {
-                    Some(SetOperatorOption::All)
+                    Some(SetQualifier::All)
                 } else {
                     None
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4173,7 +4173,7 @@ impl<'a> Parser<'a> {
                 break;
             }
             self.next_token(); // skip past the set operator
-            let set_quantifier = self.parse_set_operator_option(&op);
+            let set_quantifier = self.parse_set_quantifier(&op);
             expr = SetExpr::SetOperation {
                 left: Box::new(expr),
                 op: op.unwrap(),
@@ -4194,7 +4194,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn parse_set_operator_option(&mut self, op: &Option<SetOperator>) -> SetQuantifier {
+    pub fn parse_set_quantifier(&mut self, op: &Option<SetOperator>) -> SetQuantifier {
         match op {
             Some(SetOperator::Union) => {
                 if self.parse_keyword(Keyword::ALL) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4197,34 +4197,27 @@ impl<'a> Parser<'a> {
     pub fn parse_set_operator_option(
         &mut self,
         op: &Option<SetOperator>,
-    ) -> Option<SetQualifier> {
+    ) -> SetQualifier {
         match op {
             Some(SetOperator::Union) => {
                 if self.parse_keyword(Keyword::ALL) {
-                    Some(SetQualifier::All)
+                    SetQualifier::All
                 } else if self.parse_keyword(Keyword::DISTINCT)
                     && dialect_of!(self is MySqlDialect | BigQueryDialect)
                 {
-                    Some(SetQualifier::Distinct)
+                    SetQualifier::Distinct
                 } else {
-                    None
+                    SetQualifier::None
                 }
             }
-            Some(SetOperator::Except) => {
+            Some(SetOperator::Except) | Some(SetOperator::Intersect) => {
                 if self.parse_keyword(Keyword::ALL) {
-                    Some(SetQualifier::All)
+                    SetQualifier::All
                 } else {
-                    None
+                    SetQualifier::None
                 }
             }
-            Some(SetOperator::Intersect) => {
-                if self.parse_keyword(Keyword::ALL) {
-                    Some(SetQualifier::All)
-                } else {
-                    None
-                }
-            }
-            _ => None,
+            _ => SetQualifier::None,
         }
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -26,7 +26,7 @@ use sqlparser::ast::SelectItem::UnnamedExpr;
 use sqlparser::ast::*;
 use sqlparser::dialect::{
     AnsiDialect, BigQueryDialect, ClickHouseDialect, GenericDialect, HiveDialect, MsSqlDialect,
-    PostgreSqlDialect, SQLiteDialect, SnowflakeDialect,
+    MySqlDialect, PostgreSqlDialect, SQLiteDialect, SnowflakeDialect,
 };
 use sqlparser::keywords::ALL_KEYWORDS;
 use sqlparser::parser::{Parser, ParserError};
@@ -4094,6 +4094,16 @@ fn parse_union() {
     verified_stmt("SELECT 1 UNION SELECT 2 INTERSECT SELECT 3"); // Union[1, Intersect[2,3]]
     verified_stmt("SELECT foo FROM tab UNION SELECT bar FROM TAB");
     verified_stmt("(SELECT * FROM new EXCEPT SELECT * FROM old) UNION ALL (SELECT * FROM old EXCEPT SELECT * FROM new) ORDER BY 1");
+}
+
+#[test]
+fn parse_union_distinct() {
+    let dialects = TestedDialects {
+        dialects: vec![Box::new(BigQueryDialect {}), Box::new(MySqlDialect {})],
+    };
+    dialects.verified_stmt("SELECT 1 UNION DISTINCT SELECT 2");
+    dialects.verified_stmt("SELECT 1 UNION DISTINCT SELECT 2 INTERSECT ALL SELECT 3");
+    dialects.verified_stmt("SELECT 1 EXCEPT (SELECT 2 UNION DISTINCT SELECT 3)");
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -26,7 +26,7 @@ use sqlparser::ast::SelectItem::UnnamedExpr;
 use sqlparser::ast::*;
 use sqlparser::dialect::{
     AnsiDialect, BigQueryDialect, ClickHouseDialect, GenericDialect, HiveDialect, MsSqlDialect,
-    MySqlDialect, PostgreSqlDialect, SQLiteDialect, SnowflakeDialect,
+    PostgreSqlDialect, SQLiteDialect, SnowflakeDialect,
 };
 use sqlparser::keywords::ALL_KEYWORDS;
 use sqlparser::parser::{Parser, ParserError};
@@ -4078,14 +4078,17 @@ fn parse_derived_tables() {
 }
 
 #[test]
-fn parse_union() {
+fn parse_union_except_intersect() {
     // TODO: add assertions
     verified_stmt("SELECT 1 UNION SELECT 2");
     verified_stmt("SELECT 1 UNION ALL SELECT 2");
+    verified_stmt("SELECT 1 UNION DISTINCT SELECT 1");
     verified_stmt("SELECT 1 EXCEPT SELECT 2");
     verified_stmt("SELECT 1 EXCEPT ALL SELECT 2");
+    verified_stmt("SELECT 1 EXCEPT DISTINCT SELECT 1");
     verified_stmt("SELECT 1 INTERSECT SELECT 2");
     verified_stmt("SELECT 1 INTERSECT ALL SELECT 2");
+    verified_stmt("SELECT 1 INTERSECT DISTINCT SELECT 1");
     verified_stmt("SELECT 1 UNION SELECT 2 UNION SELECT 3");
     verified_stmt("SELECT 1 EXCEPT SELECT 2 UNION SELECT 3"); // Union[Except[1,2], 3]
     verified_stmt("SELECT 1 INTERSECT (SELECT 2 EXCEPT SELECT 3)");
@@ -4094,16 +4097,7 @@ fn parse_union() {
     verified_stmt("SELECT 1 UNION SELECT 2 INTERSECT SELECT 3"); // Union[1, Intersect[2,3]]
     verified_stmt("SELECT foo FROM tab UNION SELECT bar FROM TAB");
     verified_stmt("(SELECT * FROM new EXCEPT SELECT * FROM old) UNION ALL (SELECT * FROM old EXCEPT SELECT * FROM new) ORDER BY 1");
-}
-
-#[test]
-fn parse_union_distinct() {
-    let dialects = TestedDialects {
-        dialects: vec![Box::new(BigQueryDialect {}), Box::new(MySqlDialect {})],
-    };
-    dialects.verified_stmt("SELECT 1 UNION DISTINCT SELECT 2");
-    dialects.verified_stmt("SELECT 1 UNION DISTINCT SELECT 2 INTERSECT ALL SELECT 3");
-    dialects.verified_stmt("SELECT 1 EXCEPT (SELECT 2 UNION DISTINCT SELECT 3)");
+    verified_stmt("(SELECT * FROM new EXCEPT DISTINCT SELECT * FROM old) UNION DISTINCT (SELECT * FROM old EXCEPT DISTINCT SELECT * FROM new) ORDER BY 1");
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1310,7 +1310,7 @@ fn parse_array_subquery_expr() {
             with: None,
             body: Box::new(SetExpr::SetOperation {
                 op: SetOperator::Union,
-                set_qualifier: None,
+                set_qualifier: SetQualifier::None,
                 left: Box::new(SetExpr::Select(Box::new(Select {
                     distinct: false,
                     top: None,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1310,7 +1310,7 @@ fn parse_array_subquery_expr() {
             with: None,
             body: Box::new(SetExpr::SetOperation {
                 op: SetOperator::Union,
-                op_option: None,
+                set_qualifier: None,
                 left: Box::new(SetExpr::Select(Box::new(Select {
                     distinct: false,
                     top: None,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1310,7 +1310,7 @@ fn parse_array_subquery_expr() {
             with: None,
             body: Box::new(SetExpr::SetOperation {
                 op: SetOperator::Union,
-                all: false,
+                op_option: None,
                 left: Box::new(SetExpr::Select(Box::new(Select {
                     distinct: false,
                     top: None,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1310,7 +1310,7 @@ fn parse_array_subquery_expr() {
             with: None,
             body: Box::new(SetExpr::SetOperation {
                 op: SetOperator::Union,
-                set_qualifier: SetQualifier::None,
+                set_quantifier: SetQuantifier::None,
                 left: Box::new(SetExpr::Select(Box::new(Select {
                     distinct: false,
                     top: None,


### PR DESCRIPTION
closes #688

This supports following  for GenericDialect ~BigQuery and MySql dialects~.
- [x] UNION DISTINCT
- [x] INTERSECT DISTINCT
- [x] EXCEPT DISTINCT