### PR TITLE
Snowflake: Support semi-structured data

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -187,6 +187,8 @@ pub enum JsonOperator {
     HashArrow,
     /// #>> Extracts JSON sub-object at the specified path as text
     HashLongArrow,
+    /// : Colon is used by Snowflake (Which is similar to LongArrow)
+    Colon,
 }
 
 impl fmt::Display for JsonOperator {
@@ -203,6 +205,9 @@ impl fmt::Display for JsonOperator {
             }
             JsonOperator::HashLongArrow => {
                 write!(f, "#>>")
+            }
+            JsonOperator::Colon => {
+                write!(f, ":")
             }
         }
     }
@@ -757,7 +762,12 @@ impl fmt::Display for Expr {
                 operator,
                 right,
             } => {
-                write!(f, "{} {} {}", left, operator, right)
+                if operator == &JsonOperator::Colon  {   
+                    write!(f, "{}{}{}", left, operator, right)
+                } else {
+                    write!(f, "{} {} {}", left, operator, right)
+                }
+                
             }
             Expr::CompositeAccess { expr, key } => {
                 write!(f, "{}.{}", expr, key)

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -762,12 +762,11 @@ impl fmt::Display for Expr {
                 operator,
                 right,
             } => {
-                if operator == &JsonOperator::Colon  {   
+                if operator == &JsonOperator::Colon {
                     write!(f, "{}{}{}", left, operator, right)
                 } else {
                     write!(f, "{} {} {}", left, operator, right)
                 }
-                
             }
             Expr::CompositeAccess { expr, key } => {
                 write!(f, "{}.{}", expr, key)

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -45,6 +45,8 @@ pub enum Value {
     Null,
     /// `?` or `$` Prepared statement arg placeholder
     Placeholder(String),
+    /// Add support of snowflake field:key - key should be a value
+    UnQuotedString(String),
 }
 
 impl fmt::Display for Value {
@@ -59,6 +61,7 @@ impl fmt::Display for Value {
             Value::Boolean(v) => write!(f, "{}", v),
             Value::Null => write!(f, "NULL"),
             Value::Placeholder(v) => write!(f, "{}", v),
+            Value::UnQuotedString(v) => write!(f, "{}", v),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1429,7 +1429,7 @@ impl<'a> Parser<'a> {
         } else if Token::Colon == tok {
             Ok(Expr::JsonAccess {
                 left: Box::new(expr),
-                operator: JsonOperator::LongArrow,
+                operator: JsonOperator::Colon,
                 right: Box::new(self.parse_subexpr(51)?),
             })
         } else if Token::Arrow == tok

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3448,7 +3448,8 @@ impl<'a> Parser<'a> {
                     Some('\'') => Ok(Value::SingleQuotedString(w.value)),
                     _ => self.expected("A value?", Token::Word(w))?,
                 },
-                Keyword::NoKeyword if dialect_of!(self is SnowflakeDialect | GenericDialect) => {
+                // Case when Snowflake Semi-structured data like key:value
+                Keyword::NoKeyword | Keyword::LOCATION if dialect_of!(self is SnowflakeDialect | GenericDialect) => {
                     Ok(Value::UnQuotedString(w.value))
                 }
                 _ => self.expected("a concrete value", Token::Word(w)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1430,7 +1430,7 @@ impl<'a> Parser<'a> {
             Ok(Expr::JsonAccess {
                 left: Box::new(expr),
                 operator: JsonOperator::Colon,
-                right: Box::new(self.parse_subexpr(51)?),
+                right: Box::new(Expr::Value(self.parse_value()?)),
             })
         } else if Token::Arrow == tok
             || Token::LongArrow == tok
@@ -3448,6 +3448,9 @@ impl<'a> Parser<'a> {
                     Some('\'') => Ok(Value::SingleQuotedString(w.value)),
                     _ => self.expected("A value?", Token::Word(w))?,
                 },
+                Keyword::NoKeyword if dialect_of!(self is SnowflakeDialect) => {
+                    Ok(Value::UnQuotedString(w.value))
+                }
                 _ => self.expected("a concrete value", Token::Word(w)),
             },
             // The call to n.parse() returns a bigdecimal when the

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1426,6 +1426,12 @@ impl<'a> Parser<'a> {
                 return self.parse_array_index(expr);
             }
             self.parse_map_access(expr)
+        } else if Token::Colon == tok {
+            Ok(Expr::JsonAccess {
+                left: Box::new(expr),
+                operator: JsonOperator::LongArrow,
+                right: Box::new(self.parse_subexpr(51)?),
+            })
         } else if Token::Arrow == tok
             || Token::LongArrow == tok
             || Token::HashArrow == tok
@@ -1627,6 +1633,7 @@ impl<'a> Parser<'a> {
             Token::Plus | Token::Minus => Ok(Self::PLUS_MINUS_PREC),
             Token::Mul | Token::Div | Token::Mod | Token::StringConcat => Ok(40),
             Token::DoubleColon => Ok(50),
+            Token::Colon => Ok(50),
             Token::ExclamationMark => Ok(50),
             Token::LBracket
             | Token::LongArrow

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3448,7 +3448,7 @@ impl<'a> Parser<'a> {
                     Some('\'') => Ok(Value::SingleQuotedString(w.value)),
                     _ => self.expected("A value?", Token::Word(w))?,
                 },
-                Keyword::NoKeyword if dialect_of!(self is SnowflakeDialect) => {
+                Keyword::NoKeyword if dialect_of!(self is SnowflakeDialect | GenericDialect) => {
                     Ok(Value::UnQuotedString(w.value))
                 }
                 _ => self.expected("a concrete value", Token::Word(w)),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1595,15 +1595,6 @@ fn parse_limit_accepts_all() {
 }
 
 #[test]
-fn parse_json_using_colon() {
-    one_statement_parses_to("SELECT field:key FROM t", "SELECT field ->> key FROM t");
-    one_statement_parses_to(
-        "SELECT field:key::int FROM t",
-        "SELECT CAST(field ->> key AS INT) FROM t",
-    );
-}
-
-#[test]
 fn parse_cast() {
     let sql = "SELECT CAST(id AS BIGINT) FROM customer";
     let select = verified_only_select(sql);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1595,6 +1595,15 @@ fn parse_limit_accepts_all() {
 }
 
 #[test]
+fn parse_json_using_colon() {
+    one_statement_parses_to("SELECT field:key FROM t", "SELECT field ->> key FROM t");
+    one_statement_parses_to(
+        "SELECT field:key::int FROM t",
+        "SELECT CAST(field ->> key AS INT) FROM t",
+    );
+}
+
+#[test]
 fn parse_cast() {
     let sql = "SELECT CAST(id AS BIGINT) FROM customer";
     let select = verified_only_select(sql);

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -143,6 +143,25 @@ fn test_single_table_in_parenthesis_with_alias() {
     );
 }
 
+#[test]
+fn parse_json_using_colon() {
+    let sql = "SELECT field:key FROM t";
+    let select = snowflake().verified_only_select(sql);
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::JsonAccess {
+            left: Box::new(Expr::Identifier(Ident::new("field"))),
+            operator: JsonOperator::Colon,
+            right: Box::new(Expr::Identifier(Ident::new("key"))),
+        }),
+        select.projection[0]
+    );
+
+    snowflake().one_statement_parses_to(
+        "SELECT field:key::int FROM t",
+        "SELECT CAST(field:key AS INT) FROM t",
+    );
+}
+
 fn snowflake() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(SnowflakeDialect {})],

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -145,20 +145,20 @@ fn test_single_table_in_parenthesis_with_alias() {
 
 #[test]
 fn parse_json_using_colon() {
-    let sql = "SELECT field:key FROM t";
+    let sql = "SELECT a:b FROM t";
     let select = snowflake().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("field"))),
+            left: Box::new(Expr::Identifier(Ident::new("a"))),
             operator: JsonOperator::Colon,
-            right: Box::new(Expr::Identifier(Ident::new("key"))),
+            right: Box::new(Expr::Value(Value::UnQuotedString("b".to_string()))),
         }),
         select.projection[0]
     );
 
     snowflake().one_statement_parses_to(
-        "SELECT field:key::int FROM t",
-        "SELECT CAST(field:key AS INT) FROM t",
+        "SELECT a:b::int FROM t",
+        "SELECT CAST(a:b AS INT) FROM t",
     );
 }
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -156,10 +156,7 @@ fn parse_json_using_colon() {
         select.projection[0]
     );
 
-    snowflake().one_statement_parses_to(
-        "SELECT a:b::int FROM t",
-        "SELECT CAST(a:b AS INT) FROM t",
-    );
+    snowflake().one_statement_parses_to("SELECT a:b::int FROM t", "SELECT CAST(a:b AS INT) FROM t");
 }
 
 fn snowflake() -> TestedDialects {


### PR DESCRIPTION
Per snowflake [documentation](https://docs.snowflake.com/en/user-guide/querying-semistructured.html#traversing-semi-structured-data), Colon can be used to query semi-structured data (JSON).

I decided to use the `JsonAccess` expression (which is used by postgres), but if you think a new expression is needed - I will change.