### PR TITLE
Add a backlink from `sqlparse_derive` to `sqlparser` and publishing instructions

### DIFF
--- a/derive/README.md
+++ b/derive/README.md
@@ -2,7 +2,8 @@
 
 ## Visit
 
-This crate contains a procedural macro that can automatically derive implementations of the `Visit` trait
+This crate contains a procedural macro that can automatically derive
+implementations of the `Visit` trait in the [sqlparser](https://crates.io/crates/sqlparser) crate
 
 ```rust
 #[derive(Visit)]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -31,7 +31,7 @@ $ cargo install cargo-release
     $ cargo release minor --push-remote upstream
     ```
 
-    After verifying, you can rerun with `--execute` if all looks good. 
+    After verifying, you can rerun with `--execute` if all looks good.
     You can add `--no-push` to stop before actually publishing the release.
 
     `cargo release` will then:
@@ -56,3 +56,14 @@ $ cargo install cargo-release
 4. Check that the new version of the crate is available on crates.io:
     https://crates.io/crates/sqlparser
 
+
+## `sqlparser_derive` crate
+
+Currently this crate is manually published via `cargo publish`.
+
+crates.io homepage: https://crates.io/crates/sqlparser_derive
+
+```shell
+cd derive
+cargo publish
+```


### PR DESCRIPTION
I have pre-published the sql_derive crate https://crates.io/crates/sqlparser_derive

I will also extend ownership invitations for crates.io to the existing owners of sqlparser-rs https://crates.io/crates/sqlparser

@maxcountryman @nickolay @andygrove @Dandandan 

