### PR TITLE
fix: merge byte string literal

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -41,10 +41,8 @@ pub enum Value {
     /// See [Postgres docs](https://www.postgresql.org/docs/8.3/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS)
     /// for more details.
     EscapedStringLiteral(String),
-    /// B'string value'
-    SingleQuotedByteStringLiteral(String),
-    /// B"string value"
-    DoubleQuotedByteStringLiteral(String),
+    /// B'string value' or B"string value"
+    ByteStringLiteral(String),
     /// R'string value' or r'string value' or r"string value"
     /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#quoted_literals>
     RawStringLiteral(String),
@@ -75,8 +73,7 @@ impl fmt::Display for Value {
             Value::NationalStringLiteral(v) => write!(f, "N'{v}'"),
             Value::HexStringLiteral(v) => write!(f, "X'{v}'"),
             Value::Boolean(v) => write!(f, "{v}"),
-            Value::SingleQuotedByteStringLiteral(v) => write!(f, "B'{v}'"),
-            Value::DoubleQuotedByteStringLiteral(v) => write!(f, "B\"{v}\""),
+            Value::ByteStringLiteral(v) => write!(f, "B'{v}'"),
             Value::RawStringLiteral(v) => write!(f, "R'{v}'"),
             Value::Null => write!(f, "NULL"),
             Value::Placeholder(v) => write!(f, "{v}"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -824,8 +824,7 @@ impl<'a> Parser<'a> {
             | Token::SingleQuotedString(_)
             | Token::DoubleQuotedString(_)
             | Token::DollarQuotedString(_)
-            | Token::SingleQuotedByteStringLiteral(_)
-            | Token::DoubleQuotedByteStringLiteral(_)
+            | Token::ByteStringLiteral(_)
             | Token::RawStringLiteral(_)
             | Token::NationalStringLiteral(_)
             | Token::HexStringLiteral(_) => {
@@ -4194,12 +4193,7 @@ impl<'a> Parser<'a> {
             Token::SingleQuotedString(ref s) => Ok(Value::SingleQuotedString(s.to_string())),
             Token::DoubleQuotedString(ref s) => Ok(Value::DoubleQuotedString(s.to_string())),
             Token::DollarQuotedString(ref s) => Ok(Value::DollarQuotedString(s.clone())),
-            Token::SingleQuotedByteStringLiteral(ref s) => {
-                Ok(Value::SingleQuotedByteStringLiteral(s.clone()))
-            }
-            Token::DoubleQuotedByteStringLiteral(ref s) => {
-                Ok(Value::DoubleQuotedByteStringLiteral(s.clone()))
-            }
+            Token::ByteStringLiteral(ref s) => Ok(Value::ByteStringLiteral(s.clone())),
             Token::RawStringLiteral(ref s) => Ok(Value::RawStringLiteral(s.clone())),
             Token::NationalStringLiteral(ref s) => Ok(Value::NationalStringLiteral(s.to_string())),
             Token::EscapedStringLiteral(ref s) => Ok(Value::EscapedStringLiteral(s.to_string())),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -58,10 +58,8 @@ pub enum Token {
     DoubleQuotedString(String),
     /// Dollar quoted string: i.e: $$string$$ or $tag_name$string$tag_name$
     DollarQuotedString(DollarQuotedString),
-    /// Byte string literal: i.e: b'string' or B'string'
-    SingleQuotedByteStringLiteral(String),
-    /// Byte string literal: i.e: b"string" or B"string"
-    DoubleQuotedByteStringLiteral(String),
+    /// Byte string literal: i.e: b"string", B"string", b'string' or B'string'
+    ByteStringLiteral(String),
     /// Raw string literal: i.e: r'string' or R'string' or r"string" or R"string"
     RawStringLiteral(String),
     /// "National" string literal: i.e: N'string'
@@ -195,8 +193,7 @@ impl fmt::Display for Token {
             Token::NationalStringLiteral(ref s) => write!(f, "N'{s}'"),
             Token::EscapedStringLiteral(ref s) => write!(f, "E'{s}'"),
             Token::HexStringLiteral(ref s) => write!(f, "X'{s}'"),
-            Token::SingleQuotedByteStringLiteral(ref s) => write!(f, "B'{s}'"),
-            Token::DoubleQuotedByteStringLiteral(ref s) => write!(f, "B\"{s}\""),
+            Token::ByteStringLiteral(ref s) => write!(f, "B'{s}'"),
             Token::RawStringLiteral(ref s) => write!(f, "R'{s}'"),
             Token::Comma => f.write_str(","),
             Token::Whitespace(ws) => write!(f, "{ws}"),
@@ -508,11 +505,11 @@ impl<'a> Tokenizer<'a> {
                     match chars.peek() {
                         Some('\'') => {
                             let s = self.tokenize_quoted_string(chars, '\'')?;
-                            Ok(Some(Token::SingleQuotedByteStringLiteral(s)))
+                            Ok(Some(Token::ByteStringLiteral(s)))
                         }
                         Some('\"') => {
                             let s = self.tokenize_quoted_string(chars, '\"')?;
-                            Ok(Some(Token::DoubleQuotedByteStringLiteral(s)))
+                            Ok(Some(Token::ByteStringLiteral(s)))
                         }
                         _ => {
                             // regular identifier starting with an "b" or "B"

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -43,11 +43,11 @@ fn parse_byte_literal() {
     let select = bigquery().verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
-        &Expr::Value(Value::SingleQuotedByteStringLiteral("abc".to_string())),
+        &Expr::Value(Value::ByteStringLiteral("abc".to_string())),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
-        &Expr::Value(Value::DoubleQuotedByteStringLiteral("abc".to_string())),
+        &Expr::Value(Value::ByteStringLiteral("abc".to_string())),
         expr_from_projection(&select.projection[1])
     );
 


### PR DESCRIPTION
As the same as https://github.com/sqlparser-rs/sqlparser-rs/pull/812#discussion_r1117987296, quote style isn't important.
This PR merges `SingleQuotedByteStringLiteral` and `DoubleQuotedByteStringLiteral` to `ByteStringLiteral`.