### PR TITLE
fix: unnest join constraint with alias parsing for BigQuery dialect

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4913,12 +4913,15 @@ impl<'a> Parser<'a> {
                 Err(_) => false,
             };
 
-            let with_offset_alias =
+            let with_offset_alias = if with_offset {
                 match self.parse_optional_alias(keywords::RESERVED_FOR_COLUMN_ALIAS) {
                     Ok(Some(alias)) => Some(alias),
                     Ok(None) => None,
                     Err(e) => return Err(e),
-                };
+                }
+            } else {
+                None
+            };
 
             Ok(TableFactor::UNNEST {
                 alias,

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -99,7 +99,7 @@ fn parse_join_constraint_unnest_alias() {
     assert_eq!(
         only(
             bigquery()
-                .verified_only_select(&"SELECT * FROM t1 JOIN UNNEST(t1.a) AS f ON c1 = c2")
+                .verified_only_select("SELECT * FROM t1 JOIN UNNEST(t1.a) AS f ON c1 = c2")
                 .from
         )
         .joins,

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -95,6 +95,34 @@ fn parse_table_identifiers() {
 }
 
 #[test]
+fn parse_join_constraint_unnest_alias() {
+    assert_eq!(
+        only(
+            bigquery()
+                .verified_only_select(&"SELECT * FROM t1 JOIN UNNEST(t1.a) AS f ON c1 = c2")
+                .from
+        )
+        .joins,
+        vec![Join {
+            relation: TableFactor::UNNEST {
+                alias: table_alias("f"),
+                array_expr: Box::new(Expr::CompoundIdentifier(vec![
+                    Ident::new("t1"),
+                    Ident::new("a")
+                ])),
+                with_offset: false,
+                with_offset_alias: None
+            },
+            join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier("c1".into())),
+                op: BinaryOperator::Eq,
+                right: Box::new(Expr::Identifier("c2".into())),
+            })),
+        }]
+    );
+}
+
+#[test]
 fn parse_trailing_comma() {
     for (sql, canonical) in [
         ("SELECT a,", "SELECT a"),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3555,25 +3555,6 @@ fn parse_unnest() {
             joins: vec![],
         }],
     );
-    // 5. WITH OFFSET and WITH OFFSET Alias
-    chk(
-        true,
-        false,
-        true,
-        &dialects,
-        vec![TableWithJoins {
-            relation: TableFactor::UNNEST {
-                alias: Some(TableAlias {
-                    name: Ident::new("numbers"),
-                    columns: vec![],
-                }),
-                array_expr: Box::new(Expr::Identifier(Ident::new("expr"))),
-                with_offset: false,
-                with_offset_alias: Some(Ident::new("with_offset_alias")),
-            },
-            joins: vec![],
-        }],
-    );
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes a parsing bug for the BigQuery Dialect. 
The expected outcome is for the following statement to be parsed with join constraints:
```sql
select * from t1 join unnest(t1.col) as f1 on  c1 = 123
```
However, this statement would result in the following error:
```
ParserError("Expected end of statement, found: c1")
```
Closer inspection revealed that the following ast was produced for the join table factor 

```
UNNEST { 
  alias: Some(TableAlias { name: Ident { value: "f", quote_style: None }, columns: [] }), 
  array_expr: CompoundIdentifier([Ident { value: "t1", quote_style: None }, Ident { value: "a", quote_style: None }]), 
  with_offset: false, 
  with_offset_alias: Some(Ident { value: "ON", quote_style: None }) 
}
```
As you can see, the `with_offset_alias` parses the `ON` keyword despite the `with_offset` being false.

To replicate this behaviour, I added a failing test that verifies this behaviour difference
```
thread 'parse_join_constraint_unnest' panicked at 'called `Result::unwrap()` on an `Err` value: ParserError("Expected end of statement, found: c1")', src/test_utils.rs:86:61
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test parse_join_constraint_unnest ... FAILED
```

This fix uses the boolean check to determine if the subsequent optional alias should be parsed.