### PR TITLE
Support multiple-table DELETE syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1207,10 +1207,12 @@ pub enum Statement {
     },
     /// DELETE
     Delete {
+        /// Multi tables delete are supported in mysql
+        tables: Vec<ObjectName>,
         /// FROM
-        table_name: TableFactor,
-        /// USING (Snowflake, Postgres)
-        using: Option<TableFactor>,
+        from: Vec<TableWithJoins>,
+        /// USING (Snowflake, Postgres, MySQL)
+        using: Option<Vec<TableWithJoins>>,
         /// WHERE
         selection: Option<Expr>,
         /// RETURNING
@@ -1960,14 +1962,19 @@ impl fmt::Display for Statement {
                 Ok(())
             }
             Statement::Delete {
-                table_name,
+                tables,
+                from,
                 using,
                 selection,
                 returning,
             } => {
-                write!(f, "DELETE FROM {table_name}")?;
+                write!(f, "DELETE ")?;
+                if !tables.is_empty() {
+                    write!(f, "{} ", display_comma_separated(tables))?;
+                }
+                write!(f, "FROM {}", display_comma_separated(from))?;
                 if let Some(using) = using {
-                    write!(f, " USING {using}")?;
+                    write!(f, " USING {}", display_comma_separated(using))?;
                 }
                 if let Some(selection) = selection {
                     write!(f, " WHERE {selection}")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4813,10 +4813,17 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_delete(&mut self) -> Result<Statement, ParserError> {
-        self.expect_keyword(Keyword::FROM)?;
-        let table_name = self.parse_table_factor()?;
+        let tables = if !self.parse_keyword(Keyword::FROM) {
+            let tables = self.parse_comma_separated(Parser::parse_object_name)?;
+            self.expect_keyword(Keyword::FROM)?;
+            tables
+        } else {
+            vec![]
+        };
+
+        let from = self.parse_comma_separated(Parser::parse_table_and_joins)?;
         let using = if self.parse_keyword(Keyword::USING) {
-            Some(self.parse_table_factor()?)
+            Some(self.parse_comma_separated(Parser::parse_table_and_joins)?)
         } else {
             None
         };
@@ -4833,7 +4840,8 @@ impl<'a> Parser<'a> {
         };
 
         Ok(Statement::Delete {
-            table_name,
+            tables,
+            from,
             using,
             selection,
             returning,


### PR DESCRIPTION
Add support for MySQL's [multiple-table syntax](https://dev.mysql.com/doc/refman/8.0/en/delete.html#idm45232055997024).

Closes #854.

