### PR TITLE
Support snowflake alter table swap with

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -96,6 +96,10 @@ pub enum AlterTableOperation {
         column_name: Ident,
         op: AlterColumnOperation,
     },
+    /// 'SWAP WITH <table_name>'
+    ///
+    /// Note: this is Snowflake specific <https://docs.snowflake.com/en/sql-reference/sql/alter-table>
+    SwapWith { table_name: ObjectName },
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -202,6 +206,9 @@ impl fmt::Display for AlterTableOperation {
             }
             AlterTableOperation::RenameConstraint { old_name, new_name } => {
                 write!(f, "RENAME CONSTRAINT {old_name} TO {new_name}")
+            }
+            AlterTableOperation::SwapWith { table_name } => {
+                write!(f, "SWAP WITH {table_name}")
             }
         }
     }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -545,6 +545,7 @@ define_keywords!(
     SUM,
     SUPER,
     SUPERUSER,
+    SWAP,
     SYMMETRIC,
     SYNC,
     SYSTEM,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3891,9 +3891,13 @@ impl<'a> Parser<'a> {
                         );
                     };
                     AlterTableOperation::AlterColumn { column_name, op }
+                } else if self.parse_keyword(Keyword::SWAP) {
+                    self.expect_keyword(Keyword::WITH)?;
+                    let table_name = self.parse_object_name()?;
+                    AlterTableOperation::SwapWith { table_name }
                 } else {
                     return self.expected(
-                        "ADD, RENAME, PARTITION or DROP after ALTER TABLE",
+                        "ADD, RENAME, PARTITION, SWAP or DROP after ALTER TABLE",
                         self.peek_token(),
                     );
                 };

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -493,3 +493,18 @@ fn test_select_wildcard_with_exclude_and_rename() {
         "sql parser error: Expected end of statement, found: EXCLUDE"
     );
 }
+
+#[test]
+fn test_alter_table_swap_with() {
+    let sql = "ALTER TABLE tab1 SWAP WITH tab2";
+    match snowflake_and_generic().verified_stmt(sql) {
+        Statement::AlterTable {
+            name,
+            operation: AlterTableOperation::SwapWith { table_name },
+        } => {
+            assert_eq!("tab1", name.to_string());
+            assert_eq!("tab2", table_name.to_string());
+        }
+        _ => unreachable!(),
+    };
+}


### PR DESCRIPTION
Support snowflake's `alter table swap with` syntax. [See doc](https://docs.snowflake.com/en/sql-reference/sql/alter-table).
```
ALTER TABLE tab1 SWAP WITH tab2
```