### PR TITLE
feat: dollar-quoted strings support

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -39,7 +39,9 @@ pub use self::query::{
     SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, Table, TableAlias, TableFactor,
     TableWithJoins, Top, Values, WildcardAdditionalOptions, With,
 };
-pub use self::value::{escape_quoted_string, DateTimeField, TrimWhereField, Value};
+pub use self::value::{
+    escape_quoted_string, DateTimeField, DollarQuotedString, TrimWhereField, Value,
+};
 
 #[cfg(feature = "visitor")]
 pub use visitor::*;

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -76,6 +76,7 @@ impl fmt::Display for Value {
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit))]
 pub struct DollarQuotedString {
     pub value: String,
     pub tag: Option<String>,

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -35,6 +35,8 @@ pub enum Value {
     Number(BigDecimal, bool),
     /// 'string value'
     SingleQuotedString(String),
+    // $<tag_name>$string value$<tag_name>$ (postgres syntax)
+    DollarQuotedString(DollarQuotedString),
     /// e'string value' (postgres extension)
     /// <https://www.postgresql.org/docs/8.3/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
     EscapedStringLiteral(String),
@@ -60,6 +62,7 @@ impl fmt::Display for Value {
             Value::Number(v, l) => write!(f, "{}{long}", v, long = if *l { "L" } else { "" }),
             Value::DoubleQuotedString(v) => write!(f, "\"{}\"", v),
             Value::SingleQuotedString(v) => write!(f, "'{}'", escape_single_quote_string(v)),
+            Value::DollarQuotedString(v) => write!(f, "{}", v),
             Value::EscapedStringLiteral(v) => write!(f, "E'{}'", escape_escaped_string(v)),
             Value::NationalStringLiteral(v) => write!(f, "N'{}'", v),
             Value::HexStringLiteral(v) => write!(f, "X'{}'", v),
@@ -67,6 +70,26 @@ impl fmt::Display for Value {
             Value::Null => write!(f, "NULL"),
             Value::Placeholder(v) => write!(f, "{}", v),
             Value::UnQuotedString(v) => write!(f, "{}", v),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DollarQuotedString {
+    pub value: String,
+    pub tag: Option<String>,
+}
+
+impl fmt::Display for DollarQuotedString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.tag {
+            Some(tag) => {
+                write!(f, "${}${}${}$", tag, self.value, tag)
+            }
+            None => {
+                write!(f, "$${}$$", self.value)
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ extern crate alloc;
 #[macro_use]
 #[cfg(test)]
 extern crate pretty_assertions;
+// extern crate core;
 
 pub mod ast;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,6 @@ extern crate alloc;
 #[macro_use]
 #[cfg(test)]
 extern crate pretty_assertions;
-// extern crate core;
 
 pub mod ast;
 #[macro_use]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -155,8 +155,6 @@ pub enum Token {
     PGCubeRoot,
     /// `?` or `$` , a prepared statement arg placeholder
     Placeholder(String),
-    // todo: remove
-    /// `$$`, used for PostgreSQL create function definition
     // DoubleDollarQuoting,
     /// ->, used as a operator to extract json field in PostgreSQL
     Arrow,
@@ -244,7 +242,6 @@ impl fmt::Display for Token {
             Token::HashArrow => write!(f, "#>"),
             Token::HashLongArrow => write!(f, "#>>"),
             Token::AtArrow => write!(f, "@>"),
-            // Token::DoubleDollarQuoting => write!(f, "$$"),
             Token::ArrowAt => write!(f, "<@"),
             Token::HashMinus => write!(f, "#-"),
             Token::AtQuestion => write!(f, "@?"),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -471,7 +471,6 @@ impl<'a> Tokenizer<'a> {
 
         let mut location = state.location();
         while let Some(token) = self.next_token(&mut state)? {
-            println!("{:?}", token);
             tokens.push(TokenWithLocation {
                 token,
                 location: location.clone(),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -34,6 +34,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "visitor")]
 use sqlparser_derive::Visit;
 
+#[cfg(feature = "visitor")]
+use sqlparser_derive::Visit;
+
+use crate::ast::DollarQuotedString;
 use crate::dialect::SnowflakeDialect;
 use crate::dialect::{Dialect, MySqlDialect};
 use crate::keywords::{Keyword, ALL_KEYWORDS, ALL_KEYWORDS_INDEX};
@@ -55,6 +59,8 @@ pub enum Token {
     SingleQuotedString(String),
     /// Double quoted string: i.e: "string"
     DoubleQuotedString(String),
+    /// Dollar quoted string: i.e: $$string$$ or $tag_name$string$tag_name$
+    DollarQuotedString(DollarQuotedString),
     /// "National" string literal: i.e: N'string'
     NationalStringLiteral(String),
     /// "escaped" string literal, which are an extension to the SQL standard: i.e: e'first \n second' or E 'first \n second'
@@ -149,8 +155,9 @@ pub enum Token {
     PGCubeRoot,
     /// `?` or `$` , a prepared statement arg placeholder
     Placeholder(String),
+    // todo: remove
     /// `$$`, used for PostgreSQL create function definition
-    DoubleDollarQuoting,
+    // DoubleDollarQuoting,
     /// ->, used as a operator to extract json field in PostgreSQL
     Arrow,
     /// ->>, used as a operator to extract json field as text in PostgreSQL
@@ -184,6 +191,7 @@ impl fmt::Display for Token {
             Token::Char(ref c) => write!(f, "{}", c),
             Token::SingleQuotedString(ref s) => write!(f, "'{}'", s),
             Token::DoubleQuotedString(ref s) => write!(f, "\"{}\"", s),
+            Token::DollarQuotedString(ref s) => write!(f, "{}", s),
             Token::NationalStringLiteral(ref s) => write!(f, "N'{}'", s),
             Token::EscapedStringLiteral(ref s) => write!(f, "E'{}'", s),
             Token::HexStringLiteral(ref s) => write!(f, "X'{}'", s),
@@ -236,7 +244,7 @@ impl fmt::Display for Token {
             Token::HashArrow => write!(f, "#>"),
             Token::HashLongArrow => write!(f, "#>>"),
             Token::AtArrow => write!(f, "@>"),
-            Token::DoubleDollarQuoting => write!(f, "$$"),
+            // Token::DoubleDollarQuoting => write!(f, "$$"),
             Token::ArrowAt => write!(f, "<@"),
             Token::HashMinus => write!(f, "#-"),
             Token::AtQuestion => write!(f, "@?"),
@@ -466,6 +474,7 @@ impl<'a> Tokenizer<'a> {
 
         let mut location = state.location();
         while let Some(token) = self.next_token(&mut state)? {
+            println!("{:?}", token);
             tokens.push(TokenWithLocation {
                 token,
                 location: location.clone(),
@@ -837,17 +846,8 @@ impl<'a> Tokenizer<'a> {
                     let s = peeking_take_while(chars, |ch| ch.is_numeric());
                     Ok(Some(Token::Placeholder(String::from("?") + &s)))
                 }
-                '$' => {
-                    chars.next();
-                    match chars.peek() {
-                        Some('$') => self.consume_and_return(chars, Token::DoubleDollarQuoting),
-                        _ => {
-                            let s =
-                                peeking_take_while(chars, |ch| ch.is_alphanumeric() || ch == '_');
-                            Ok(Some(Token::Placeholder(String::from("$") + &s)))
-                        }
-                    }
-                }
+                '$' => Ok(Some(self.tokenize_dollar_preceded_value(chars)?)),
+
                 //whitespace check (including unicode chars) should be last as it covers some of the chars above
                 ch if ch.is_whitespace() => {
                     self.consume_and_return(chars, Token::Whitespace(Whitespace::Space))
@@ -856,6 +856,79 @@ impl<'a> Tokenizer<'a> {
             },
             None => Ok(None),
         }
+    }
+
+    /// Tokenize dollar preceded value (i.e: a string/placeholder)
+    fn tokenize_dollar_preceded_value(&self, chars: &mut State) -> Result<Token, TokenizerError> {
+        let mut s = String::new();
+        let mut value = String::new();
+
+        chars.next();
+
+        if let Some('$') = chars.peek() {
+            chars.next();
+            s.push_str(&peeking_take_while(chars, |ch| ch != '$'));
+            chars.next();
+
+            return if let Some('$') = chars.peek() {
+                chars.next();
+                Ok(Token::DollarQuotedString(DollarQuotedString {
+                    value: s,
+                    tag: None,
+                }))
+            } else {
+                self.tokenizer_error(chars.location(), "Unterminated dollar-quoted string")
+            };
+        } else {
+            value.push_str(&peeking_take_while(chars, |ch| {
+                ch.is_alphanumeric() || ch == '_'
+            }));
+
+            if let Some('$') = chars.peek() {
+                chars.next();
+                s.push_str(&peeking_take_while(chars, |ch| ch != '$'));
+
+                match chars.peek() {
+                    Some('$') => {
+                        chars.next();
+                        for (_, c) in value.chars().enumerate() {
+                            let next_char = chars.next();
+                            if Some(c) != next_char {
+                                return self.tokenizer_error(
+                                    chars.location(),
+                                    format!(
+                                        "Unterminated dollar-quoted string, expected ${}$",
+                                        value
+                                    ),
+                                );
+                            }
+                        }
+
+                        if let Some('$') = chars.peek() {
+                            chars.next();
+                        } else {
+                            return self.tokenizer_error(
+                                chars.location(),
+                                "Unterminated dollar-quoted string, expected $",
+                            );
+                        }
+                    }
+                    _ => {
+                        return self.tokenizer_error(
+                            chars.location(),
+                            "Unterminated dollar-quoted, expected $",
+                        );
+                    }
+                }
+            } else {
+                return Ok(Token::Placeholder(String::from("$") + &value));
+            }
+        }
+
+        Ok(Token::DollarQuotedString(DollarQuotedString {
+            value: s,
+            tag: if value.is_empty() { None } else { Some(value) },
+        }))
     }
 
     fn tokenizer_error<R>(

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -34,9 +34,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "visitor")]
 use sqlparser_derive::Visit;
 
-#[cfg(feature = "visitor")]
-use sqlparser_derive::Visit;
-
 use crate::ast::DollarQuotedString;
 use crate::dialect::SnowflakeDialect;
 use crate::dialect::{Dialect, MySqlDialect};

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2534,7 +2534,7 @@ fn parse_dollar_quoted_string() {
 fn parse_incorrect_dollar_quoted_string() {
     let sql = "SELECT $x$hello$$";
     assert!(pg().parse_sql_statements(sql).is_err());
-    
+
     let sql = "SELECT $hello$$";
     assert!(pg().parse_sql_statements(sql).is_err());
 }


### PR DESCRIPTION
Previously, there was the `DoubleDollarQuoting` token, and it was used only in the context of functions. But technically, dollar-quoting is another way to present strings. 
e.g.

```sql
SELECT $$Hello, World!$$;
SELECT $tag_name$Hello, World!$tag_name$;
```

That's why I think it's reasonable to introduce the `DollarQuotedString` token, which can hold such string values and their optional tag names.

I have not added any tests yet but will do it if otherwise, it looks ok.

Closes #698