### PR TITLE
Fix interval parsing logic and precedence

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -363,6 +363,36 @@ impl<'a> Parser<'a> {
         Ok(expr)
     }
 
+    pub fn parse_interval_expr(&mut self) -> Result<Expr, ParserError> {
+        let precedence = 0;
+        let mut expr = self.parse_prefix()?;
+
+        loop {
+            let next_precedence = self.get_next_interval_precedence()?;
+
+            if precedence >= next_precedence {
+                break;
+            }
+
+            expr = self.parse_infix(expr, next_precedence)?;
+        }
+
+        Ok(expr)
+    }
+
+    /// Get the precedence of the next token
+    /// With AND, OR, and XOR
+    pub fn get_next_interval_precedence(&self) -> Result<u8, ParserError> {
+        let token = self.peek_token();
+
+        match token {
+            Token::Word(w) if w.keyword == Keyword::AND => Ok(0),
+            Token::Word(w) if w.keyword == Keyword::OR => Ok(0),
+            Token::Word(w) if w.keyword == Keyword::XOR => Ok(0),
+            _ => self.get_next_precedence()
+        }
+    }
+
     pub fn parse_assert(&mut self) -> Result<Statement, ParserError> {
         let condition = self.parse_expr()?;
         let message = if self.parse_keyword(Keyword::AS) {
@@ -1151,7 +1181,7 @@ impl<'a> Parser<'a> {
 
         // The first token in an interval is a string literal which specifies
         // the duration of the interval.
-        let value = self.parse_expr()?;
+        let value = self.parse_interval_expr()?;
 
         // Following the string literal is a qualifier which indicates the units
         // of the duration specified in the string literal.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -389,7 +389,7 @@ impl<'a> Parser<'a> {
             Token::Word(w) if w.keyword == Keyword::AND => Ok(0),
             Token::Word(w) if w.keyword == Keyword::OR => Ok(0),
             Token::Word(w) if w.keyword == Keyword::XOR => Ok(0),
-            _ => self.get_next_precedence()
+            _ => self.get_next_precedence(),
         }
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3216,19 +3216,22 @@ fn parse_interval_and_or_xor() {
 
     assert_eq!(actual_ast, expected_ast);
 
-    verified_stmt("SELECT col FROM test \
+    verified_stmt(
+        "SELECT col FROM test \
         WHERE d3_date > d1_date + INTERVAL '5 days' \
-        AND d2_date > d1_date + INTERVAL '3 days'"
+        AND d2_date > d1_date + INTERVAL '3 days'",
     );
 
-    verified_stmt("SELECT col FROM test \
+    verified_stmt(
+        "SELECT col FROM test \
         WHERE d3_date > d1_date + INTERVAL '5 days' \
-        OR d2_date > d1_date + INTERVAL '3 days'"
+        OR d2_date > d1_date + INTERVAL '3 days'",
     );
 
-    verified_stmt("SELECT col FROM test \
+    verified_stmt(
+        "SELECT col FROM test \
         WHERE d3_date > d1_date + INTERVAL '5 days' \
-        XOR d2_date > d1_date + INTERVAL '3 days'"
+        XOR d2_date > d1_date + INTERVAL '3 days'",
     );
 }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3121,6 +3121,70 @@ fn parse_interval() {
 }
 
 #[test]
+fn parse_interval_and_or_xor() {
+    let sql = "SELECT col FROM test \
+        WHERE d3_date > d1_date + INTERVAL '5 days' \
+        AND d2_date > d1_date + INTERVAL '3 days'";
+
+    let actual_ast = Parser::parse_sql(&GenericDialect {}, sql).unwrap();
+
+    let expected_ast = vec![Statement::Query(Box::new(Query {
+        with: None,
+        body: Box::new(SetExpr::Select(Box::new(Select {
+            distinct: false,
+            top: None,
+            projection: vec![UnnamedExpr(Expr::Identifier(Ident { value: "col".to_string(), quote_style: None }))],
+            into: None,
+            from: vec![TableWithJoins {
+                relation: TableFactor::Table {
+                    name: ObjectName(vec![Ident { value: "test".to_string(), quote_style: None }]),
+                    alias: None,
+                    args: None,
+                    with_hints: vec![] },
+                joins: vec![] }],
+            lateral_views: vec![],
+            selection: Some(Expr::BinaryOp {
+                left: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Identifier(Ident { value: "d3_date".to_string(), quote_style: None })),
+                    op: BinaryOperator::Gt,
+                    right: Box::new(Expr::BinaryOp {
+                        left: Box::new(Expr::Identifier(Ident { value: "d1_date".to_string(), quote_style: None })),
+                        op: BinaryOperator::Plus,
+                        right: Box::new(Expr::Interval {
+                            value: Box::new(Expr::Value(Value::SingleQuotedString("5 days".to_string()))),  // Token ?
+                            leading_field: None,
+                            leading_precision: None,
+                            last_field: None,
+                            fractional_seconds_precision: None }) }) }),
+                op: BinaryOperator::And,
+                right: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Identifier(Ident { value: "d2_date".to_string(), quote_style: None })),
+                    op: BinaryOperator::Gt,
+                    right: Box::new(Expr::BinaryOp {
+                        left: Box::new(Expr::Identifier(Ident { value: "d1_date".to_string(), quote_style: None })),
+                        op: BinaryOperator::Plus,
+                        right: Box::new(Expr::Interval {
+                            value: Box::new(Expr::Value(Value::SingleQuotedString("3 days".to_string()))),  // Token ?
+                            leading_field: None,
+                            leading_precision: None,
+                            last_field: None,
+                            fractional_seconds_precision: None }) }) }) }),
+            group_by: vec![],
+            cluster_by: vec![],
+            distribute_by: vec![],
+            sort_by: vec![],
+            having: None,
+            qualify: None }))),
+        order_by: vec![],
+        limit: None,
+        offset: None,
+        fetch: None,
+        lock: None }))];
+
+    assert_eq!(actual_ast, expected_ast);
+}
+
+#[test]
 fn parse_at_timezone() {
     let zero = Expr::Value(number("0"));
     let sql = "SELECT FROM_UNIXTIME(0) AT TIME ZONE 'UTC-06:00' FROM t";

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3215,6 +3215,21 @@ fn parse_interval_and_or_xor() {
     }))];
 
     assert_eq!(actual_ast, expected_ast);
+
+    verified_stmt("SELECT col FROM test \
+        WHERE d3_date > d1_date + INTERVAL '5 days' \
+        AND d2_date > d1_date + INTERVAL '3 days'"
+    );
+
+    verified_stmt("SELECT col FROM test \
+        WHERE d3_date > d1_date + INTERVAL '5 days' \
+        OR d2_date > d1_date + INTERVAL '3 days'"
+    );
+
+    verified_stmt("SELECT col FROM test \
+        WHERE d3_date > d1_date + INTERVAL '5 days' \
+        XOR d2_date > d1_date + INTERVAL '3 days'"
+    );
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3133,53 +3133,86 @@ fn parse_interval_and_or_xor() {
         body: Box::new(SetExpr::Select(Box::new(Select {
             distinct: false,
             top: None,
-            projection: vec![UnnamedExpr(Expr::Identifier(Ident { value: "col".to_string(), quote_style: None }))],
+            projection: vec![UnnamedExpr(Expr::Identifier(Ident {
+                value: "col".to_string(),
+                quote_style: None,
+            }))],
             into: None,
             from: vec![TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec![Ident { value: "test".to_string(), quote_style: None }]),
+                    name: ObjectName(vec![Ident {
+                        value: "test".to_string(),
+                        quote_style: None,
+                    }]),
                     alias: None,
                     args: None,
-                    with_hints: vec![] },
-                joins: vec![] }],
+                    with_hints: vec![],
+                },
+                joins: vec![],
+            }],
             lateral_views: vec![],
             selection: Some(Expr::BinaryOp {
                 left: Box::new(Expr::BinaryOp {
-                    left: Box::new(Expr::Identifier(Ident { value: "d3_date".to_string(), quote_style: None })),
+                    left: Box::new(Expr::Identifier(Ident {
+                        value: "d3_date".to_string(),
+                        quote_style: None,
+                    })),
                     op: BinaryOperator::Gt,
                     right: Box::new(Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident { value: "d1_date".to_string(), quote_style: None })),
+                        left: Box::new(Expr::Identifier(Ident {
+                            value: "d1_date".to_string(),
+                            quote_style: None,
+                        })),
                         op: BinaryOperator::Plus,
                         right: Box::new(Expr::Interval {
-                            value: Box::new(Expr::Value(Value::SingleQuotedString("5 days".to_string()))),  // Token ?
+                            value: Box::new(Expr::Value(Value::SingleQuotedString(
+                                "5 days".to_string(),
+                            ))),
                             leading_field: None,
                             leading_precision: None,
                             last_field: None,
-                            fractional_seconds_precision: None }) }) }),
+                            fractional_seconds_precision: None,
+                        }),
+                    }),
+                }),
                 op: BinaryOperator::And,
                 right: Box::new(Expr::BinaryOp {
-                    left: Box::new(Expr::Identifier(Ident { value: "d2_date".to_string(), quote_style: None })),
+                    left: Box::new(Expr::Identifier(Ident {
+                        value: "d2_date".to_string(),
+                        quote_style: None,
+                    })),
                     op: BinaryOperator::Gt,
                     right: Box::new(Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident { value: "d1_date".to_string(), quote_style: None })),
+                        left: Box::new(Expr::Identifier(Ident {
+                            value: "d1_date".to_string(),
+                            quote_style: None,
+                        })),
                         op: BinaryOperator::Plus,
                         right: Box::new(Expr::Interval {
-                            value: Box::new(Expr::Value(Value::SingleQuotedString("3 days".to_string()))),  // Token ?
+                            value: Box::new(Expr::Value(Value::SingleQuotedString(
+                                "3 days".to_string(),
+                            ))),
                             leading_field: None,
                             leading_precision: None,
                             last_field: None,
-                            fractional_seconds_precision: None }) }) }) }),
+                            fractional_seconds_precision: None,
+                        }),
+                    }),
+                }),
+            }),
             group_by: vec![],
             cluster_by: vec![],
             distribute_by: vec![],
             sort_by: vec![],
             having: None,
-            qualify: None }))),
+            qualify: None,
+        }))),
         order_by: vec![],
         limit: None,
         offset: None,
         fetch: None,
-        lock: None }))];
+        lock: None,
+    }))];
 
     assert_eq!(actual_ast, expected_ast);
 }


### PR DESCRIPTION
I originally opened an issue for this on the DataFusion side: https://github.com/apache/arrow-datafusion/issues/3944, but found the error to lie in how the queries were being parsed.

These changes allow something like `"SELECT col FROM test WHERE d3_date > d1_date + INTERVAL '5 days' AND d2_date > d1_date + INTERVAL '3 days'"` to be parsed correctly. Previously, the '5 days' was getting separated from the `INTERVAL` keyword and lumped into the `AND` operator.