### PR TITLE
Add Location/Spans in to the AST/parse layer

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -17,7 +17,9 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+use core::borrow::Borrow;
 use core::fmt;
+use std::ops::Deref;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -44,6 +46,7 @@ pub use self::value::{
     escape_quoted_string, DateTimeField, DollarQuotedString, TrimWhereField, Value,
 };
 
+use crate::tokenizer::Span;
 #[cfg(feature = "visitor")]
 pub use visitor::*;
 
@@ -251,6 +254,76 @@ impl fmt::Display for JsonOperator {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct WithSpan<T>
+where
+    T: Clone + Eq + Ord + std::hash::Hash + PartialOrd + PartialEq,
+{
+    inner: T,
+    span: Span,
+}
+
+impl<T> WithSpan<T>
+where
+    T: Clone + Eq + Ord + std::hash::Hash + PartialOrd + PartialEq,
+{
+    pub fn new(inner: T, span: Span) -> Self {
+        Self { inner, span }
+    }
+
+    pub fn unwrap(self) -> T {
+        self.inner
+    }
+}
+
+pub trait SpanWrapped: Clone + Eq + Ord + std::hash::Hash + PartialOrd + PartialEq {
+    fn spanning<U: Into<Span>>(self, span: U) -> WithSpan<Self> {
+        WithSpan::new(self, span.into())
+    }
+
+    fn empty_span(self) -> WithSpan<Self> {
+        self.spanning(Span::default())
+    }
+}
+
+impl<T> SpanWrapped for T
+where
+    T: Clone + Eq + Ord + std::hash::Hash + PartialOrd + PartialEq,
+{
+    fn spanning<U: Into<Span>>(self, span: U) -> WithSpan<Self> {
+        WithSpan::new(self, span.into())
+    }
+}
+
+impl<T> Deref for WithSpan<T>
+where
+    T: Clone + Eq + Ord + std::hash::Hash + PartialOrd + PartialEq,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> Borrow<T> for WithSpan<T>
+where
+    T: Clone + Eq + Ord + std::hash::Hash + PartialOrd + PartialEq,
+{
+    fn borrow(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for WithSpan<T>
+where
+    T: Clone + Eq + Ord + std::hash::Hash + PartialOrd + PartialEq,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
 /// An SQL expression of any type.
 ///
 /// The parser does not distinguish between expressions of different types
@@ -265,7 +338,7 @@ impl fmt::Display for JsonOperator {
 )]
 pub enum Expr {
     /// Identifier e.g. table name or column name
-    Identifier(Ident),
+    Identifier(WithSpan<Ident>),
     /// Multi-part identifier, e.g. `table_alias.column` or `schema.table.col`
     CompoundIdentifier(Vec<Ident>),
     /// JSON access (postgres)  eg: data->'tags'
@@ -4162,6 +4235,12 @@ impl fmt::Display for SearchModifier {
 mod tests {
     use super::*;
 
+    fn ident<T: Into<String>>(value: T) -> WithSpan<Ident> {
+        use crate::ast::SpanWrapped;
+
+        SpanWrapped::empty_span(Ident::new(value))
+    }
+
     #[test]
     fn test_window_frame_default() {
         let window_frame = WindowFrame::default();
@@ -4172,84 +4251,72 @@ mod tests {
     fn test_grouping_sets_display() {
         // a and b in different group
         let grouping_sets = Expr::GroupingSets(vec![
-            vec![Expr::Identifier(Ident::new("a"))],
-            vec![Expr::Identifier(Ident::new("b"))],
+            vec![Expr::Identifier(ident("a"))],
+            vec![Expr::Identifier(ident("b"))],
         ]);
         assert_eq!("GROUPING SETS ((a), (b))", format!("{grouping_sets}"));
 
         // a and b in the same group
         let grouping_sets = Expr::GroupingSets(vec![vec![
-            Expr::Identifier(Ident::new("a")),
-            Expr::Identifier(Ident::new("b")),
+            Expr::Identifier(ident("a")),
+            Expr::Identifier(ident("b")),
         ]]);
         assert_eq!("GROUPING SETS ((a, b))", format!("{grouping_sets}"));
 
         // (a, b) and (c, d) in different group
         let grouping_sets = Expr::GroupingSets(vec![
-            vec![
-                Expr::Identifier(Ident::new("a")),
-                Expr::Identifier(Ident::new("b")),
-            ],
-            vec![
-                Expr::Identifier(Ident::new("c")),
-                Expr::Identifier(Ident::new("d")),
-            ],
+            vec![Expr::Identifier(ident("a")), Expr::Identifier(ident("b"))],
+            vec![Expr::Identifier(ident("c")), Expr::Identifier(ident("d"))],
         ]);
         assert_eq!("GROUPING SETS ((a, b), (c, d))", format!("{grouping_sets}"));
     }
 
     #[test]
     fn test_rollup_display() {
-        let rollup = Expr::Rollup(vec![vec![Expr::Identifier(Ident::new("a"))]]);
+        let rollup = Expr::Rollup(vec![vec![Expr::Identifier(ident("a"))]]);
         assert_eq!("ROLLUP (a)", format!("{rollup}"));
 
         let rollup = Expr::Rollup(vec![vec![
-            Expr::Identifier(Ident::new("a")),
-            Expr::Identifier(Ident::new("b")),
+            Expr::Identifier(ident("a")),
+            Expr::Identifier(ident("b")),
         ]]);
         assert_eq!("ROLLUP ((a, b))", format!("{rollup}"));
 
         let rollup = Expr::Rollup(vec![
-            vec![Expr::Identifier(Ident::new("a"))],
-            vec![Expr::Identifier(Ident::new("b"))],
+            vec![Expr::Identifier(ident("a"))],
+            vec![Expr::Identifier(ident("b"))],
         ]);
         assert_eq!("ROLLUP (a, b)", format!("{rollup}"));
 
         let rollup = Expr::Rollup(vec![
-            vec![Expr::Identifier(Ident::new("a"))],
-            vec![
-                Expr::Identifier(Ident::new("b")),
-                Expr::Identifier(Ident::new("c")),
-            ],
-            vec![Expr::Identifier(Ident::new("d"))],
+            vec![Expr::Identifier(ident("a"))],
+            vec![Expr::Identifier(ident("b")), Expr::Identifier(ident("c"))],
+            vec![Expr::Identifier(ident("d"))],
         ]);
         assert_eq!("ROLLUP (a, (b, c), d)", format!("{rollup}"));
     }
 
     #[test]
     fn test_cube_display() {
-        let cube = Expr::Cube(vec![vec![Expr::Identifier(Ident::new("a"))]]);
+        let cube = Expr::Cube(vec![vec![Expr::Identifier(ident("a"))]]);
         assert_eq!("CUBE (a)", format!("{cube}"));
 
         let cube = Expr::Cube(vec![vec![
-            Expr::Identifier(Ident::new("a")),
-            Expr::Identifier(Ident::new("b")),
+            Expr::Identifier(ident("a")),
+            Expr::Identifier(ident("b")),
         ]]);
         assert_eq!("CUBE ((a, b))", format!("{cube}"));
 
         let cube = Expr::Cube(vec![
-            vec![Expr::Identifier(Ident::new("a"))],
-            vec![Expr::Identifier(Ident::new("b"))],
+            vec![Expr::Identifier(ident("a"))],
+            vec![Expr::Identifier(ident("b"))],
         ]);
         assert_eq!("CUBE (a, b)", format!("{cube}"));
 
         let cube = Expr::Cube(vec![
-            vec![Expr::Identifier(Ident::new("a"))],
-            vec![
-                Expr::Identifier(Ident::new("b")),
-                Expr::Identifier(Ident::new("c")),
-            ],
-            vec![Expr::Identifier(Ident::new("d"))],
+            vec![Expr::Identifier(ident("a"))],
+            vec![Expr::Identifier(ident("b")), Expr::Identifier(ident("c"))],
+            vec![Expr::Identifier(ident("d"))],
         ]);
         assert_eq!("CUBE (a, (b, c), d)", format!("{cube}"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ extern crate alloc;
 #[macro_use]
 #[cfg(test)]
 extern crate pretty_assertions;
+extern crate core;
 
 pub mod ast;
 #[macro_use]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -27,6 +27,8 @@ use alloc::{
 use core::fmt;
 use core::iter::Peekable;
 use core::str::Chars;
+use std::cmp::{max, min};
+use std::ops::Range;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -338,32 +340,135 @@ impl fmt::Display for Whitespace {
     }
 }
 
+pub type LineNumber = u64;
+pub type ColumnPosition = u64;
+pub type LineColumn = (LineNumber, ColumnPosition);
+
 /// Location in input string
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Hash)]
 pub struct Location {
     /// Line number, starting from 1
-    pub line: u64,
+    pub line: LineNumber,
     /// Line column, starting from 1
-    pub column: u64,
+    pub column: ColumnPosition,
 }
 
-/// A [Token] with [Location] attached to it
+impl Default for Location {
+    fn default() -> Self {
+        Self { line: 1, column: 1 }
+    }
+}
+
+impl From<LineColumn> for Location {
+    fn from(value: LineColumn) -> Self {
+        Location {
+            line: value.0,
+            column: value.1,
+        }
+    }
+}
+
+impl From<u64> for Location {
+    fn from(value: u64) -> Self {
+        Location {
+            line: 1,
+            column: value,
+        }
+    }
+}
+
+impl From<usize> for Location {
+    fn from(value: usize) -> Self {
+        Location {
+            line: 1,
+            column: value as u64,
+        }
+    }
+}
+
+impl From<i32> for Location {
+    fn from(value: i32) -> Self {
+        Location {
+            line: 1,
+            column: value as u64,
+        }
+    }
+}
+
+impl Location {
+    pub fn of(line: LineNumber, column: ColumnPosition) -> Self {
+        Self { line, column }
+    }
+
+    pub fn span_to(self, end: Self) -> Span {
+        Span { start: self, end }
+    }
+}
+
+/// Location in input string
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Default, Ord, PartialOrd, Hash)]
+pub struct Span {
+    /// The span start location, inclusive.
+    pub start: Location,
+    /// The span end location, exclusive.
+    pub end: Location,
+}
+
+impl Span {
+    pub fn new<T: Into<Location>, U: Into<Location>>(start: T, end: U) -> Self {
+        Self {
+            start: start.into(),
+            end: end.into(),
+        }
+    }
+
+    pub fn zero_width(start: Location) -> Self {
+        Self { start, end: start }
+    }
+
+    pub fn union(self, other: Self) -> Self {
+        Self {
+            start: min(self.start, other.start),
+            end: max(self.end, other.end),
+        }
+    }
+
+    pub fn start(self) -> Location {
+        self.start
+    }
+
+    pub fn end(self) -> Location {
+        self.end
+    }
+}
+
+impl<T: Into<Location>> From<Range<T>> for Span {
+    fn from(value: Range<T>) -> Self {
+        Span::new(value.start.into(), value.end.into())
+    }
+}
+
+/// A [Token] with [Span] attached to it
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct TokenWithLocation {
     pub token: Token,
-    pub location: Location,
+    pub span: Span,
 }
 
 impl TokenWithLocation {
-    pub fn new(token: Token, line: u64, column: u64) -> TokenWithLocation {
+    pub fn new(token: Token, span: Span) -> TokenWithLocation {
+        TokenWithLocation { token, span }
+    }
+
+    pub fn at(token: Token, start: LineColumn, end: LineColumn) -> TokenWithLocation {
         TokenWithLocation {
             token,
-            location: Location { line, column },
+            span: Location::from(start).span_to(end.into()),
         }
     }
 
     pub fn wrap(token: Token) -> TokenWithLocation {
-        TokenWithLocation::new(token, 0, 0)
+        TokenWithLocation::new(token, Span::default())
     }
 }
 
@@ -476,10 +581,8 @@ impl<'a> Tokenizer<'a> {
 
         let mut location = state.location();
         while let Some(token) = self.next_token(&mut state)? {
-            tokens.push(TokenWithLocation {
-                token,
-                location: location.clone(),
-            });
+            let span = location.span_to(state.location());
+            tokens.push(TokenWithLocation { token, span });
 
             location = state.location();
         }
@@ -1862,13 +1965,13 @@ mod tests {
         let mut tokenizer = Tokenizer::new(&dialect, sql);
         let tokens = tokenizer.tokenize_with_location().unwrap();
         let expected = vec![
-            TokenWithLocation::new(Token::make_keyword("SELECT"), 1, 1),
-            TokenWithLocation::new(Token::Whitespace(Whitespace::Space), 1, 7),
-            TokenWithLocation::new(Token::make_word("a", None), 1, 8),
-            TokenWithLocation::new(Token::Comma, 1, 9),
-            TokenWithLocation::new(Token::Whitespace(Whitespace::Newline), 1, 10),
-            TokenWithLocation::new(Token::Whitespace(Whitespace::Space), 2, 1),
-            TokenWithLocation::new(Token::make_word("b", None), 2, 2),
+            TokenWithLocation::at(Token::make_keyword("SELECT"), (1, 1), (1, 7)),
+            TokenWithLocation::at(Token::Whitespace(Whitespace::Space), (1, 7), (1, 8)),
+            TokenWithLocation::at(Token::make_word("a", None), (1, 8), (1, 9)),
+            TokenWithLocation::at(Token::Comma, (1, 9), (1, 10)),
+            TokenWithLocation::at(Token::Whitespace(Whitespace::Newline), (1, 10), (2, 1)),
+            TokenWithLocation::at(Token::Whitespace(Whitespace::Space), (2, 1), (2, 2)),
+            TokenWithLocation::at(Token::make_word("b", None), (2, 2), (2, 3)),
         ];
         compare(expected, tokens);
     }

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -17,7 +17,7 @@
 
 use sqlparser::ast::{
     CreateFunctionBody, CreateFunctionUsing, Expr, Function, FunctionDefinition, Ident, ObjectName,
-    SelectItem, Statement, TableFactor, UnaryOperator, Value,
+    SelectItem, SpanWrapped, Statement, TableFactor, UnaryOperator, Value,
 };
 use sqlparser::dialect::{GenericDialect, HiveDialect};
 use sqlparser::parser::ParserError;
@@ -224,7 +224,7 @@ fn set_statement_with_minus() {
             ]),
             value: vec![Expr::UnaryOp {
                 op: UnaryOperator::Minus,
-                expr: Box::new(Expr::Identifier(Ident::new("Xmx4g")))
+                expr: Box::new(Expr::Identifier(Ident::new("Xmx4g").empty_span()))
             }],
         }
     );
@@ -350,7 +350,10 @@ fn parse_delimited_identifiers() {
     );
     match &select.projection[2] {
         SelectItem::ExprWithAlias { expr, alias } => {
-            assert_eq!(&Expr::Identifier(Ident::with_quote('"', "simple id")), expr);
+            assert_eq!(
+                &Expr::Identifier(Ident::with_quote('"', "simple id").empty_span()),
+                expr
+            );
             assert_eq!(&Ident::with_quote('"', "column alias"), alias);
         }
         _ => panic!("Expected ExprWithAlias"),
@@ -371,7 +374,7 @@ fn parse_like() {
         let select = hive().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -387,7 +390,7 @@ fn parse_like() {
         let select = hive().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -404,7 +407,7 @@ fn parse_like() {
         let select = hive().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -426,7 +429,7 @@ fn parse_similar_to() {
         let select = hive().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -442,7 +445,7 @@ fn parse_similar_to() {
         let select = hive().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -458,7 +461,7 @@ fn parse_similar_to() {
         let select = hive().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -26,11 +26,11 @@ fn parse_mssql_identifiers() {
     let sql = "SELECT @@version, _foo$123 FROM ##temp";
     let select = ms_and_generic().verified_only_select(sql);
     assert_eq!(
-        &Expr::Identifier(Ident::new("@@version")),
+        &Expr::Identifier(Ident::new("@@version").empty_span()),
         expr_from_projection(&select.projection[0]),
     );
     assert_eq!(
-        &Expr::Identifier(Ident::new("_foo$123")),
+        &Expr::Identifier(Ident::new("_foo$123").empty_span()),
         expr_from_projection(&select.projection[1]),
     );
     assert_eq!(2, select.projection.len());
@@ -182,7 +182,10 @@ fn parse_delimited_identifiers() {
     );
     match &select.projection[2] {
         SelectItem::ExprWithAlias { expr, alias } => {
-            assert_eq!(&Expr::Identifier(Ident::with_quote('"', "simple id")), expr);
+            assert_eq!(
+                &Expr::Identifier(Ident::with_quote('"', "simple id").empty_span()),
+                expr
+            );
             assert_eq!(&Ident::with_quote('"', "column alias"), alias);
         }
         _ => panic!("Expected ExprWithAlias"),
@@ -203,7 +206,7 @@ fn parse_like() {
         let select = ms_and_generic().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -219,7 +222,7 @@ fn parse_like() {
         let select = ms_and_generic().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -236,7 +239,7 @@ fn parse_like() {
         let select = ms_and_generic().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -258,7 +261,7 @@ fn parse_similar_to() {
         let select = ms_and_generic().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -274,7 +277,7 @@ fn parse_similar_to() {
         let select = ms_and_generic().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -290,7 +293,7 @@ fn parse_similar_to() {
         let select = ms_and_generic().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -447,10 +447,13 @@ fn parse_quote_identifiers_2() {
             body: Box::new(SetExpr::Select(Box::new(Select {
                 distinct: false,
                 top: None,
-                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-                    value: "quoted ` identifier".into(),
-                    quote_style: Some('`'),
-                }))],
+                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(
+                    Ident {
+                        value: "quoted ` identifier".into(),
+                        quote_style: Some('`'),
+                    }
+                    .empty_span()
+                ))],
                 into: None,
                 from: vec![],
                 lateral_views: vec![],
@@ -481,10 +484,13 @@ fn parse_quote_identifiers_3() {
             body: Box::new(SetExpr::Select(Box::new(Select {
                 distinct: false,
                 top: None,
-                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-                    value: "`quoted identifier`".into(),
-                    quote_style: Some('`'),
-                }))],
+                projection: vec![SelectItem::UnnamedExpr(Expr::Identifier(
+                    Ident {
+                        value: "`quoted identifier`".into(),
+                        quote_style: Some('`'),
+                    }
+                    .empty_span()
+                ))],
                 into: None,
                 from: vec![],
                 lateral_views: vec![],
@@ -787,7 +793,7 @@ fn parse_insert_with_on_duplicate_update() {
                         value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                                Expr::Identifier(Ident::new("description"))
+                                Expr::Identifier(Ident::new("description").empty_span())
                             ))],
                             over: None,
                             distinct: false,
@@ -799,7 +805,7 @@ fn parse_insert_with_on_duplicate_update() {
                         value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                                Expr::Identifier(Ident::new("perm_create"))
+                                Expr::Identifier(Ident::new("perm_create").empty_span())
                             ))],
                             over: None,
                             distinct: false,
@@ -811,7 +817,7 @@ fn parse_insert_with_on_duplicate_update() {
                         value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                                Expr::Identifier(Ident::new("perm_read"))
+                                Expr::Identifier(Ident::new("perm_read").empty_span())
                             ))],
                             over: None,
                             distinct: false,
@@ -823,7 +829,7 @@ fn parse_insert_with_on_duplicate_update() {
                         value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                                Expr::Identifier(Ident::new("perm_update"))
+                                Expr::Identifier(Ident::new("perm_update").empty_span())
                             ))],
                             over: None,
                             distinct: false,
@@ -835,7 +841,7 @@ fn parse_insert_with_on_duplicate_update() {
                         value: Expr::Function(Function {
                             name: ObjectName(vec![Ident::new("VALUES".to_string()),]),
                             args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                                Expr::Identifier(Ident::new("perm_delete"))
+                                Expr::Identifier(Ident::new("perm_delete").empty_span())
                             ))],
                             over: None,
                             distinct: false,
@@ -979,10 +985,13 @@ fn parse_substring_in_select() {
                         distinct: true,
                         top: None,
                         projection: vec![SelectItem::UnnamedExpr(Expr::Substring {
-                            expr: Box::new(Expr::Identifier(Ident {
-                                value: "description".to_string(),
-                                quote_style: None
-                            })),
+                            expr: Box::new(Expr::Identifier(
+                                Ident {
+                                    value: "description".to_string(),
+                                    quote_style: None
+                                }
+                                .empty_span()
+                            )),
                             substring_from: Some(Box::new(Expr::Value(Value::Number(
                                 "0".to_string(),
                                 false

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -986,10 +986,13 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variable: ObjectName(vec![Ident::new("a")]),
-            value: vec![Expr::Identifier(Ident {
-                value: "b".into(),
-                quote_style: None
-            })],
+            value: vec![Expr::Identifier(
+                Ident {
+                    value: "b".into(),
+                    quote_style: None
+                }
+                .empty_span()
+            )],
         }
     );
 
@@ -1028,10 +1031,13 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variable: ObjectName(vec![Ident::new("a")]),
-            value: vec![Expr::Identifier(Ident {
-                value: "DEFAULT".into(),
-                quote_style: None
-            })],
+            value: vec![Expr::Identifier(
+                Ident {
+                    value: "DEFAULT".into(),
+                    quote_style: None
+                }
+                .empty_span()
+            )],
         }
     );
 
@@ -1042,7 +1048,7 @@ fn parse_set() {
             local: true,
             hivevar: false,
             variable: ObjectName(vec![Ident::new("a")]),
-            value: vec![Expr::Identifier("b".into())],
+            value: vec![Expr::Identifier(Ident::new("b").empty_span())],
         }
     );
 
@@ -1053,10 +1059,13 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variable: ObjectName(vec![Ident::new("a"), Ident::new("b"), Ident::new("c")]),
-            value: vec![Expr::Identifier(Ident {
-                value: "b".into(),
-                quote_style: None
-            })],
+            value: vec![Expr::Identifier(
+                Ident {
+                    value: "b".into(),
+                    quote_style: None
+                }
+                .empty_span()
+            )],
         }
     );
 
@@ -1258,9 +1267,9 @@ fn parse_prepare() {
             assert!(columns.is_empty());
 
             let expected_values = [vec![
-                Expr::Identifier("a1".into()),
-                Expr::Identifier("a2".into()),
-                Expr::Identifier("a3".into()),
+                Expr::Identifier(Ident::new("a1").empty_span()),
+                Expr::Identifier(Ident::new("a2").empty_span()),
+                Expr::Identifier(Ident::new("a3").empty_span()),
             ]];
             match &*source.body {
                 SetExpr::Values(Values { rows, .. }) => {
@@ -1409,10 +1418,13 @@ fn parse_pg_on_conflict() {
                         value: Expr::Value(Value::Placeholder("$1".to_string()))
                     },],
                     selection: Some(Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident {
-                            value: "dsize".to_string(),
-                            quote_style: None
-                        })),
+                        left: Box::new(Expr::Identifier(
+                            Ident {
+                                value: "dsize".to_string(),
+                                quote_style: None
+                            }
+                            .empty_span()
+                        )),
                         op: BinaryOperator::Gt,
                         right: Box::new(Expr::Value(Value::Placeholder("$2".to_string())))
                     })
@@ -1446,10 +1458,13 @@ fn parse_pg_on_conflict() {
                         value: Expr::Value(Value::Placeholder("$1".to_string()))
                     },],
                     selection: Some(Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident {
-                            value: "dsize".to_string(),
-                            quote_style: None
-                        })),
+                        left: Box::new(Expr::Identifier(
+                            Ident {
+                                value: "dsize".to_string(),
+                                quote_style: None
+                            }
+                            .empty_span()
+                        )),
                         op: BinaryOperator::Gt,
                         right: Box::new(Expr::Value(Value::Placeholder("$2".to_string())))
                     })
@@ -1470,7 +1485,7 @@ fn parse_pg_returning() {
         Statement::Insert { returning, .. } => {
             assert_eq!(
                 Some(vec![SelectItem::UnnamedExpr(Expr::Identifier(
-                    "did".into()
+                    Ident::new("did").empty_span()
                 )),]),
                 returning
             );
@@ -1488,14 +1503,14 @@ fn parse_pg_returning() {
             assert_eq!(
                 Some(vec![
                     SelectItem::ExprWithAlias {
-                        expr: Expr::Identifier("temp_lo".into()),
+                        expr: Expr::Identifier(Ident::new("temp_lo").empty_span()),
                         alias: "lo".into()
                     },
                     SelectItem::ExprWithAlias {
-                        expr: Expr::Identifier("temp_hi".into()),
+                        expr: Expr::Identifier(Ident::new("temp_hi").empty_span()),
                         alias: "hi".into()
                     },
-                    SelectItem::UnnamedExpr(Expr::Identifier("prcp".into())),
+                    SelectItem::UnnamedExpr(Expr::Identifier(Ident::new("prcp").empty_span())),
                 ]),
                 returning
             );
@@ -1531,9 +1546,9 @@ fn parse_pg_binary_ops() {
         let select = dialects.verified_only_select(&format!("SELECT a {} b", &str_op));
         assert_eq!(
             SelectItem::UnnamedExpr(Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(Ident::new("a"))),
+                left: Box::new(Expr::Identifier(Ident::new("a").empty_span())),
                 op: op.clone(),
-                right: Box::new(Expr::Identifier(Ident::new("b"))),
+                right: Box::new(Expr::Identifier(Ident::new("b").empty_span())),
             }),
             select.projection[0]
         );
@@ -1555,7 +1570,7 @@ fn parse_pg_unary_ops() {
         assert_eq!(
             SelectItem::UnnamedExpr(Expr::UnaryOp {
                 op: *op,
-                expr: Box::new(Expr::Identifier(Ident::new("a"))),
+                expr: Box::new(Expr::Identifier(Ident::new("a").empty_span())),
             }),
             select.projection[0]
         );
@@ -1571,7 +1586,7 @@ fn parse_pg_postfix_factorial() {
         assert_eq!(
             SelectItem::UnnamedExpr(Expr::UnaryOp {
                 op: *op,
-                expr: Box::new(Expr::Identifier(Ident::new("a"))),
+                expr: Box::new(Expr::Identifier(Ident::new("a").empty_span())),
             }),
             select.projection[0]
         );
@@ -1615,7 +1630,7 @@ fn parse_array_index_expr() {
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
         &Expr::ArrayIndex {
-            obj: Box::new(Expr::Identifier(Ident::new("foo"))),
+            obj: Box::new(Expr::Identifier(Ident::new("foo").empty_span())),
             indexes: vec![num[0].clone()],
         },
         expr_from_projection(only(&select.projection)),
@@ -1625,7 +1640,7 @@ fn parse_array_index_expr() {
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
         &Expr::ArrayIndex {
-            obj: Box::new(Expr::Identifier(Ident::new("foo"))),
+            obj: Box::new(Expr::Identifier(Ident::new("foo").empty_span())),
             indexes: vec![num[0].clone(), num[0].clone()],
         },
         expr_from_projection(only(&select.projection)),
@@ -1635,17 +1650,23 @@ fn parse_array_index_expr() {
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(
         &Expr::ArrayIndex {
-            obj: Box::new(Expr::Identifier(Ident::new("bar"))),
+            obj: Box::new(Expr::Identifier(Ident::new("bar").empty_span())),
             indexes: vec![
                 num[0].clone(),
-                Expr::Identifier(Ident {
-                    value: "baz".to_string(),
-                    quote_style: Some('"')
-                }),
-                Expr::Identifier(Ident {
-                    value: "fooz".to_string(),
-                    quote_style: Some('"')
-                })
+                Expr::Identifier(
+                    Ident {
+                        value: "baz".to_string(),
+                        quote_style: Some('"')
+                    }
+                    .empty_span()
+                ),
+                Expr::Identifier(
+                    Ident {
+                        value: "fooz".to_string(),
+                        quote_style: Some('"')
+                    }
+                    .empty_span()
+                )
             ],
         },
         expr_from_projection(only(&select.projection)),
@@ -1788,7 +1809,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("params"))),
+            left: Box::new(Expr::Identifier(Ident::new("params").empty_span())),
             operator: JsonOperator::LongArrow,
             right: Box::new(Expr::Value(Value::SingleQuotedString("name".to_string()))),
         }),
@@ -1799,7 +1820,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("params"))),
+            left: Box::new(Expr::Identifier(Ident::new("params").empty_span())),
             operator: JsonOperator::Arrow,
             right: Box::new(Expr::Value(Value::SingleQuotedString("name".to_string()))),
         }),
@@ -1810,7 +1831,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("info"))),
+            left: Box::new(Expr::Identifier(Ident::new("info").empty_span())),
             operator: JsonOperator::Arrow,
             right: Box::new(Expr::JsonAccess {
                 left: Box::new(Expr::Value(Value::SingleQuotedString("items".to_string()))),
@@ -1827,7 +1848,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("info"))),
+            left: Box::new(Expr::Identifier(Ident::new("info").empty_span())),
             operator: JsonOperator::HashArrow,
             right: Box::new(Expr::Value(Value::SingleQuotedString(
                 "{a,b,c}".to_string()
@@ -1840,7 +1861,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("info"))),
+            left: Box::new(Expr::Identifier(Ident::new("info").empty_span())),
             operator: JsonOperator::HashLongArrow,
             right: Box::new(Expr::Value(Value::SingleQuotedString(
                 "{a,b,c}".to_string()
@@ -1853,7 +1874,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("info"))),
+            left: Box::new(Expr::Identifier(Ident::new("info").empty_span())),
             operator: JsonOperator::AtArrow,
             right: Box::new(Expr::Value(Value::SingleQuotedString(
                 "{\"a\": 1}".to_string()
@@ -1870,7 +1891,7 @@ fn test_json() {
                 "{\"a\": 1}".to_string()
             ))),
             operator: JsonOperator::ArrowAt,
-            right: Box::new(Expr::Identifier(Ident::new("info"))),
+            right: Box::new(Expr::Identifier(Ident::new("info").empty_span())),
         },
         select.selection.unwrap(),
     );
@@ -1879,7 +1900,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::from("info"))),
+            left: Box::new(Expr::Identifier(Ident::from("info").empty_span())),
             operator: JsonOperator::HashMinus,
             right: Box::new(Expr::Array(Array {
                 elem: vec![
@@ -1896,7 +1917,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::from("info"))),
+            left: Box::new(Expr::Identifier(Ident::from("info").empty_span())),
             operator: JsonOperator::AtQuestion,
             right: Box::new(Expr::Value(Value::SingleQuotedString("$.a".to_string())),),
         },
@@ -1907,7 +1928,7 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::from("info"))),
+            left: Box::new(Expr::Identifier(Ident::from("info").empty_span())),
             operator: JsonOperator::AtAt,
             right: Box::new(Expr::Value(Value::SingleQuotedString("$.a".to_string())),),
         },
@@ -2197,10 +2218,13 @@ fn parse_custom_operator() {
     assert_eq!(
         select.selection,
         Some(Expr::BinaryOp {
-            left: Box::new(Expr::Identifier(Ident {
-                value: "relname".into(),
-                quote_style: None,
-            })),
+            left: Box::new(Expr::Identifier(
+                Ident {
+                    value: "relname".into(),
+                    quote_style: None,
+                }
+                .empty_span()
+            )),
             op: BinaryOperator::PGCustomBinaryOperator(vec![
                 "database".into(),
                 "pg_catalog".into(),
@@ -2216,10 +2240,13 @@ fn parse_custom_operator() {
     assert_eq!(
         select.selection,
         Some(Expr::BinaryOp {
-            left: Box::new(Expr::Identifier(Ident {
-                value: "relname".into(),
-                quote_style: None,
-            })),
+            left: Box::new(Expr::Identifier(
+                Ident {
+                    value: "relname".into(),
+                    quote_style: None,
+                }
+                .empty_span()
+            )),
             op: BinaryOperator::PGCustomBinaryOperator(vec!["pg_catalog".into(), "~".into()]),
             right: Box::new(Expr::Value(Value::SingleQuotedString("^(table)$".into())))
         })
@@ -2231,10 +2258,13 @@ fn parse_custom_operator() {
     assert_eq!(
         select.selection,
         Some(Expr::BinaryOp {
-            left: Box::new(Expr::Identifier(Ident {
-                value: "relname".into(),
-                quote_style: None,
-            })),
+            left: Box::new(Expr::Identifier(
+                Ident {
+                    value: "relname".into(),
+                    quote_style: None,
+                }
+                .empty_span()
+            )),
             op: BinaryOperator::PGCustomBinaryOperator(vec!["~".into()]),
             right: Box::new(Expr::Value(Value::SingleQuotedString("^(table)$".into())))
         })
@@ -2419,7 +2449,10 @@ fn parse_delimited_identifiers() {
     );
     match &select.projection[2] {
         SelectItem::ExprWithAlias { expr, alias } => {
-            assert_eq!(&Expr::Identifier(Ident::with_quote('"', "simple id")), expr);
+            assert_eq!(
+                &Expr::Identifier(Ident::with_quote('"', "simple id").empty_span()),
+                expr
+            );
             assert_eq!(&Ident::with_quote('"', "column alias"), alias);
         }
         _ => panic!("Expected ExprWithAlias"),
@@ -2440,7 +2473,7 @@ fn parse_like() {
         let select = pg().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -2456,7 +2489,7 @@ fn parse_like() {
         let select = pg().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -2473,7 +2506,7 @@ fn parse_like() {
         let select = pg().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -2495,7 +2528,7 @@ fn parse_similar_to() {
         let select = pg().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -2511,7 +2544,7 @@ fn parse_similar_to() {
         let select = pg().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -2527,7 +2560,7 @@ fn parse_similar_to() {
         let select = pg().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -2585,9 +2618,9 @@ fn parse_create_function() {
                 language: Some("SQL".into()),
                 behavior: Some(FunctionBehavior::Immutable),
                 return_: Some(Expr::BinaryOp {
-                    left: Box::new(Expr::Identifier("a".into())),
+                    left: Box::new(Expr::Identifier(Ident::new("a").empty_span())),
                     op: BinaryOperator::Plus,
-                    right: Box::new(Expr::Identifier("b".into())),
+                    right: Box::new(Expr::Identifier(Ident::new("b").empty_span())),
                 }),
                 ..Default::default()
             },

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -23,10 +23,13 @@ fn test_square_brackets_over_db_schema_table_name() {
     let select = redshift().verified_only_select("SELECT [col1] FROM [test_schema].[test_table]");
     assert_eq!(
         select.projection[0],
-        SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-            value: "col1".to_string(),
-            quote_style: Some('[')
-        })),
+        SelectItem::UnnamedExpr(Expr::Identifier(
+            Ident {
+                value: "col1".to_string(),
+                quote_style: Some('[')
+            }
+            .empty_span()
+        )),
     );
     assert_eq!(
         select.from[0],
@@ -67,10 +70,13 @@ fn test_double_quotes_over_db_schema_table_name() {
         redshift().verified_only_select("SELECT \"col1\" FROM \"test_schema\".\"test_table\"");
     assert_eq!(
         select.projection[0],
-        SelectItem::UnnamedExpr(Expr::Identifier(Ident {
-            value: "col1".to_string(),
-            quote_style: Some('"')
-        })),
+        SelectItem::UnnamedExpr(Expr::Identifier(
+            Ident {
+                value: "col1".to_string(),
+                quote_style: Some('"')
+            }
+            .empty_span()
+        )),
     );
     assert_eq!(
         select.from[0],
@@ -137,7 +143,10 @@ fn parse_delimited_identifiers() {
     );
     match &select.projection[2] {
         SelectItem::ExprWithAlias { expr, alias } => {
-            assert_eq!(&Expr::Identifier(Ident::with_quote('"', "simple id")), expr);
+            assert_eq!(
+                &Expr::Identifier(Ident::with_quote('"', "simple id").empty_span()),
+                expr
+            );
             assert_eq!(&Ident::with_quote('"', "column alias"), alias);
         }
         _ => panic!("Expected ExprWithAlias"),
@@ -158,7 +167,7 @@ fn parse_like() {
         let select = redshift().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -174,7 +183,7 @@ fn parse_like() {
         let select = redshift().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -191,7 +200,7 @@ fn parse_like() {
         let select = redshift().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -213,7 +222,7 @@ fn parse_similar_to() {
         let select = redshift().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -229,7 +238,7 @@ fn parse_similar_to() {
         let select = redshift().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -245,7 +254,7 @@ fn parse_similar_to() {
         let select = redshift().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -268,7 +277,7 @@ fn test_sharp() {
     let sql = "SELECT #_of_values";
     let select = redshift().verified_only_select(sql);
     assert_eq!(
-        SelectItem::UnnamedExpr(Expr::Identifier(Ident::new("#_of_values"))),
+        SelectItem::UnnamedExpr(Expr::Identifier(Ident::new("#_of_values").empty_span())),
         select.projection[0]
     );
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -163,7 +163,7 @@ fn parse_array() {
     let select = snowflake().verified_only_select(sql);
     assert_eq!(
         &Expr::Cast {
-            expr: Box::new(Expr::Identifier(Ident::new("a"))),
+            expr: Box::new(Expr::Identifier(Ident::new("a").empty_span())),
             data_type: DataType::Array(None),
         },
         expr_from_projection(only(&select.projection))
@@ -176,7 +176,7 @@ fn parse_json_using_colon() {
     let select = snowflake().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("a"))),
+            left: Box::new(Expr::Identifier(Ident::new("a").empty_span())),
             operator: JsonOperator::Colon,
             right: Box::new(Expr::Value(Value::UnQuotedString("b".to_string()))),
         }),
@@ -187,7 +187,7 @@ fn parse_json_using_colon() {
     let select = snowflake().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("a"))),
+            left: Box::new(Expr::Identifier(Ident::new("a").empty_span())),
             operator: JsonOperator::Colon,
             right: Box::new(Expr::Value(Value::UnQuotedString("type".to_string()))),
         }),
@@ -198,7 +198,7 @@ fn parse_json_using_colon() {
     let select = snowflake().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::JsonAccess {
-            left: Box::new(Expr::Identifier(Ident::new("a"))),
+            left: Box::new(Expr::Identifier(Ident::new("a").empty_span())),
             operator: JsonOperator::Colon,
             right: Box::new(Expr::Value(Value::UnQuotedString("location".to_string()))),
         }),
@@ -250,7 +250,10 @@ fn parse_delimited_identifiers() {
     );
     match &select.projection[2] {
         SelectItem::ExprWithAlias { expr, alias } => {
-            assert_eq!(&Expr::Identifier(Ident::with_quote('"', "simple id")), expr);
+            assert_eq!(
+                &Expr::Identifier(Ident::with_quote('"', "simple id").empty_span()),
+                expr
+            );
             assert_eq!(&Ident::with_quote('"', "column alias"), alias);
         }
         _ => panic!("Expected ExprWithAlias"),
@@ -271,7 +274,7 @@ fn parse_like() {
         let select = snowflake().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -287,7 +290,7 @@ fn parse_like() {
         let select = snowflake().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -304,7 +307,7 @@ fn parse_like() {
         let select = snowflake().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -326,7 +329,7 @@ fn parse_similar_to() {
         let select = snowflake().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -342,7 +345,7 @@ fn parse_similar_to() {
         let select = snowflake().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -358,7 +361,7 @@ fn parse_similar_to() {
         let select = snowflake().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -143,7 +143,7 @@ fn parse_like() {
         let select = sqlite().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -159,7 +159,7 @@ fn parse_like() {
         let select = sqlite().verified_only_select(sql);
         assert_eq!(
             Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -176,7 +176,7 @@ fn parse_like() {
         let select = sqlite().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::Like {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -198,7 +198,7 @@ fn parse_similar_to() {
         let select = sqlite().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
@@ -214,7 +214,7 @@ fn parse_similar_to() {
         let select = sqlite().verified_only_select(sql);
         assert_eq!(
             Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),
@@ -230,7 +230,7 @@ fn parse_similar_to() {
         let select = sqlite().verified_only_select(sql);
         assert_eq!(
             Expr::IsNull(Box::new(Expr::SimilarTo {
-                expr: Box::new(Expr::Identifier(Ident::new("name"))),
+                expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('\\'),


### PR DESCRIPTION
This is an attempt at starting to plumb a location (or in this case a `Span`) through to the parsing/AST layer: #757.

# Changes

1. Add a new wrapper type `WithSpan<T>` which can be used to wrap and attach a span to any AST node. Not sure about this approach yet, but it seemed to work OK. I think this might need to evolve in to a type called `WithTrivia<T>` where `Span` and "trivia items" like leading and trailing `Token`'s to an AST node are attached. (i.e. the `SELECT` keyword for a query, to get a span for the entire select query.) This "trivia" based approach is something I've learned from [dotnet/roslyn (the C# compiler)](https://github.com/dotnet/roslyn/blob/e47b15b2485bee978bafb5c7dcce99d8bdc2f8fd/src/Compilers/Core/Portable/Syntax/SyntaxTrivia.cs#L22). (This trivia based approach was also taken with typescript.)
2. Add a `Span` type which is a struct with a start (inclusive) and end (exclusive) `Location`


# ToDo still
- [ ] Finish wiring spans through the tests. This is going to be the most annoying part about this work. Would love to hear folks thoughts on this.

# Open Questions
- Should this work just align to using [zkat/miette](https://github.com/zkat/miette) `Diagnostic` and `SourceSpan`.