### PR TITLE
Parse exponent literal as number

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -144,6 +144,7 @@ pub fn all_dialects() -> TestedDialects {
             Box::new(RedshiftSqlDialect {}),
             Box::new(MySqlDialect {}),
             Box::new(BigQueryDialect {}),
+            Box::new(SQLiteDialect {}),
         ],
     }
 }


### PR DESCRIPTION
Resolve part of https://github.com/sqlparser-rs/sqlparser-rs/issues/610

Allows parsing of exponent literals as numbers, provided the dialect does not allow an identifier to being with a number (Hive dialect). Will need more thinking on how to handle that specific case.