### PR TITLE
add notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+| :exclamation: Note: this is not [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) |
+| --------------------------------------------------------------------------------------------------------- |
+This fork of the sqlparser-rs project is not maintained by the sqlparser-rs 
+community. This is a fork of that project used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) 
+project.
+
 # Extensible SQL Lexer and Parser for Rust
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
We need a way to help ensure that those who are looking for the official parser don't confuse it with our fork. This adds a notice to the README.