### PR TITLE
Propagate locations throughout the parser

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use sqlparser_derive::{Visit, VisitMut};
 
 use crate::ast::*;
+use crate::location::Located;
 
 /// The most complete variant of a `SELECT` query expression, optionally
 /// including `WITH`, `UNION` / other set operations, and `ORDER BY`.
@@ -283,7 +284,7 @@ pub struct LateralView {
     /// LATERAL VIEW table name
     pub lateral_view_name: ObjectName,
     /// LATERAL VIEW optional column aliases
-    pub lateral_col_alias: Vec<Ident>,
+    pub lateral_col_alias: Vec<Located<Ident>>,
     /// LATERAL VIEW OUTER
     pub outer: bool,
 }
@@ -337,7 +338,7 @@ impl fmt::Display for With {
 pub struct Cte {
     pub alias: TableAlias,
     pub query: Box<Query>,
-    pub from: Option<Ident>,
+    pub from: Option<Located<Ident>>,
 }
 
 impl fmt::Display for Cte {
@@ -358,7 +359,7 @@ pub enum SelectItem {
     /// Any expression, not followed by `[ AS ] alias`
     UnnamedExpr(Expr),
     /// An expression, followed by `[ AS ] alias`
-    ExprWithAlias { expr: Expr, alias: Ident },
+    ExprWithAlias { expr: Expr, alias: Located<Ident> },
     /// `alias.*` or even `schema.table.*`
     QualifiedWildcard(ObjectName, WildcardAdditionalOptions),
     /// An unqualified `*`
@@ -375,8 +376,8 @@ pub enum SelectItem {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct IdentWithAlias {
-    pub ident: Ident,
-    pub alias: Ident,
+    pub ident: Located<Ident>,
+    pub alias: Located<Ident>,
 }
 
 impl fmt::Display for IdentWithAlias {
@@ -430,13 +431,13 @@ pub enum ExcludeSelectItem {
     /// ```plaintext
     /// <col_name>
     /// ```
-    Single(Ident),
+    Single(Located<Ident>),
     /// Multiple column names inside parenthesis.
     /// # Syntax
     /// ```plaintext
     /// (<col_name>, <col_name>, ...)
     /// ```
-    Multiple(Vec<Ident>),
+    Multiple(Vec<Located<Ident>>),
 }
 
 impl fmt::Display for ExcludeSelectItem {
@@ -506,9 +507,9 @@ impl fmt::Display for RenameSelectItem {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct ExceptSelectItem {
     /// First guaranteed column.
-    pub first_element: Ident,
+    pub first_element: Located<Ident>,
     /// Additional columns. This list can be empty.
-    pub additional_elements: Vec<Ident>,
+    pub additional_elements: Vec<Located<Ident>>,
 }
 
 impl fmt::Display for ExceptSelectItem {
@@ -609,7 +610,7 @@ pub enum TableFactor {
         alias: Option<TableAlias>,
         array_expr: Box<Expr>,
         with_offset: bool,
-        with_offset_alias: Option<Ident>,
+        with_offset_alias: Option<Located<Ident>>,
     },
     /// Represents a parenthesized table factor. The SQL spec only allows a
     /// join expression (`(foo <JOIN> bar [ <JOIN> baz ... ])`) to be nested,
@@ -701,8 +702,8 @@ impl fmt::Display for TableFactor {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct TableAlias {
-    pub name: Ident,
-    pub columns: Vec<Ident>,
+    pub name: Located<Ident>,
+    pub columns: Vec<Located<Ident>>,
 }
 
 impl fmt::Display for TableAlias {
@@ -838,7 +839,7 @@ pub enum JoinOperator {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum JoinConstraint {
     On(Expr),
-    Using(Vec<Ident>),
+    Using(Vec<Located<Ident>>),
     Natural,
     None,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod ast;
 #[macro_use]
 pub mod dialect;
 pub mod keywords;
+pub mod location;
 pub mod parser;
 pub mod tokenizer;
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,0 +1,169 @@
+use core::cmp::Eq;
+use core::cmp::Ordering;
+use core::hash::{Hash, Hasher};
+use std::fmt;
+
+/// Location in input string
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Location {
+    /// Line number, starting from 1
+    pub line: u64,
+    /// Line column, starting from 1
+    pub column: u64,
+}
+
+impl Location {
+    pub fn valid(&self) -> bool {
+        self.line > 0 && self.column > 0
+    }
+}
+
+impl Ord for Location {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.line == other.line {
+            self.column.cmp(&other.column)
+        } else {
+            self.line.cmp(&other.line)
+        }
+    }
+}
+
+impl PartialOrd for Location {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Range {
+    pub start: Location,
+    pub end: Location,
+}
+
+impl Range {
+    pub fn valid(&self) -> bool {
+        self.start.valid() && self.end.valid()
+    }
+
+    pub fn into_option(self) -> Option<Range> {
+        if self.valid() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+}
+
+pub struct Located<T, L = Option<Range>> {
+    value: T,
+    location: L,
+}
+
+impl<T, L> Clone for Located<T, L>
+where
+    T: Clone,
+    L: Clone,
+{
+    fn clone(&self) -> Self {
+        Located {
+            value: self.value.clone(),
+            location: self.location.clone(),
+        }
+    }
+}
+
+impl<T, L> fmt::Debug for Located<T, L>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.value, f)
+    }
+}
+
+impl<T, L> fmt::Display for Located<T, L>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.value, f)
+    }
+}
+
+impl<T, L> Eq for Located<T, L>
+where
+    T: Eq,
+    L: Eq,
+{
+}
+
+impl<T, L> Hash for Located<T, L>
+where
+    T: Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+impl<T, L> PartialEq<Self> for Located<T, L>
+where
+    T: PartialEq,
+    L: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value) && self.location.eq(&other.location)
+    }
+}
+
+impl<T, L> Ord for Located<T, L>
+where
+    T: Ord,
+    L: Ord,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.value
+            .cmp(&other.value)
+            .then_with(|| self.location.cmp(&other.location))
+    }
+}
+
+impl<T, L> PartialOrd for Located<T, L>
+where
+    T: PartialOrd,
+    L: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.value.partial_cmp(&other.value) {
+            Some(Ordering::Equal) => self.location.partial_cmp(&other.location),
+            Some(o) => Some(o),
+            None => None,
+        }
+    }
+}
+
+impl<T, L> Located<T, L> {
+    pub fn new(value: T, location: L) -> Located<T, L> {
+        Located { value, location }
+    }
+
+    pub fn location(&self) -> &L {
+        &self.location
+    }
+
+    pub fn get(&self) -> &T {
+        &self.value
+    }
+
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+}
+
+impl<T, L> std::ops::Deref for Located<T, L> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -17,6 +17,7 @@ use test_utils::*;
 
 use sqlparser::ast::*;
 use sqlparser::dialect::{BigQueryDialect, GenericDialect};
+use sqlparser::location::Located;
 
 #[test]
 fn parse_literal_string() {
@@ -35,7 +36,7 @@ fn parse_literal_string() {
 
 #[test]
 fn parse_table_identifiers() {
-    fn test_table_ident(ident: &str, expected: Vec<Ident>) {
+    fn test_table_ident(ident: &str, expected: Vec<Located<Ident>>) {
         let sql = format!("SELECT 1 FROM {}", ident);
         let select = bigquery().verified_only_select(&sql);
         assert_eq!(

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -35,10 +35,7 @@ fn parse_map_access_expr() {
             distinct: false,
             top: None,
             projection: vec![UnnamedExpr(MapAccess {
-                column: Box::new(Identifier(Ident {
-                    value: "string_values".to_string(),
-                    quote_style: None,
-                })),
+                column: Box::new(Identifier(Ident::new("string_values".to_string()))),
                 keys: vec![Expr::Function(Function {
                     name: ObjectName(vec!["indexOf".into()]),
                     args: vec![

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -27,6 +27,7 @@ use sqlparser::dialect::{
     MySqlDialect, PostgreSqlDialect, RedshiftSqlDialect, SQLiteDialect, SnowflakeDialect,
 };
 use sqlparser::keywords::ALL_KEYWORDS;
+use sqlparser::location::Located;
 use sqlparser::parser::{Parser, ParserError};
 use test_utils::{
     all_dialects, assert_eq_vec, expr_from_projection, join, number, only, table, table_alias,
@@ -831,10 +832,7 @@ fn parse_select_with_date_column_name() {
     let sql = "SELECT date";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Identifier(Ident {
-            value: "date".into(),
-            quote_style: None,
-        }),
+        &Expr::Identifier(Ident::new("date")),
         expr_from_projection(only(&select.projection)),
     );
 }
@@ -1057,10 +1055,7 @@ fn parse_null_like() {
                 pattern: Box::new(Expr::Value(Value::Null)),
                 escape_char: None,
             },
-            alias: Ident {
-                value: "col_null".to_owned(),
-                quote_style: None,
-            },
+            alias: Ident::new("col_null"),
         },
         select.projection[0]
     );
@@ -1072,10 +1067,7 @@ fn parse_null_like() {
                 pattern: Box::new(Expr::Identifier(Ident::new("column1"))),
                 escape_char: None,
             },
-            alias: Ident {
-                value: "null_col".to_owned(),
-                quote_style: None,
-            },
+            alias: Ident::new("null_col"),
         },
         select.projection[1]
     );
@@ -1906,18 +1898,12 @@ fn parse_listagg() {
     });
     let within_group = vec![
         OrderByExpr {
-            expr: Expr::Identifier(Ident {
-                value: "id".to_string(),
-                quote_style: None,
-            }),
+            expr: Expr::Identifier(Ident::new("id")),
             asc: None,
             nulls_first: None,
         },
         OrderByExpr {
-            expr: Expr::Identifier(Ident {
-                value: "username".to_string(),
-                quote_style: None,
-            }),
+            expr: Expr::Identifier(Ident::new("username")),
             asc: None,
             nulls_first: None,
         },
@@ -3444,17 +3430,11 @@ fn parse_interval_and_or_xor() {
         body: Box::new(SetExpr::Select(Box::new(Select {
             distinct: false,
             top: None,
-            projection: vec![UnnamedExpr(Expr::Identifier(Ident {
-                value: "col".to_string(),
-                quote_style: None,
-            }))],
+            projection: vec![UnnamedExpr(Expr::Identifier(Ident::new("col")))],
             into: None,
             from: vec![TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec![Ident {
-                        value: "test".to_string(),
-                        quote_style: None,
-                    }]),
+                    name: ObjectName(vec![Ident::new("test")]),
                     alias: None,
                     args: None,
                     with_hints: vec![],
@@ -3464,16 +3444,10 @@ fn parse_interval_and_or_xor() {
             lateral_views: vec![],
             selection: Some(Expr::BinaryOp {
                 left: Box::new(Expr::BinaryOp {
-                    left: Box::new(Expr::Identifier(Ident {
-                        value: "d3_date".to_string(),
-                        quote_style: None,
-                    })),
+                    left: Box::new(Expr::Identifier(Ident::new("d3_date"))),
                     op: BinaryOperator::Gt,
                     right: Box::new(Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident {
-                            value: "d1_date".to_string(),
-                            quote_style: None,
-                        })),
+                        left: Box::new(Expr::Identifier(Ident::new("d1_date"))),
                         op: BinaryOperator::Plus,
                         right: Box::new(Expr::Interval {
                             value: Box::new(Expr::Value(Value::SingleQuotedString(
@@ -3488,16 +3462,10 @@ fn parse_interval_and_or_xor() {
                 }),
                 op: BinaryOperator::And,
                 right: Box::new(Expr::BinaryOp {
-                    left: Box::new(Expr::Identifier(Ident {
-                        value: "d2_date".to_string(),
-                        quote_style: None,
-                    })),
+                    left: Box::new(Expr::Identifier(Ident::new("d2_date"))),
                     op: BinaryOperator::Gt,
                     right: Box::new(Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident {
-                            value: "d1_date".to_string(),
-                            quote_style: None,
-                        })),
+                        left: Box::new(Expr::Identifier(Ident::new("d1_date"))),
                         op: BinaryOperator::Plus,
                         right: Box::new(Expr::Interval {
                             value: Box::new(Expr::Value(Value::SingleQuotedString(
@@ -3554,10 +3522,7 @@ fn parse_at_timezone() {
     assert_eq!(
         &Expr::AtTimeZone {
             timestamp: Box::new(Expr::Function(Function {
-                name: ObjectName(vec![Ident {
-                    value: "FROM_UNIXTIME".to_string(),
-                    quote_style: None,
-                }]),
+                name: ObjectName(vec![Ident::new("FROM_UNIXTIME")]),
                 args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(zero.clone()))],
                 over: None,
                 distinct: false,
@@ -3573,17 +3538,11 @@ fn parse_at_timezone() {
     assert_eq!(
         &SelectItem::ExprWithAlias {
             expr: Expr::Function(Function {
-                name: ObjectName(vec![Ident {
-                    value: "DATE_FORMAT".to_string(),
-                    quote_style: None,
-                },],),
+                name: ObjectName(vec![Ident::new("DATE_FORMAT")]),
                 args: vec![
                     FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::AtTimeZone {
                         timestamp: Box::new(Expr::Function(Function {
-                            name: ObjectName(vec![Ident {
-                                value: "FROM_UNIXTIME".to_string(),
-                                quote_style: None,
-                            },],),
+                            name: ObjectName(vec![Ident::new("FROM_UNIXTIME")]),
                             args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(zero))],
                             over: None,
                             distinct: false,
@@ -3599,10 +3558,7 @@ fn parse_at_timezone() {
                 distinct: false,
                 special: false,
             },),
-            alias: Ident {
-                value: "hour".to_string(),
-                quote_style: Some('"'),
-            },
+            alias: Ident::with_quote('"', "hour"),
         },
         only(&select.projection),
     );
@@ -4283,14 +4239,8 @@ fn parse_recursive_cte() {
     assert_eq!(with.cte_tables.len(), 1);
     let expected = Cte {
         alias: TableAlias {
-            name: Ident {
-                value: "nums".to_string(),
-                quote_style: None,
-            },
-            columns: vec![Ident {
-                value: "val".to_string(),
-                quote_style: None,
-            }],
+            name: Ident::new("nums"),
+            columns: vec![Ident::new("val")],
         },
         query: Box::new(cte_query),
         from: None,
@@ -4608,7 +4558,7 @@ fn parse_create_view() {
             cluster_by,
         } => {
             assert_eq!("myschema.myview", name.to_string());
-            assert_eq!(Vec::<Ident>::new(), columns);
+            assert_eq!(Vec::<Located<Ident>>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
             assert!(!materialized);
             assert!(!or_replace);
@@ -4735,7 +4685,7 @@ fn parse_create_materialized_view() {
             cluster_by,
         } => {
             assert_eq!("myschema.myview", name.to_string());
-            assert_eq!(Vec::<Ident>::new(), columns);
+            assert_eq!(Vec::<Located<Ident>>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
             assert!(materialized);
             assert_eq!(with_options, vec![]);
@@ -4760,7 +4710,7 @@ fn parse_create_materialized_view_with_cluster_by() {
             cluster_by,
         } => {
             assert_eq!("myschema.myview", name.to_string());
-            assert_eq!(Vec::<Ident>::new(), columns);
+            assert_eq!(Vec::<Located<Ident>>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
             assert!(materialized);
             assert_eq!(with_options, vec![]);
@@ -5445,16 +5395,7 @@ fn parse_grant() {
                         Action::Select { columns: None },
                         Action::Insert { columns: None },
                         Action::Update {
-                            columns: Some(vec![
-                                Ident {
-                                    value: "shape".into(),
-                                    quote_style: None,
-                                },
-                                Ident {
-                                    value: "size".into(),
-                                    quote_style: None,
-                                },
-                            ])
+                            columns: Some(vec![Ident::new("shape"), Ident::new("size"),])
                         },
                         Action::Usage,
                         Action::Delete,
@@ -5673,10 +5614,7 @@ fn parse_merge() {
                         locks: vec![],
                     }),
                     alias: Some(TableAlias {
-                        name: Ident {
-                            value: "stg".to_string(),
-                            quote_style: None,
-                        },
+                        name: Ident::new("stg"),
                         columns: vec![],
                     }),
                 }
@@ -5818,13 +5756,7 @@ fn test_lock_table() {
     assert_eq!(ast.locks.len(), 1);
     let lock = ast.locks.pop().unwrap();
     assert_eq!(lock.lock_type, LockType::Update);
-    assert_eq!(
-        lock.of.unwrap().0,
-        vec![Ident {
-            value: "school".to_string(),
-            quote_style: None
-        }]
-    );
+    assert_eq!(lock.of.unwrap().0, vec![Ident::new("school")]);
     assert!(lock.nonblock.is_none());
 
     let sql = "SELECT * FROM student WHERE id = '1' FOR SHARE OF school";
@@ -5832,13 +5764,7 @@ fn test_lock_table() {
     assert_eq!(ast.locks.len(), 1);
     let lock = ast.locks.pop().unwrap();
     assert_eq!(lock.lock_type, LockType::Share);
-    assert_eq!(
-        lock.of.unwrap().0,
-        vec![Ident {
-            value: "school".to_string(),
-            quote_style: None
-        }]
-    );
+    assert_eq!(lock.of.unwrap().0, vec![Ident::new("school")]);
     assert!(lock.nonblock.is_none());
 
     let sql = "SELECT * FROM student WHERE id = '1' FOR SHARE OF school FOR UPDATE OF student";
@@ -5846,23 +5772,11 @@ fn test_lock_table() {
     assert_eq!(ast.locks.len(), 2);
     let lock = ast.locks.remove(0);
     assert_eq!(lock.lock_type, LockType::Share);
-    assert_eq!(
-        lock.of.unwrap().0,
-        vec![Ident {
-            value: "school".to_string(),
-            quote_style: None
-        }]
-    );
+    assert_eq!(lock.of.unwrap().0, vec![Ident::new("school")]);
     assert!(lock.nonblock.is_none());
     let lock = ast.locks.remove(0);
     assert_eq!(lock.lock_type, LockType::Update);
-    assert_eq!(
-        lock.of.unwrap().0,
-        vec![Ident {
-            value: "student".to_string(),
-            quote_style: None
-        }]
-    );
+    assert_eq!(lock.of.unwrap().0, vec![Ident::new("student")]);
     assert!(lock.nonblock.is_none());
 }
 
@@ -5873,13 +5787,7 @@ fn test_lock_nonblock() {
     assert_eq!(ast.locks.len(), 1);
     let lock = ast.locks.pop().unwrap();
     assert_eq!(lock.lock_type, LockType::Update);
-    assert_eq!(
-        lock.of.unwrap().0,
-        vec![Ident {
-            value: "school".to_string(),
-            quote_style: None
-        }]
-    );
+    assert_eq!(lock.of.unwrap().0, vec![Ident::new("school")]);
     assert_eq!(lock.nonblock.unwrap(), NonBlock::SkipLocked);
 
     let sql = "SELECT * FROM student WHERE id = '1' FOR SHARE OF school NOWAIT";
@@ -5887,13 +5795,7 @@ fn test_lock_nonblock() {
     assert_eq!(ast.locks.len(), 1);
     let lock = ast.locks.pop().unwrap();
     assert_eq!(lock.lock_type, LockType::Share);
-    assert_eq!(
-        lock.of.unwrap().0,
-        vec![Ident {
-            value: "school".to_string(),
-            quote_style: None
-        }]
-    );
+    assert_eq!(lock.of.unwrap().0, vec![Ident::new("school")]);
     assert_eq!(lock.nonblock.unwrap(), NonBlock::Nowait);
 }
 

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -130,10 +130,7 @@ fn parse_mssql_create_role() {
             assert_eq_vec(&["mssql"], &names);
             assert_eq!(
                 authorization_owner,
-                Some(ObjectName(vec![Ident {
-                    value: "helena".into(),
-                    quote_style: None
-                }]))
+                Some(ObjectName(vec![Ident::new("helena")])),
             );
         }
         _ => unreachable!(),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -447,10 +447,9 @@ fn parse_quote_identifiers_2() {
             body: Box::new(SetExpr::Select(Box::new(Select {
                 distinct: false,
                 top: None,
-                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-                    value: "quoted ` identifier".into(),
-                    quote_style: Some('`'),
-                }))],
+                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(
+                    Ident::with_quote('`', "quoted ` identifier")
+                ))],
                 into: None,
                 from: vec![],
                 lateral_views: vec![],
@@ -481,10 +480,9 @@ fn parse_quote_identifiers_3() {
             body: Box::new(SetExpr::Select(Box::new(Select {
                 distinct: false,
                 top: None,
-                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-                    value: "`quoted identifier`".into(),
-                    quote_style: Some('`'),
-                }))],
+                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(
+                    Ident::with_quote('`', "`quoted identifier`")
+                ))],
                 into: None,
                 from: vec![],
                 lateral_views: vec![],
@@ -979,10 +977,7 @@ fn parse_substring_in_select() {
                         distinct: true,
                         top: None,
                         projection: vec![SelectItem::UnnamedExpr(Expr::Substring {
-                            expr: Box::new(Expr::Identifier(Ident {
-                                value: "description".to_string(),
-                                quote_style: None
-                            })),
+                            expr: Box::new(Expr::Identifier(Ident::new("description"))),
                             substring_from: Some(Box::new(Expr::Value(Value::Number(
                                 "0".to_string(),
                                 false
@@ -995,10 +990,7 @@ fn parse_substring_in_select() {
                         into: None,
                         from: vec![TableWithJoins {
                             relation: TableFactor::Table {
-                                name: ObjectName(vec![Ident {
-                                    value: "test".to_string(),
-                                    quote_style: None
-                                }]),
+                                name: ObjectName(vec![Ident::new("test")]),
                                 alias: None,
                                 args: None,
                                 with_hints: vec![]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -790,10 +790,7 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variable: ObjectName(vec![Ident::new("a")]),
-            value: vec![Expr::Identifier(Ident {
-                value: "b".into(),
-                quote_style: None
-            })],
+            value: vec![Expr::Identifier(Ident::new("b"))],
         }
     );
 
@@ -832,10 +829,7 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variable: ObjectName(vec![Ident::new("a")]),
-            value: vec![Expr::Identifier(Ident {
-                value: "DEFAULT".into(),
-                quote_style: None
-            })],
+            value: vec![Expr::Identifier(Ident::new("DEFAULT"))],
         }
     );
 
@@ -857,10 +851,7 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variable: ObjectName(vec![Ident::new("a"), Ident::new("b"), Ident::new("c")]),
-            value: vec![Expr::Identifier(Ident {
-                value: "b".into(),
-                quote_style: None
-            })],
+            value: vec![Expr::Identifier(Ident::new("b"))],
         }
     );
 
@@ -928,10 +919,7 @@ fn parse_set_role() {
         stmt,
         Statement::SetRole {
             context_modifier: ContextModifier::Local,
-            role_name: Some(Ident {
-                value: "rolename".to_string(),
-                quote_style: Some('\"'),
-            }),
+            role_name: Some(Ident::with_quote('\"', "rolename".to_string())),
         }
     );
     assert_eq!(query, stmt.to_string());
@@ -942,10 +930,7 @@ fn parse_set_role() {
         stmt,
         Statement::SetRole {
             context_modifier: ContextModifier::None,
-            role_name: Some(Ident {
-                value: "rolename".to_string(),
-                quote_style: Some('\''),
-            }),
+            role_name: Some(Ident::with_quote('\'', "rolename".to_string())),
         }
     );
     assert_eq!(query, stmt.to_string());
@@ -1117,7 +1102,7 @@ fn parse_pg_on_conflict() {
                 })),
             ..
         } => {
-            assert_eq!(vec![Ident::from("did")], cols);
+            assert_eq!(vec![Located::<Ident>::from("did")], cols);
             assert_eq!(
                 OnConflictAction::DoUpdate(DoUpdate {
                     assignments: vec![Assignment {
@@ -1147,7 +1132,13 @@ fn parse_pg_on_conflict() {
                 })),
             ..
         } => {
-            assert_eq!(vec![Ident::from("did"), Ident::from("area"),], cols);
+            assert_eq!(
+                vec![
+                    Located::<Ident>::from("did"),
+                    Located::<Ident>::from("area"),
+                ],
+                cols
+            );
             assert_eq!(
                 OnConflictAction::DoUpdate(DoUpdate {
                     assignments: vec![
@@ -1205,7 +1196,7 @@ fn parse_pg_on_conflict() {
                 })),
             ..
         } => {
-            assert_eq!(vec![Ident::from("did")], cols);
+            assert_eq!(vec![Located::<Ident>::from("did")], cols);
             assert_eq!(
                 OnConflictAction::DoUpdate(DoUpdate {
                     assignments: vec![Assignment {
@@ -1213,10 +1204,7 @@ fn parse_pg_on_conflict() {
                         value: Expr::Value(Value::Placeholder("$1".to_string()))
                     },],
                     selection: Some(Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident {
-                            value: "dsize".to_string(),
-                            quote_style: None
-                        })),
+                        left: Box::new(Expr::Identifier(Ident::new("dsize".to_string()))),
                         op: BinaryOperator::Gt,
                         right: Box::new(Expr::Value(Value::Placeholder("$2".to_string())))
                     })
@@ -1242,7 +1230,10 @@ fn parse_pg_on_conflict() {
                 })),
             ..
         } => {
-            assert_eq!(vec![Ident::from("distributors_did_pkey")], cname.0);
+            assert_eq!(
+                vec![Located::<Ident>::from("distributors_did_pkey")],
+                cname.0
+            );
             assert_eq!(
                 OnConflictAction::DoUpdate(DoUpdate {
                     assignments: vec![Assignment {
@@ -1250,10 +1241,7 @@ fn parse_pg_on_conflict() {
                         value: Expr::Value(Value::Placeholder("$1".to_string()))
                     },],
                     selection: Some(Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident {
-                            value: "dsize".to_string(),
-                            quote_style: None
-                        })),
+                        left: Box::new(Expr::Identifier(Ident::new("dsize".to_string()))),
                         op: BinaryOperator::Gt,
                         right: Box::new(Expr::Value(Value::Placeholder("$2".to_string())))
                     })
@@ -1443,14 +1431,8 @@ fn parse_array_index_expr() {
             obj: Box::new(Expr::Identifier(Ident::new("bar"))),
             indexes: vec![
                 num[0].clone(),
-                Expr::Identifier(Ident {
-                    value: "baz".to_string(),
-                    quote_style: Some('"')
-                }),
-                Expr::Identifier(Ident {
-                    value: "fooz".to_string(),
-                    quote_style: Some('"')
-                })
+                Expr::Identifier(Ident::with_quote('"', "baz".to_string())),
+                Expr::Identifier(Ident::with_quote('"', "fooz".to_string())),
             ],
         },
         expr_from_projection(only(&select.projection)),
@@ -1684,7 +1666,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::from("info"))),
+            left: Box::new(Expr::Identifier(Located::<Ident>::from("info"))),
             operator: JsonOperator::HashMinus,
             right: Box::new(Expr::Array(Array {
                 elem: vec![
@@ -1701,7 +1683,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::from("info"))),
+            left: Box::new(Expr::Identifier(Located::<Ident>::from("info"))),
             operator: JsonOperator::AtQuestion,
             right: Box::new(Expr::Value(Value::SingleQuotedString("$.a".to_string())),),
         },
@@ -1712,7 +1694,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::from("info"))),
+            left: Box::new(Expr::Identifier(Located::<Ident>::from("info"))),
             operator: JsonOperator::AtAt,
             right: Box::new(Expr::Value(Value::SingleQuotedString("$.a".to_string())),),
         },
@@ -1996,10 +1978,7 @@ fn parse_custom_operator() {
     assert_eq!(
         select.selection,
         Some(Expr::BinaryOp {
-            left: Box::new(Expr::Identifier(Ident {
-                value: "relname".into(),
-                quote_style: None,
-            })),
+            left: Box::new(Expr::Identifier(Ident::new("relname"))),
             op: BinaryOperator::PGCustomBinaryOperator(vec![
                 "database".into(),
                 "pg_catalog".into(),
@@ -2015,10 +1994,7 @@ fn parse_custom_operator() {
     assert_eq!(
         select.selection,
         Some(Expr::BinaryOp {
-            left: Box::new(Expr::Identifier(Ident {
-                value: "relname".into(),
-                quote_style: None,
-            })),
+            left: Box::new(Expr::Identifier(Ident::new("relname"))),
             op: BinaryOperator::PGCustomBinaryOperator(vec!["pg_catalog".into(), "~".into()]),
             right: Box::new(Expr::Value(Value::SingleQuotedString("^(table)$".into())))
         })
@@ -2030,10 +2006,7 @@ fn parse_custom_operator() {
     assert_eq!(
         select.selection,
         Some(Expr::BinaryOp {
-            left: Box::new(Expr::Identifier(Ident {
-                value: "relname".into(),
-                quote_style: None,
-            })),
+            left: Box::new(Expr::Identifier(Ident::new("relname"))),
             op: BinaryOperator::PGCustomBinaryOperator(vec!["~".into()]),
             right: Box::new(Expr::Value(Value::SingleQuotedString("^(table)$".into())))
         })
@@ -2426,10 +2399,7 @@ fn parse_drop_function() {
         Statement::DropFunction {
             if_exists: true,
             func_desc: vec![DropFunctionDesc {
-                name: ObjectName(vec![Ident {
-                    value: "test_func".to_string(),
-                    quote_style: None
-                }]),
+                name: ObjectName(vec![Ident::new("test_func".to_string())]),
                 args: None
             }],
             option: None
@@ -2442,10 +2412,7 @@ fn parse_drop_function() {
         Statement::DropFunction {
             if_exists: true,
             func_desc: vec![DropFunctionDesc {
-                name: ObjectName(vec![Ident {
-                    value: "test_func".to_string(),
-                    quote_style: None
-                }]),
+                name: ObjectName(vec![Ident::new("test_func".to_string())]),
                 args: Some(vec![
                     OperateFunctionArg::with_name("a", DataType::Integer(None)),
                     OperateFunctionArg {
@@ -2467,10 +2434,7 @@ fn parse_drop_function() {
             if_exists: true,
             func_desc: vec![
                 DropFunctionDesc {
-                    name: ObjectName(vec![Ident {
-                        value: "test_func1".to_string(),
-                        quote_style: None
-                    }]),
+                    name: ObjectName(vec![Ident::new("test_func1".to_string())]),
                     args: Some(vec![
                         OperateFunctionArg::with_name("a", DataType::Integer(None)),
                         OperateFunctionArg {
@@ -2485,10 +2449,7 @@ fn parse_drop_function() {
                     ]),
                 },
                 DropFunctionDesc {
-                    name: ObjectName(vec![Ident {
-                        value: "test_func2".to_string(),
-                        quote_style: None
-                    }]),
+                    name: ObjectName(vec![Ident::new("test_func2")]),
                     args: Some(vec![
                         OperateFunctionArg::with_name("a", DataType::Varchar(None)),
                         OperateFunctionArg {
@@ -2553,10 +2514,7 @@ fn parse_dollar_quoted_string() {
                 tag: None,
                 value: "Foo$Bar".into(),
             })),
-            alias: Ident {
-                value: "col_name".into(),
-                quote_style: None,
-            },
+            alias: Ident::new("col_name".to_string()),
         }
     );
 

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -23,24 +23,15 @@ fn test_square_brackets_over_db_schema_table_name() {
     let select = redshift().verified_only_select("SELECT [col1] FROM [test_schema].[test_table]");
     assert_eq!(
         select.projection[0],
-        SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-            value: "col1".to_string(),
-            quote_style: Some('[')
-        })),
+        SelectItem::UnnamedExpr(Expr::Identifier(Ident::with_quote('[', "col1"))),
     );
     assert_eq!(
         select.from[0],
         TableWithJoins {
             relation: TableFactor::Table {
                 name: ObjectName(vec![
-                    Ident {
-                        value: "test_schema".to_string(),
-                        quote_style: Some('[')
-                    },
-                    Ident {
-                        value: "test_table".to_string(),
-                        quote_style: Some('[')
-                    }
+                    Ident::with_quote('[', "test_schema"),
+                    Ident::with_quote('[', "test_table"),
                 ]),
                 alias: None,
                 args: None,
@@ -67,24 +58,15 @@ fn test_double_quotes_over_db_schema_table_name() {
         redshift().verified_only_select("SELECT \"col1\" FROM \"test_schema\".\"test_table\"");
     assert_eq!(
         select.projection[0],
-        SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-            value: "col1".to_string(),
-            quote_style: Some('"')
-        })),
+        SelectItem::UnnamedExpr(Expr::Identifier(Ident::with_quote('"', "col1"))),
     );
     assert_eq!(
         select.from[0],
         TableWithJoins {
             relation: TableFactor::Table {
                 name: ObjectName(vec![
-                    Ident {
-                        value: "test_schema".to_string(),
-                        quote_style: Some('"')
-                    },
-                    Ident {
-                        value: "test_table".to_string(),
-                        quote_style: Some('"')
-                    }
+                    Ident::with_quote('"', "test_schema"),
+                    Ident::with_quote('"', "test_table"),
                 ]),
                 alias: None,
                 args: None,


### PR DESCRIPTION
This diff propagates location information throughout identifiers in the parser, and includes the machinery (namely, the `Located` struct) that should make it straightforward to do so for other types.

CC @alamb 