### PR TITLE
Support the ARRAY type of Snowflake

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use core::fmt;
 
 #[cfg(feature = "serde")]

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -136,8 +136,6 @@ pub enum DataType {
     Enum(Vec<String>),
     /// Set
     Set(Vec<String>),
-    // SnowflakeArray (Not Typed, without [])
-    SnowflakeArray,
 }
 
 impl fmt::Display for DataType {
@@ -218,8 +216,16 @@ impl fmt::Display for DataType {
             DataType::Text => write!(f, "TEXT"),
             DataType::String => write!(f, "STRING"),
             DataType::Bytea => write!(f, "BYTEA"),
-            DataType::SnowflakeArray => write!(f, "ARRAY"),
-            DataType::Array(ty) => write!(f, "{}[]", ty),
+            DataType::Array(ty) => {
+                if ty.to_string()
+                    == Box::new(DataType::Custom(ObjectName(vec!["VARAINT".into()]), vec![]))
+                        .to_string()
+                {
+                    write!(f, "ARRAY")
+                } else {
+                    write!(f, "{}[]", ty)
+                }
+            }
             DataType::Custom(ty, modifiers) => {
                 if modifiers.is_empty() {
                     write!(f, "{}", ty)

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -141,7 +141,7 @@ pub enum DataType {
     /// Custom type such as enums
     Custom(ObjectName, Vec<String>),
     /// Arrays
-    Array(Box<DataType>),
+    Array(Option<Box<DataType>>),
     /// Enums
     Enum(Vec<String>),
     /// Set
@@ -233,10 +233,10 @@ impl fmt::Display for DataType {
             DataType::String => write!(f, "STRING"),
             DataType::Bytea => write!(f, "BYTEA"),
             DataType::Array(ty) => {
-                if ty == &Box::new(DataType::Custom(ObjectName(vec!["VARAINT".into()]), vec![])) {
-                    write!(f, "ARRAY")
+                if let Some(t) = &ty {
+                    write!(f, "{}[]", t)
                 } else {
-                    write!(f, "{}[]", ty)
+                    write!(f, "ARRAY")
                 }
             }
             DataType::Custom(ty, modifiers) => {

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -217,10 +217,7 @@ impl fmt::Display for DataType {
             DataType::String => write!(f, "STRING"),
             DataType::Bytea => write!(f, "BYTEA"),
             DataType::Array(ty) => {
-                if ty.to_string()
-                    == Box::new(DataType::Custom(ObjectName(vec!["VARAINT".into()]), vec![]))
-                        .to_string()
-                {
+                if ty == &Box::new(DataType::Custom(ObjectName(vec!["VARAINT".into()]), vec![])) {
                     write!(f, "ARRAY")
                 } else {
                     write!(f, "{}[]", ty)

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -136,6 +136,8 @@ pub enum DataType {
     Enum(Vec<String>),
     /// Set
     Set(Vec<String>),
+    // SnowflakeArray (Not Typed, without [])
+    SnowflakeArray,
 }
 
 impl fmt::Display for DataType {
@@ -216,6 +218,7 @@ impl fmt::Display for DataType {
             DataType::Text => write!(f, "TEXT"),
             DataType::String => write!(f, "STRING"),
             DataType::Bytea => write!(f, "BYTEA"),
+            DataType::SnowflakeArray => write!(f, "ARRAY"),
             DataType::Array(ty) => write!(f, "{}[]", ty),
             DataType::Custom(ty, modifiers) => {
                 if modifiers.is_empty() {

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt;
 
 #[cfg(feature = "serde")]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3650,13 +3650,17 @@ impl<'a> Parser<'a> {
                 Keyword::ENUM => Ok(DataType::Enum(self.parse_string_values()?)),
                 Keyword::SET => Ok(DataType::Set(self.parse_string_values()?)),
                 Keyword::ARRAY => {
-                    // Hive array syntax. Note that nesting arrays - or other Hive syntax
-                    // that ends with > will fail due to "C++" problem - >> is parsed as
-                    // Token::ShiftRight
-                    self.expect_token(&Token::Lt)?;
-                    let inside_type = self.parse_data_type()?;
-                    self.expect_token(&Token::Gt)?;
-                    Ok(DataType::Array(Box::new(inside_type)))
+                    if dialect_of!(self is SnowflakeDialect) {
+                        Ok(DataType::SnowflakeArray)
+                    } else {
+                        // Hive array syntax. Note that nesting arrays - or other Hive syntax
+                        // that ends with > will fail due to "C++" problem - >> is parsed as
+                        // Token::ShiftRight
+                        self.expect_token(&Token::Lt)?;
+                        let inside_type = self.parse_data_type()?;
+                        self.expect_token(&Token::Gt)?;
+                        Ok(DataType::Array(Box::new(inside_type)))
+                    }
                 }
                 _ => {
                     self.prev_token();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3673,10 +3673,7 @@ impl<'a> Parser<'a> {
                 Keyword::SET => Ok(DataType::Set(self.parse_string_values()?)),
                 Keyword::ARRAY => {
                     if dialect_of!(self is SnowflakeDialect) {
-                        Ok(DataType::Array(Box::new(DataType::Custom(
-                            ObjectName(vec!["VARAINT".into()]),
-                            vec![],
-                        ))))
+                        Ok(DataType::Array(None))
                     } else {
                         // Hive array syntax. Note that nesting arrays - or other Hive syntax
                         // that ends with > will fail due to "C++" problem - >> is parsed as
@@ -3684,7 +3681,7 @@ impl<'a> Parser<'a> {
                         self.expect_token(&Token::Lt)?;
                         let inside_type = self.parse_data_type()?;
                         self.expect_token(&Token::Gt)?;
-                        Ok(DataType::Array(Box::new(inside_type)))
+                        Ok(DataType::Array(Some(Box::new(inside_type))))
                     }
                 }
                 _ => {
@@ -3704,7 +3701,7 @@ impl<'a> Parser<'a> {
         // Keyword::ARRAY syntax from above
         while self.consume_token(&Token::LBracket) {
             self.expect_token(&Token::RBracket)?;
-            data = DataType::Array(Box::new(data))
+            data = DataType::Array(Some(Box::new(data)))
         }
         Ok(data)
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3651,7 +3651,10 @@ impl<'a> Parser<'a> {
                 Keyword::SET => Ok(DataType::Set(self.parse_string_values()?)),
                 Keyword::ARRAY => {
                     if dialect_of!(self is SnowflakeDialect) {
-                        Ok(DataType::SnowflakeArray)
+                        Ok(DataType::Array(Box::new(DataType::Custom(
+                            ObjectName(vec!["VARAINT".into()]),
+                            vec![],
+                        ))))
                     } else {
                         // Hive array syntax. Note that nesting arrays - or other Hive syntax
                         // that ends with > will fail due to "C++" problem - >> is parsed as

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -26,7 +26,7 @@ use sqlparser::ast::SelectItem::UnnamedExpr;
 use sqlparser::ast::*;
 use sqlparser::dialect::{
     AnsiDialect, BigQueryDialect, ClickHouseDialect, GenericDialect, HiveDialect, MsSqlDialect,
-    PostgreSqlDialect, SQLiteDialect, SnowflakeDialect,
+    MySqlDialect, PostgreSqlDialect, SQLiteDialect, SnowflakeDialect,
 };
 use sqlparser::keywords::ALL_KEYWORDS;
 use sqlparser::parser::{Parser, ParserError};
@@ -2123,12 +2123,20 @@ fn parse_create_table_hive_array() {
         _ => unreachable!(),
     }
 
-    let res =
-        parse_sql_statements("CREATE TABLE IF NOT EXISTS something (name int, val array<int)");
-    assert!(res
-        .unwrap_err()
-        .to_string()
-        .contains("Expected >, found: )"));
+    // SnowflakeDialect using array diffrent
+    let dialects = TestedDialects {
+        dialects: vec![
+            Box::new(PostgreSqlDialect {}),
+            Box::new(HiveDialect {}),
+            Box::new(MySqlDialect {}),
+        ],
+    };
+    let sql = "CREATE TABLE IF NOT EXISTS something (name int, val array<int)";
+
+    assert_eq!(
+        dialects.parse_sql_statements(sql).unwrap_err(),
+        ParserError::ParserError("Expected >, found: )".to_string())
+    );
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2099,7 +2099,7 @@ fn parse_create_table_hive_array() {
                     },
                     ColumnDef {
                         name: Ident::new("val"),
-                        data_type: DataType::Array(Box::new(DataType::Int(None))),
+                        data_type: DataType::Array(Some(Box::new(DataType::Int(None)))),
                         collation: None,
                         options: vec![],
                     },

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1281,9 +1281,9 @@ fn parse_array_index_expr() {
                     })],
                     named: true,
                 })),
-                data_type: DataType::Array(Box::new(DataType::Array(Box::new(DataType::Int(
-                    None
-                )))))
+                data_type: DataType::Array(Some(Box::new(DataType::Array(Some(Box::new(
+                    DataType::Int(None)
+                ))))))
             }))),
             indexes: vec![num[1].clone(), num[2].clone()],
         },

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -150,10 +150,7 @@ fn parse_array() {
     assert_eq!(
         &Expr::Cast {
             expr: Box::new(Expr::Identifier(Ident::new("a"))),
-            data_type: DataType::Array(Box::new(DataType::Custom(
-                ObjectName(vec!["VARAINT".into()]),
-                vec![]
-            ))),
+            data_type: DataType::Array(None),
         },
         expr_from_projection(only(&select.projection))
     );

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -150,7 +150,10 @@ fn parse_array() {
     assert_eq!(
         &Expr::Cast {
             expr: Box::new(Expr::Identifier(Ident::new("a"))),
-            data_type: DataType::SnowflakeArray,
+            data_type: DataType::Array(Box::new(DataType::Custom(
+                ObjectName(vec!["VARAINT".into()]),
+                vec![]
+            ))),
         },
         expr_from_projection(only(&select.projection))
     );

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -143,6 +143,19 @@ fn test_single_table_in_parenthesis_with_alias() {
     );
 }
 
+#[test]
+fn parse_array() {
+    let sql = "SELECT CAST(a AS ARRAY) FROM customer";
+    let select = snowflake().verified_only_select(sql);
+    assert_eq!(
+        &Expr::Cast {
+            expr: Box::new(Expr::Identifier(Ident::new("a"))),
+            data_type: DataType::SnowflakeArray,
+        },
+        expr_from_projection(only(&select.projection))
+    );
+}
+
 fn snowflake() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(SnowflakeDialect {})],


### PR DESCRIPTION
According snowflake [documentation](https://docs.snowflake.com/en/sql-reference/data-types-semistructured.html#array), There is an ARRAY type.
Behind the scenes  it contains the `VARIANT` Data type, but the syntax is different. Snowflake don't support `VARIANT[]`.
The query that I want to support is: `SELECT CAST (a as array)`
I started with creating a new data type called `SnowflakeArray`, But I think it's better to use the existing `ARRAY` data type (which created for the HIVE dialect)