### PR TITLE
fix: handle bigquery offset in map key

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4183,7 +4183,14 @@ impl<'a> Parser<'a> {
     pub fn parse_map_key(&mut self) -> Result<Expr, ParserError> {
         let next_token = self.next_token();
         match next_token.token {
-            Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => {
+            // handle bigquery offset()
+            Token::Word(Word { value, keyword, .. })
+                if (dialect_of!(self is BigQueryDialect | GenericDialect)
+                    && keyword == Keyword::OFFSET) =>
+            {
+                return self.parse_function(ObjectName(vec![Ident::new(value)]));
+            }
+            Token::Word(Word { value, keyword, .. }) if (keyword == Keyword::NoKeyword) => {
                 if self.peek_token() == Token::LParen {
                     return self.parse_function(ObjectName(vec![Ident::new(value)]));
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4187,7 +4187,7 @@ impl<'a> Parser<'a> {
             Token::Word(Word { value, keyword, .. })
                 if (dialect_of!(self is BigQueryDialect) && keyword == Keyword::OFFSET) =>
             {
-                return self.parse_function(ObjectName(vec![Ident::new(value)]));
+                self.parse_function(ObjectName(vec![Ident::new(value)]))
             }
             Token::Word(Word { value, keyword, .. }) if (keyword == Keyword::NoKeyword) => {
                 if self.peek_token() == Token::LParen {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4183,10 +4183,9 @@ impl<'a> Parser<'a> {
     pub fn parse_map_key(&mut self) -> Result<Expr, ParserError> {
         let next_token = self.next_token();
         match next_token.token {
-            // handle bigquery offset()
+            // handle bigquery offset subscript operator which overlaps with OFFSET operator
             Token::Word(Word { value, keyword, .. })
-                if (dialect_of!(self is BigQueryDialect | GenericDialect)
-                    && keyword == Keyword::OFFSET) =>
+                if (dialect_of!(self is BigQueryDialect) && keyword == Keyword::OFFSET) =>
             {
                 return self.parse_function(ObjectName(vec![Ident::new(value)]));
             }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -330,5 +330,14 @@ fn parse_map_access_offset() {
                 special: false,
             })],
         })
-    )
+    );
+
+    // test other operators
+    for sql in [
+        "SELECT d[SAFE_OFFSET(0)]",
+        "SELECT d[ORDINAL(0)]",
+        "SELECT d[SAFE_ORDINAL(0)]",
+    ] {
+        bigquery().verified_only_select(sql);
+    }
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -13,12 +13,9 @@
 #[macro_use]
 mod test_utils;
 
-use test_utils::*;
-
-use sqlparser::ast::Expr::{Identifier, MapAccess};
-use sqlparser::ast::SelectItem::UnnamedExpr;
 use sqlparser::ast::*;
 use sqlparser::dialect::{BigQueryDialect, GenericDialect};
+use test_utils::*;
 
 #[test]
 fn parse_literal_string() {
@@ -312,18 +309,19 @@ fn bigquery_and_generic() -> TestedDialects {
 #[test]
 fn parse_map_access_offset() {
     let sql = "SELECT d[offset(0)]";
-    let select = bigquery().verified_only_select(sql);
+    let _select = bigquery().verified_only_select(sql);
+    #[cfg(not(feature = "bigdecimal"))]
     assert_eq!(
-        select.projection[0],
-        UnnamedExpr(MapAccess {
-            column: Box::new(Identifier(Ident {
+        _select.projection[0],
+        SelectItem::UnnamedExpr(Expr::MapAccess {
+            column: Box::new(Expr::Identifier(Ident {
                 value: "d".to_string(),
                 quote_style: None,
             })),
             keys: vec![Expr::Function(Function {
                 name: ObjectName(vec!["offset".into()]),
                 args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
-                    Value::Number("0".to_string(), false)
+                    Value::Number("0".into(), false)
                 ))),],
                 over: None,
                 distinct: false,


### PR DESCRIPTION
This PR adds in handling of the [array subscript operator](https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#array_subscript_operator)
