### PR TITLE
feat: add method to get current parsing index

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5775,6 +5775,11 @@ impl<'a> Parser<'a> {
         }
         Ok(sequence_options)
     }
+
+    /// The index of the first unprocessed token.
+    pub fn index(&self) -> usize {
+        self.index
+    }
 }
 
 impl Word {


### PR DESCRIPTION
We need to know where the invalid token is so that we can highlight it, and probably color the word or the clause to make it more obvious what's wrong. It'd be better as a higher-level utility than as part of the parser, so I expose the `index` field.