### PR TITLE
Support grouping sets parsing for `GenericDialect`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -763,7 +763,7 @@ impl<'a> Parser<'a> {
     /// parse a group by expr. a group by expr can be one of group sets, roll up, cube, or simple
     /// expr.
     fn parse_group_by_expr(&mut self) -> Result<Expr, ParserError> {
-        if dialect_of!(self is PostgreSqlDialect) {
+        if dialect_of!(self is PostgreSqlDialect | GenericDialect) {
             if self.parse_keywords(&[Keyword::GROUPING, Keyword::SETS]) {
                 self.expect_token(&Token::LParen)?;
                 let result = self.parse_comma_separated(|p| p.parse_tuple(false, true))?;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1462,7 +1462,7 @@ fn parse_select_group_by() {
 #[test]
 fn parse_select_group_by_grouping_sets() {
     let dialects = TestedDialects {
-        dialects: vec![Box::new(PostgreSqlDialect {})],
+        dialects: vec![Box::new(GenericDialect {}), Box::new(PostgreSqlDialect {})],
     };
     let sql =
         "SELECT brand, size, sum(sales) FROM items_sold GROUP BY size, GROUPING SETS ((brand), (size), ())";
@@ -1483,7 +1483,7 @@ fn parse_select_group_by_grouping_sets() {
 #[test]
 fn parse_select_group_by_rollup() {
     let dialects = TestedDialects {
-        dialects: vec![Box::new(PostgreSqlDialect {})],
+        dialects: vec![Box::new(GenericDialect {}), Box::new(PostgreSqlDialect {})],
     };
     let sql = "SELECT brand, size, sum(sales) FROM items_sold GROUP BY size, ROLLUP (brand, size)";
     let select = dialects.verified_only_select(sql);
@@ -1502,7 +1502,7 @@ fn parse_select_group_by_rollup() {
 #[test]
 fn parse_select_group_by_cube() {
     let dialects = TestedDialects {
-        dialects: vec![Box::new(PostgreSqlDialect {})],
+        dialects: vec![Box::new(GenericDialect {}), Box::new(PostgreSqlDialect {})],
     };
     let sql = "SELECT brand, size, sum(sales) FROM items_sold GROUP BY size, CUBE (brand, size)";
     let select = dialects.verified_only_select(sql);


### PR DESCRIPTION
Part of https://github.com/apache/arrow-datafusion/issues/2469

To allow GenericDialect to parse Grouping sets.

Note that will also now parse rollup & cube as their Expr enum variant now, instead of as Expr::Function