### PR TITLE
Snowflake - allow the "type" key

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3818,7 +3818,7 @@ impl<'a> Parser<'a> {
                     )?,
                 },
                 // Case when Snowflake Semi-structured data like key:value
-                Keyword::NoKeyword | Keyword::LOCATION if dialect_of!(self is SnowflakeDialect | GenericDialect) => {
+                Keyword::NoKeyword | Keyword::LOCATION | Keyword::TYPE if dialect_of!(self is SnowflakeDialect | GenericDialect) => {
                     Ok(Value::UnQuotedString(w.value))
                 }
                 _ => self.expected(

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -169,6 +169,28 @@ fn parse_json_using_colon() {
         select.projection[0]
     );
 
+    let sql = "SELECT a:type FROM t";
+    let select = snowflake().verified_only_select(sql);
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::JsonAccess {
+            left: Box::new(Expr::Identifier(Ident::new("a"))),
+            operator: JsonOperator::Colon,
+            right: Box::new(Expr::Value(Value::UnQuotedString("type".to_string()))),
+        }),
+        select.projection[0]
+    );
+
+    let sql = "SELECT a:location FROM t";
+    let select = snowflake().verified_only_select(sql);
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::JsonAccess {
+            left: Box::new(Expr::Identifier(Ident::new("a"))),
+            operator: JsonOperator::Colon,
+            right: Box::new(Expr::Value(Value::UnQuotedString("location".to_string()))),
+        }),
+        select.projection[0]
+    );
+
     snowflake().one_statement_parses_to("SELECT a:b::int FROM t", "SELECT CAST(a:b AS INT) FROM t");
 }
 


### PR DESCRIPTION
In continue of [693](https://github.com/sqlparser-rs/sqlparser-rs/pull/693) , the parser parse key:value syntax of snowflake. this pr adds support when they key is "type".