### PR TITLE
feat: `SELECT * REPLACE <Expr> AS <Identifier>` for bigquery

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -36,8 +36,9 @@ pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, ExceptSelectItem, ExcludeSelectItem, Fetch, IdentWithAlias, Join, JoinConstraint,
     JoinOperator, LateralView, LockClause, LockType, NonBlock, Offset, OffsetRows, OrderByExpr,
-    Query, RenameSelectItem, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier,
-    Table, TableAlias, TableFactor, TableWithJoins, Top, Values, WildcardAdditionalOptions, With,
+    Query, RenameSelectItem, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr,
+    SetOperator, SetQuantifier, Table, TableAlias, TableFactor, TableWithJoins, Top, Values,
+    WildcardAdditionalOptions, With,
 };
 pub use self::value::{
     escape_quoted_string, DateTimeField, DollarQuotedString, TrimWhereField, Value,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -36,7 +36,7 @@ pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, ExceptSelectItem, ExcludeSelectItem, Fetch, IdentWithAlias, Join, JoinConstraint,
     JoinOperator, LateralView, LockClause, LockType, NonBlock, Offset, OffsetRows, OrderByExpr,
-    Query, RenameSelectItem, Select, SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier,
+    Query, RenameSelectItem, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier,
     Table, TableAlias, TableFactor, TableWithJoins, Top, Values, WildcardAdditionalOptions, With,
 };
 pub use self::value::{

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -36,9 +36,9 @@ pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, ExceptSelectItem, ExcludeSelectItem, Fetch, IdentWithAlias, Join, JoinConstraint,
     JoinOperator, LateralView, LockClause, LockType, NonBlock, Offset, OffsetRows, OrderByExpr,
-    Query, RenameSelectItem, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr,
-    SetOperator, SetQuantifier, Table, TableAlias, TableFactor, TableWithJoins, Top, Values,
-    WildcardAdditionalOptions, With,
+    Query, RenameSelectItem, ReplaceSelectElement, ReplaceSelectItem, Select, SelectInto,
+    SelectItem, SetExpr, SetOperator, SetQuantifier, Table, TableAlias, TableFactor,
+    TableWithJoins, Top, Values, WildcardAdditionalOptions, With,
 };
 pub use self::value::{
     escape_quoted_string, DateTimeField, DollarQuotedString, TrimWhereField, Value,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -395,7 +395,7 @@ pub struct WildcardAdditionalOptions {
     /// `[RENAME ...]`.
     pub opt_rename: Option<RenameSelectItem>,
     /// `[REPLACE]`
-    pub opt_replace:Option<ReplaceSelectItem>
+    pub opt_replace: Option<ReplaceSelectItem>,
 }
 
 impl fmt::Display for WildcardAdditionalOptions {
@@ -408,6 +408,9 @@ impl fmt::Display for WildcardAdditionalOptions {
         }
         if let Some(rename) = &self.opt_rename {
             write!(f, " {rename}")?;
+        }
+        if let Some(replace) = &self.opt_replace {
+            write!(f, " {replace}")?;
         }
         Ok(())
     }
@@ -544,13 +547,13 @@ pub enum ReplaceSelectItem {
     /// ```plaintext
     /// <col_name> AS <col_alias>
     /// ```
-    Single(IdentWithAlias),
+    Single(Box<SelectItem>),
     /// Multiple column names with aliases inside parenthesis.
     /// # Syntax
     /// ```plaintext
     /// (<col_name> AS <col_alias>, <col_name> AS <col_alias>, ...)
     /// ```
-    Multiple(Vec<IdentWithAlias>),
+    Multiple(Vec<Box<SelectItem>>),
 }
 
 impl fmt::Display for ReplaceSelectItem {

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -394,6 +394,8 @@ pub struct WildcardAdditionalOptions {
     pub opt_except: Option<ExceptSelectItem>,
     /// `[RENAME ...]`.
     pub opt_rename: Option<RenameSelectItem>,
+    /// `[REPLACE]`
+    pub opt_replace:Option<ReplaceSelectItem>
 }
 
 impl fmt::Display for WildcardAdditionalOptions {
@@ -521,6 +523,46 @@ impl fmt::Display for ExceptSelectItem {
                 self.first_element,
                 display_comma_separated(&self.additional_elements)
             )?;
+        }
+        Ok(())
+    }
+}
+
+/// Bigquery `REPLACE` information.
+///
+/// # Syntax
+/// ```plaintext
+/// REPLACE <new_expr> AS <col_name>
+/// ```
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum ReplaceSelectItem {
+    /// Single column name with alias without parenthesis.
+    ///
+    /// # Syntax
+    /// ```plaintext
+    /// <col_name> AS <col_alias>
+    /// ```
+    Single(IdentWithAlias),
+    /// Multiple column names with aliases inside parenthesis.
+    /// # Syntax
+    /// ```plaintext
+    /// (<col_name> AS <col_alias>, <col_name> AS <col_alias>, ...)
+    /// ```
+    Multiple(Vec<IdentWithAlias>),
+}
+
+impl fmt::Display for ReplaceSelectItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "REPLACE")?;
+        match self {
+            Self::Single(column) => {
+                write!(f, " {column}")?;
+            }
+            Self::Multiple(columns) => {
+                write!(f, " ({})", display_comma_separated(columns))?;
+            }
         }
         Ok(())
     }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -540,33 +540,21 @@ impl fmt::Display for ExceptSelectItem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
-pub enum ReplaceSelectItem {
-    /// Single column name with alias without parenthesis.
-    ///
+pub struct ReplaceSelectItem {
     /// # Syntax
     /// ```plaintext
-    /// <col_name> [AS] <col_alias>
+    /// (<col_name> [AS] <col_alias>)
     /// ```
-    Single(Box<ReplaceSelectElement>),
-    /// Multiple column names with aliases inside parenthesis.
-    /// # Syntax
     /// ```plaintext
     /// (<col_name> [AS] <col_alias>, <col_name> [AS] <col_alias>, ...)
     /// ```
-    Multiple(Vec<Box<ReplaceSelectElement>>),
+    pub items: Vec<Box<ReplaceSelectElement>>,
 }
 
 impl fmt::Display for ReplaceSelectItem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "REPLACE")?;
-        match self {
-            Self::Single(column) => {
-                write!(f, " {column}")?;
-            }
-            Self::Multiple(columns) => {
-                write!(f, " ({})", display_comma_separated(columns))?;
-            }
-        }
+        write!(f, " ({})", display_comma_separated(&self.items))?;
         Ok(())
     }
 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -395,6 +395,7 @@ pub struct WildcardAdditionalOptions {
     /// `[RENAME ...]`.
     pub opt_rename: Option<RenameSelectItem>,
     /// `[REPLACE]`
+    ///  BigQuery syntax: <https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace>
     pub opt_replace: Option<ReplaceSelectItem>,
 }
 

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -535,19 +535,13 @@ impl fmt::Display for ExceptSelectItem {
 ///
 /// # Syntax
 /// ```plaintext
-/// REPLACE <new_expr> [AS] <col_name>
+/// REPLACE (<new_expr> [AS] <col_name>)
+/// REPLACE (<col_name> [AS] <col_alias>, <col_name> [AS] <col_alias>, ...)
 /// ```
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct ReplaceSelectItem {
-    /// # Syntax
-    /// ```plaintext
-    /// (<col_name> [AS] <col_alias>)
-    /// ```
-    /// ```plaintext
-    /// (<col_name> [AS] <col_alias>, <col_name> [AS] <col_alias>, ...)
-    /// ```
     pub items: Vec<Box<ReplaceSelectElement>>,
 }
 
@@ -564,6 +558,8 @@ impl fmt::Display for ReplaceSelectItem {
 /// <expr> [AS] <column_name>
 /// ```
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct ReplaceSelectElement {
     pub expr: Expr,
     pub colum_name: Ident,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -535,7 +535,7 @@ impl fmt::Display for ExceptSelectItem {
 ///
 /// # Syntax
 /// ```plaintext
-/// REPLACE <new_expr> AS <col_name>
+/// REPLACE <new_expr> [AS] <col_name>
 /// ```
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -545,15 +545,15 @@ pub enum ReplaceSelectItem {
     ///
     /// # Syntax
     /// ```plaintext
-    /// <col_name> AS <col_alias>
+    /// <col_name> [AS] <col_alias>
     /// ```
-    Single(Box<SelectItem>),
+    Single(Box<ReplaceSelectElement>),
     /// Multiple column names with aliases inside parenthesis.
     /// # Syntax
     /// ```plaintext
-    /// (<col_name> AS <col_alias>, <col_name> AS <col_alias>, ...)
+    /// (<col_name> [AS] <col_alias>, <col_name> [AS] <col_alias>, ...)
     /// ```
-    Multiple(Vec<Box<SelectItem>>),
+    Multiple(Vec<Box<ReplaceSelectElement>>),
 }
 
 impl fmt::Display for ReplaceSelectItem {
@@ -568,6 +568,27 @@ impl fmt::Display for ReplaceSelectItem {
             }
         }
         Ok(())
+    }
+}
+
+/// # Syntax
+/// ```plaintext
+/// <expr> [AS] <column_name>
+/// ```
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct ReplaceSelectElement {
+    pub expr: Expr,
+    pub colum_name: Ident,
+    pub as_keyword: bool,
+}
+
+impl fmt::Display for ReplaceSelectElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.as_keyword {
+            write!(f, "{} AS {}", self.expr, self.colum_name)
+        } else {
+            write!(f, "{} {}", self.expr, self.colum_name)
+        }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6248,7 +6248,7 @@ impl<'a> Parser<'a> {
         Ok(opt_rename)
     }
 
-    /// Parse a [`Replace](RepalceSelectItem) information for wildcard select items.
+    /// Parse a [`Replace`](ReplaceSelectItem) information for wildcard select items.
     pub fn parse_optional_select_item_replace(
         &mut self,
     ) -> Result<Option<ReplaceSelectItem>, ParserError> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6164,9 +6164,9 @@ impl<'a> Parser<'a> {
             None
         };
 
-        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect){
-    self.parse_optional_select_item_replace()?
-        }else {
+        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect) {
+            self.parse_optional_select_item_replace()?
+        } else {
             None
         };
 
@@ -6174,7 +6174,7 @@ impl<'a> Parser<'a> {
             opt_exclude,
             opt_except,
             opt_rename,
-            opt_replace
+            opt_replace,
         })
     }
 
@@ -6248,26 +6248,26 @@ impl<'a> Parser<'a> {
         Ok(opt_rename)
     }
 
-        /// Parse a [`Replace](RepalceSelectItem) information for wildcard select items.
-        pub fn parse_optional_select_item_replace(
-            &mut self,
-        ) -> Result<Option<ReplaceSelectItem>, ParserError> {
-            let opt_replace = if self.parse_keyword(Keyword::REPLACE) {
-                if self.consume_token(&Token::LParen) {
-                    let idents =
-                        self.parse_comma_separated(|parser| parser.parse_identifier_with_alias())?;
-                    self.expect_token(&Token::RParen)?;
-                    Some(ReplaceSelectItem::Multiple(idents))
-                } else {
-                    let ident = self.parse_identifier_with_alias()?;
-                    Some(ReplaceSelectItem::Single(ident))
-                }
+    /// Parse a [`Replace](RepalceSelectItem) information for wildcard select items.
+    pub fn parse_optional_select_item_replace(
+        &mut self,
+    ) -> Result<Option<ReplaceSelectItem>, ParserError> {
+        let opt_replace = if self.parse_keyword(Keyword::REPLACE) {
+            if self.consume_token(&Token::LParen) {
+                let idents =
+                    self.parse_comma_separated(|parser| Ok(Box::new(parser.parse_select_item()?)))?;
+                self.expect_token(&Token::RParen)?;
+                Some(ReplaceSelectItem::Multiple(idents))
             } else {
-                None
-            };
+                let ident = self.parse_select_item()?;
+                Some(ReplaceSelectItem::Single(Box::new(ident)))
+            }
+        } else {
+            None
+        };
 
-            Ok(opt_replace)
-        }
+        Ok(opt_replace)
+    }
 
     /// Parse an expression, optionally followed by ASC or DESC (used in ORDER BY)
     pub fn parse_order_by_expr(&mut self) -> Result<OrderByExpr, ParserError> {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -316,17 +316,27 @@ fn test_select_wildcard_with_except() {
 #[test]
 fn test_select_wildcard_with_replace() {
     let select = bigquery_and_generic()
+        .verified_only_select(r#"SELECT * REPLACE 'widget' AS item_name FROM orders"#);
+    let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
+        opt_replace: Some(ReplaceSelectItem::Single(Box::new(
+            SelectItem::ExprWithAlias {
+                expr: Expr::Value(Value::SingleQuotedString("widget".to_owned())),
+                alias: Ident::new("item_name"),
+            },
+        ))),
+        ..Default::default()
+    });
+    assert_eq!(expected, select.projection[0]);
+
+    let select = bigquery_and_generic()
         .verified_only_select(r#"SELECT * REPLACE (quantity / 2 AS quantity) FROM orders"#);
     let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
         opt_replace: Some(ReplaceSelectItem::Multiple(vec![Box::new(
             SelectItem::ExprWithAlias {
                 expr: Expr::BinaryOp {
-                    left: Box::new(sqlparser::ast::Expr::Identifier(Ident::new("quantity"))),
+                    left: Box::new(Expr::Identifier(Ident::new("quantity"))),
                     op: BinaryOperator::Divide,
-                    right: Box::new(sqlparser::ast::Expr::Value(Value::Number(
-                        "2".to_string(),
-                        false,
-                    ))),
+                    right: Box::new(Expr::Value(Value::Number("2".to_string(), false))),
                 },
                 alias: Ident::new("quantity"),
             },

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -321,37 +321,47 @@ fn test_select_wildcard_with_except() {
 #[test]
 fn test_select_wildcard_with_replace() {
     let select = bigquery_and_generic()
-        .verified_only_select(r#"SELECT * REPLACE 'widget' AS item_name FROM orders"#);
+        .verified_only_select(r#"SELECT * REPLACE ('widget' AS item_name) FROM orders"#);
     let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
-        opt_replace: Some(ReplaceSelectItem::Single(Box::new(
-            SelectItem::ExprWithAlias {
+        opt_replace: Some(ReplaceSelectItem {
+            items: vec![Box::new(ReplaceSelectElement {
                 expr: Expr::Value(Value::SingleQuotedString("widget".to_owned())),
-                alias: Ident::new("item_name"),
-            },
-        ))),
+                colum_name: Ident::new("item_name"),
+                as_keyword: true,
+            })],
+        }),
         ..Default::default()
     });
     assert_eq!(expected, select.projection[0]);
 
-    let select = bigquery_and_generic()
-        .verified_only_select(r#"SELECT * REPLACE (quantity / 2 AS quantity) FROM orders"#);
+    let select = bigquery_and_generic().verified_only_select(
+        r#"SELECT * REPLACE (quantity / 2 AS quantity, 3 AS order_id) FROM orders"#,
+    );
     let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
-        opt_replace: Some(ReplaceSelectItem::Multiple(vec![Box::new(
-            SelectItem::ExprWithAlias {
-                expr: Expr::BinaryOp {
-                    left: Box::new(Expr::Identifier(Ident::new("quantity"))),
-                    op: BinaryOperator::Divide,
-                    #[cfg(not(feature = "bigdecimal"))]
-                    right: Box::new(Expr::Value(Value::Number("2".to_string(), false))),
-                    #[cfg(feature = "bigdecimal")]
-                    right: Box::new(Expr::Value(Value::Number(
-                        BigDecimal::from_str("2").unwrap(),
-                        false,
-                    ))),
-                },
-                alias: Ident::new("quantity"),
-            },
-        )])),
+        opt_replace: Some(ReplaceSelectItem {
+            items: vec![
+                Box::new(ReplaceSelectElement {
+                    expr: Expr::BinaryOp {
+                        left: Box::new(Expr::Identifier(Ident::new("quantity"))),
+                        op: BinaryOperator::Divide,
+                        #[cfg(not(feature = "bigdecimal"))]
+                        right: Box::new(Expr::Value(Value::Number("2".to_string(), false))),
+                        #[cfg(feature = "bigdecimal")]
+                        right: Box::new(Expr::Value(Value::Number(
+                            BigDecimal::from_str("2").unwrap(),
+                            false,
+                        ))),
+                    },
+                    colum_name: Ident::new("quantity"),
+                    as_keyword: true,
+                }),
+                Box::new(ReplaceSelectElement {
+                    expr: Expr::Value(Value::Number("3".to_string(), false)),
+                    colum_name: Ident::new("order_id"),
+                    as_keyword: true,
+                }),
+            ],
+        }),
         ..Default::default()
     });
     assert_eq!(expected, select.projection[0]);

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -313,6 +313,24 @@ fn test_select_wildcard_with_except() {
     );
 }
 
+#[test]
+fn test_select_wildcard_with_replace() {
+    let select = bigquery_and_generic().verified_only_select(r#"WITH orders AS
+    (SELECT 5 as order_id,
+    "sprocket" as item_name,
+    200 as quantity)
+  SELECT * REPLACE ("widget" AS item_name)
+  FROM orders;"#);
+    let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
+        opt_except: Some(ExceptSelectItem {
+            first_element: Ident::new("col_a"),
+            additional_elements: vec![],
+        }),
+        ..Default::default()
+    });
+    assert_eq!(expected, select.projection[0]);
+}
+
 fn bigquery() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(BigQueryDialect {})],

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -356,7 +356,10 @@ fn test_select_wildcard_with_replace() {
                     as_keyword: true,
                 }),
                 Box::new(ReplaceSelectElement {
+                    #[cfg(not(feature = "bigdecimal"))]
                     expr: Expr::Value(Value::Number("3".to_string(), false)),
+                    #[cfg(feature = "bigdecimal")]
+                    expr: Expr::Value(Value::Number(BigDecimal::from_str("3").unwrap(), false)),
                     colum_name: Ident::new("order_id"),
                     as_keyword: true,
                 }),

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -17,6 +17,11 @@ use sqlparser::ast::*;
 use sqlparser::dialect::{BigQueryDialect, GenericDialect};
 use test_utils::*;
 
+#[cfg(feature = "bigdecimal")]
+use bigdecimal::*;
+#[cfg(feature = "bigdecimal")]
+use std::str::FromStr;
+
 #[test]
 fn parse_literal_string() {
     let sql = r#"SELECT 'single', "double""#;
@@ -336,7 +341,13 @@ fn test_select_wildcard_with_replace() {
                 expr: Expr::BinaryOp {
                     left: Box::new(Expr::Identifier(Ident::new("quantity"))),
                     op: BinaryOperator::Divide,
+                    #[cfg(not(feature = "bigdecimal"))]
                     right: Box::new(Expr::Value(Value::Number("2".to_string(), false))),
+                    #[cfg(feature = "bigdecimal")]
+                    right: Box::new(Expr::Value(Value::Number(
+                        BigDecimal::from_str("2").unwrap(),
+                        false,
+                    ))),
                 },
                 alias: Ident::new("quantity"),
             },


### PR DESCRIPTION
Support: https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace