### PR TITLE
feat: add snowflake and generic exclude support

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -31,9 +31,9 @@ pub use self::ddl::{
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
-    Cte, Fetch, Join, JoinConstraint, JoinOperator, LateralView, LockType, Offset, OffsetRows,
-    OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier,
-    TableAlias, TableFactor, TableWithJoins, Top, Values, With,
+    Cte, ExcludeSelectItem, Fetch, Join, JoinConstraint, JoinOperator, LateralView, LockType,
+    Offset, OffsetRows, OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator,
+    SetQuantifier, TableAlias, TableFactor, TableWithJoins, Top, Values, With,
 };
 pub use self::value::{escape_quoted_string, DateTimeField, TrimWhereField, Value};
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -225,6 +225,7 @@ define_keywords!(
     EVENT,
     EVERY,
     EXCEPT,
+    EXCLUDE,
     EXEC,
     EXECUTE,
     EXISTS,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5339,9 +5339,47 @@ impl<'a> Parser<'a> {
                         None => SelectItem::UnnamedExpr(expr),
                     })
             }
-            WildcardExpr::QualifiedWildcard(prefix) => Ok(SelectItem::QualifiedWildcard(prefix)),
-            WildcardExpr::Wildcard => Ok(SelectItem::Wildcard),
+            WildcardExpr::QualifiedWildcard(prefix) => {
+                let opt_exclude = if dialect_of!(self is GenericDialect | SnowflakeDialect) {
+                    self.parse_optional_select_item_exclude()?
+                } else {
+                    None
+                };
+
+                Ok(SelectItem::QualifiedWildcard(prefix, opt_exclude))
+            }
+            WildcardExpr::Wildcard => {
+                let opt_exclude = if dialect_of!(self is GenericDialect | SnowflakeDialect) {
+                    self.parse_optional_select_item_exclude()?
+                } else {
+                    None
+                };
+
+                Ok(SelectItem::Wildcard(opt_exclude))
+            }
         }
+    }
+
+    /// Parse an [`Exclude`](ExcludeSelectItem) information for wildcard select items.
+    ///
+    /// If it is not possible to parse it, will return an option.
+    pub fn parse_optional_select_item_exclude(
+        &mut self,
+    ) -> Result<Option<ExcludeSelectItem>, ParserError> {
+        let opt_exclude = if self.parse_keyword(Keyword::EXCLUDE) {
+            if self.consume_token(&Token::LParen) {
+                let columns = self.parse_comma_separated(|parser| parser.parse_identifier())?;
+                self.expect_token(&Token::RParen)?;
+                Some(ExcludeSelectItem::Multiple(columns))
+            } else {
+                let column = self.parse_identifier()?;
+                Some(ExcludeSelectItem::Single(column))
+            }
+        } else {
+            None
+        };
+
+        Ok(opt_exclude)
     }
 
     /// Parse an expression, optionally followed by ASC or DESC (used in ORDER BY)
@@ -5841,7 +5879,6 @@ mod tests {
 
     #[cfg(test)]
     mod test_parse_data_type {
-
         use crate::ast::{
             CharLengthUnits, CharacterLength, DataType, ExactNumberInfo, ObjectName, TimezoneInfo,
         };

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -578,22 +578,22 @@ fn parse_select_into() {
 fn parse_select_wildcard() {
     let sql = "SELECT * FROM foo";
     let select = verified_only_select(sql);
-    assert_eq!(&SelectItem::Wildcard, only(&select.projection));
+    assert_eq!(&SelectItem::Wildcard(None), only(&select.projection));
 
     let sql = "SELECT foo.* FROM foo";
     let select = verified_only_select(sql);
     assert_eq!(
-        &SelectItem::QualifiedWildcard(ObjectName(vec![Ident::new("foo")])),
+        &SelectItem::QualifiedWildcard(ObjectName(vec![Ident::new("foo")]), None),
         only(&select.projection)
     );
 
     let sql = "SELECT myschema.mytable.* FROM myschema.mytable";
     let select = verified_only_select(sql);
     assert_eq!(
-        &SelectItem::QualifiedWildcard(ObjectName(vec![
-            Ident::new("myschema"),
-            Ident::new("mytable"),
-        ])),
+        &SelectItem::QualifiedWildcard(
+            ObjectName(vec![Ident::new("myschema"), Ident::new("mytable"),]),
+            None
+        ),
         only(&select.projection)
     );
 
@@ -5239,7 +5239,7 @@ fn parse_merge() {
                         body: Box::new(SetExpr::Select(Box::new(Select {
                             distinct: false,
                             top: None,
-                            projection: vec![SelectItem::Wildcard],
+                            projection: vec![SelectItem::Wildcard(None)],
                             into: None,
                             from: vec![TableWithJoins {
                                 relation: TableFactor::Table {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1229,7 +1229,7 @@ fn parse_pg_returning() {
         pg_and_generic().verified_stmt("DELETE FROM tasks WHERE status = 'DONE' RETURNING *");
     match stmt {
         Statement::Delete { returning, .. } => {
-            assert_eq!(Some(vec![SelectItem::Wildcard,]), returning);
+            assert_eq!(Some(vec![SelectItem::Wildcard(None),]), returning);
         }
         _ => unreachable!(),
     };


### PR DESCRIPTION
The exclude clause can be used after a possibly qualified on SELECT. [(1)](https://docs.snowflake.com/en/sql-reference/sql/select.html)

Refs: #716