### PR TITLE
Move tests from parser.rs to appropriate parse_XX tests

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7406,11 +7406,4 @@ mod tests {
             ))
         );
     }
-
-    #[test]
-    fn test_update_in_with_subquery() {
-        let sql = r#"WITH "result" AS (UPDATE "Hero" SET "name" = 'Captain America', "number_of_movies" = "number_of_movies" + 1 WHERE "secret_identity" = 'Sam Wilson' RETURNING "id", "name", "secret_identity", "number_of_movies") SELECT * FROM "result""#;
-        let ast = Parser::parse_sql(&GenericDialect, sql).unwrap();
-        assert_eq!(ast[0].to_string(), sql);
-    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6912,40 +6912,6 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_parse_limit() {
-        let sql = "SELECT * FROM user LIMIT 1";
-        all_dialects().run_parser_method(sql, |parser| {
-            let ast = parser.parse_query().unwrap();
-            assert_eq!(ast.to_string(), sql.to_string());
-        });
-
-        let sql = "SELECT * FROM user LIMIT $1 OFFSET $2";
-        let dialects = TestedDialects {
-            dialects: vec![
-                Box::new(PostgreSqlDialect {}),
-                Box::new(ClickHouseDialect {}),
-                Box::new(GenericDialect {}),
-                Box::new(MsSqlDialect {}),
-                Box::new(SnowflakeDialect {}),
-            ],
-        };
-
-        dialects.run_parser_method(sql, |parser| {
-            let ast = parser.parse_query().unwrap();
-            assert_eq!(ast.to_string(), sql.to_string());
-        });
-
-        let sql = "SELECT * FROM user LIMIT ? OFFSET ?";
-        let dialects = TestedDialects {
-            dialects: vec![Box::new(MySqlDialect {})],
-        };
-        dialects.run_parser_method(sql, |parser| {
-            let ast = parser.parse_query().unwrap();
-            assert_eq!(ast.to_string(), sql.to_string());
-        });
-    }
-
     #[cfg(test)]
     mod test_parse_data_type {
         use crate::ast::{
@@ -7399,24 +7365,6 @@ mod tests {
                 index_type: Some(IndexType::Hash),
                 columns: vec![Ident::new("c1")],
             }
-        );
-    }
-
-    #[test]
-    fn test_update_has_keyword() {
-        let sql = r#"UPDATE test SET name=$1,
-                value=$2,
-                where=$3,
-                create=$4,
-                is_default=$5,
-                classification=$6,
-                sort=$7
-                WHERE id=$8"#;
-        let pg_dialect = PostgreSqlDialect {};
-        let ast = Parser::parse_sql(&pg_dialect, sql).unwrap();
-        assert_eq!(
-            ast[0].to_string(),
-            r#"UPDATE test SET name = $1, value = $2, where = $3, create = $4, is_default = $5, classification = $6, sort = $7 WHERE id = $8"#
         );
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1565,65 +1565,6 @@ fn parse_select_group_by() {
 }
 
 #[test]
-fn parse_select_group_by_grouping_sets() {
-    let dialects = TestedDialects {
-        dialects: vec![Box::new(GenericDialect {}), Box::new(PostgreSqlDialect {})],
-    };
-    let sql =
-        "SELECT brand, size, sum(sales) FROM items_sold GROUP BY size, GROUPING SETS ((brand), (size), ())";
-    let select = dialects.verified_only_select(sql);
-    assert_eq!(
-        vec![
-            Expr::Identifier(Ident::new("size")),
-            Expr::GroupingSets(vec![
-                vec![Expr::Identifier(Ident::new("brand"))],
-                vec![Expr::Identifier(Ident::new("size"))],
-                vec![],
-            ]),
-        ],
-        select.group_by
-    );
-}
-
-#[test]
-fn parse_select_group_by_rollup() {
-    let dialects = TestedDialects {
-        dialects: vec![Box::new(GenericDialect {}), Box::new(PostgreSqlDialect {})],
-    };
-    let sql = "SELECT brand, size, sum(sales) FROM items_sold GROUP BY size, ROLLUP (brand, size)";
-    let select = dialects.verified_only_select(sql);
-    assert_eq!(
-        vec![
-            Expr::Identifier(Ident::new("size")),
-            Expr::Rollup(vec![
-                vec![Expr::Identifier(Ident::new("brand"))],
-                vec![Expr::Identifier(Ident::new("size"))],
-            ]),
-        ],
-        select.group_by
-    );
-}
-
-#[test]
-fn parse_select_group_by_cube() {
-    let dialects = TestedDialects {
-        dialects: vec![Box::new(GenericDialect {}), Box::new(PostgreSqlDialect {})],
-    };
-    let sql = "SELECT brand, size, sum(sales) FROM items_sold GROUP BY size, CUBE (brand, size)";
-    let select = dialects.verified_only_select(sql);
-    assert_eq!(
-        vec![
-            Expr::Identifier(Ident::new("size")),
-            Expr::Cube(vec![
-                vec![Expr::Identifier(Ident::new("brand"))],
-                vec![Expr::Identifier(Ident::new("size"))],
-            ]),
-        ],
-        select.group_by
-    );
-}
-
-#[test]
 fn parse_select_having() {
     let sql = "SELECT foo FROM bar GROUP BY foo HAVING COUNT(*) > 1";
     let select = verified_only_select(sql);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -514,6 +514,11 @@ fn parse_simple_select() {
 }
 
 #[test]
+fn parse_limit() {
+    verified_stmt("SELECT * FROM user LIMIT 1");
+}
+
+#[test]
 fn parse_limit_is_not_an_alias() {
     // In dialects supporting LIMIT it shouldn't be parsed as a table alias
     let ast = verified_query("SELECT id FROM customer LIMIT 1");

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1134,6 +1134,7 @@ fn parse_limit_my_sql_syntax() {
         "SELECT id, fname, lname FROM customer LIMIT 5, 10",
         "SELECT id, fname, lname FROM customer LIMIT 10 OFFSET 5",
     );
+    mysql_and_generic().verified_stmt("SELECT * FROM user LIMIT ? OFFSET ?");
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2446,6 +2446,11 @@ fn parse_update_has_keyword() {
 }
 
 #[test]
+fn parse_update_in_with_subquery() {
+    pg_and_generic().verified_stmt(r#"WITH "result" AS (UPDATE "Hero" SET "name" = 'Captain America', "number_of_movies" = "number_of_movies" + 1 WHERE "secret_identity" = 'Sam Wilson' RETURNING "id", "name", "secret_identity", "number_of_movies") SELECT * FROM "result""#);
+}
+
+#[test]
 fn parse_like() {
     fn chk(negated: bool) {
         let sql = &format!(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2427,7 +2427,22 @@ fn parse_delimited_identifiers() {
 
     pg().verified_stmt(r#"CREATE TABLE "foo" ("bar" "int")"#);
     pg().verified_stmt(r#"ALTER TABLE foo ADD CONSTRAINT "bar" PRIMARY KEY (baz)"#);
-    //TODO verified_stmt(r#"UPDATE foo SET "bar" = 5"#);
+    pg().verified_stmt(r#"UPDATE foo SET "bar" = 5"#);
+}
+
+#[test]
+fn parse_update_has_keyword() {
+    pg().one_statement_parses_to(
+        r#"UPDATE test SET name=$1,
+                value=$2,
+                where=$3,
+                create=$4,
+                is_default=$5,
+                classification=$6,
+                sort=$7
+                WHERE id=$8"#,
+        r#"UPDATE test SET name = $1, value = $2, where = $3, create = $4, is_default = $5, classification = $6, sort = $7 WHERE id = $8"#
+    );
 }
 
 #[test]


### PR DESCRIPTION
Follow on to @ankrgyl 's suggestion in https://github.com/sqlparser-rs/sqlparser-rs/pull/842/files#r1149575835

I tried to clean up the tests a little both to make the current code a little nicer but also to help future contributors find the right place (and the right pattern)