### PR TITLE
Add parse_multipart_identifier function to parser

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7544,6 +7544,7 @@ mod tests {
     fn test_parse_multipart_identifier_positive() {
         let dialect = TestedDialects {
             dialects: vec![Box::new(GenericDialect {})],
+            options: None,
         };
 
         // parse multipart with quotes

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4688,6 +4688,44 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse identifiers of form ident1[.identN]*
+    ///
+    /// Similar in functionality to [parse_identifiers], with difference
+    /// being this function is much more strict about parsing a valid multipart identifier, not
+    /// allowing extraneous tokens to be parsed, otherwise it fails.
+    ///
+    /// For example:
+    ///
+    /// ```rust
+    /// use sqlparser::ast::Ident;
+    /// use sqlparser::dialect::GenericDialect;
+    /// use sqlparser::parser::Parser;
+    ///
+    /// let dialect = GenericDialect {};
+    /// let expected = vec![Ident::new("one"), Ident::new("two")];
+    ///
+    /// // expected usage
+    /// let sql = "one.two";
+    /// let mut parser = Parser::new(&dialect).try_with_sql(sql).unwrap();
+    /// let actual = parser.parse_multipart_identifier().unwrap();
+    /// assert_eq!(&actual, &expected);
+    ///
+    /// // parse_identifiers is more loose on what it allows, parsing successfully
+    /// let sql = "one + two";
+    /// let mut parser = Parser::new(&dialect).try_with_sql(sql).unwrap();
+    /// let actual = parser.parse_identifiers().unwrap();
+    /// assert_eq!(&actual, &expected);
+    ///
+    /// // expected to strictly fail due to + separator
+    /// let sql = "one + two";
+    /// let mut parser = Parser::new(&dialect).try_with_sql(sql).unwrap();
+    /// let actual = parser.parse_multipart_identifier().unwrap_err();
+    /// assert_eq!(
+    ///     actual.to_string(),
+    ///     "sql parser error: Unexpected token in identifier: +"
+    /// );
+    /// ```
+    ///
+    /// [parse_identifiers]: Parser::parse_identifiers
     pub fn parse_multipart_identifier(&mut self) -> Result<Vec<Ident>, ParserError> {
         let mut idents = vec![];
 


### PR DESCRIPTION
Closes #805

To be used for parsing identifiers which when could be quoted, can get quite complex (rather than relying on simple split on dot)

Pulled from DataFusion with one change: allow whitespaces between parts in the identifier, as seems this is supported by Spark SQL and Postgres

So following idents would be parsed with the same result:

```sql
catalog.database.table

catalog . database . table
```