### PR TITLE
Add precision for TIME, DATETIME, and TIMESTAMP

### DIFF
--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3032,7 +3032,7 @@ fn parse_literal_time() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::TypedString {
-            data_type: DataType::Time(TimezoneInfo::None),
+            data_type: DataType::Time(None, TimezoneInfo::None),
             value: "01:23:34".into(),
         },
         expr_from_projection(only(&select.projection)),
@@ -3045,7 +3045,7 @@ fn parse_literal_datetime() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::TypedString {
-            data_type: DataType::Datetime,
+            data_type: DataType::Datetime(None),
             value: "1999-01-01 01:23:34.45".into(),
         },
         expr_from_projection(only(&select.projection)),
@@ -3058,7 +3058,7 @@ fn parse_literal_timestamp_without_time_zone() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::TypedString {
-            data_type: DataType::Timestamp(TimezoneInfo::None),
+            data_type: DataType::Timestamp(None, TimezoneInfo::None),
             value: "1999-01-01 01:23:34".into(),
         },
         expr_from_projection(only(&select.projection)),
@@ -3073,7 +3073,7 @@ fn parse_literal_timestamp_with_time_zone() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::TypedString {
-            data_type: DataType::Timestamp(TimezoneInfo::Tz),
+            data_type: DataType::Timestamp(None, TimezoneInfo::Tz),
             value: "1999-01-01 01:23:34Z".into(),
         },
         expr_from_projection(only(&select.projection)),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1027,7 +1027,7 @@ fn parse_table_colum_option_on_update() {
             assert_eq!(
                 vec![ColumnDef {
                     name: Ident::with_quote('`', "modification_time"),
-                    data_type: DataType::Datetime,
+                    data_type: DataType::Datetime(None),
                     collation: None,
                     options: vec![ColumnOptionDef {
                         name: None,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -227,7 +227,7 @@ fn parse_create_table_with_defaults() {
                     },
                     ColumnDef {
                         name: "last_update".into(),
-                        data_type: DataType::Timestamp(TimezoneInfo::WithoutTimeZone),
+                        data_type: DataType::Timestamp(None, TimezoneInfo::WithoutTimeZone),
                         collation: None,
                         options: vec![
                             ColumnOptionDef {


### PR DESCRIPTION
feat: add precision for TIME, DATETIME, and TIMESTAMP data types

Now all those statements are both parsed and displayed with precision and timezone info. Tests were added to the ones presented in the ANSI standard [(1)](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#datetime-type).

[1] : https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#datetime-type