### PR TITLE
feat: add 'compression' as keyword

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -142,6 +142,7 @@ define_keywords!(
     COMMENT,
     COMMIT,
     COMMITTED,
+    COMPRESSION,
     COMPUTE,
     CONDITION,
     CONFLICT,


### PR DESCRIPTION
Closes #718 

As requested, now `compression` is a keyword.
