### PR TITLE
Add REGEXP infix operator for MySQL

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -85,6 +85,8 @@ pub enum BinaryOperator {
     BitwiseOr,
     BitwiseAnd,
     BitwiseXor,
+    // MySQL & Sqlite use `REGEXP` as an infix operator
+    Regexp,
     PGBitwiseXor,
     PGBitwiseShiftLeft,
     PGBitwiseShiftRight,
@@ -122,6 +124,7 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::BitwiseOr => f.write_str("|"),
             BinaryOperator::BitwiseAnd => f.write_str("&"),
             BinaryOperator::BitwiseXor => f.write_str("^"),
+            BinaryOperator::Regexp => f.write_str("REGEXP"),
             BinaryOperator::PGBitwiseXor => f.write_str("#"),
             BinaryOperator::PGBitwiseShiftLeft => f.write_str("<<"),
             BinaryOperator::PGBitwiseShiftRight => f.write_str(">>"),

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -10,6 +10,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 use crate::{
     ast::{BinaryOperator, Expr},
     dialect::Dialect,

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -10,7 +10,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::dialect::Dialect;
+use crate::{
+    ast::{BinaryOperator, Expr},
+    dialect::Dialect,
+    keywords::Keyword,
+};
 
 /// [MySQL](https://www.mysql.com/)
 #[derive(Debug)]
@@ -34,5 +38,23 @@ impl Dialect for MySqlDialect {
 
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
         ch == '`'
+    }
+
+    fn parse_infix(
+        &self,
+        _parser: &mut crate::parser::Parser,
+        _expr: &crate::ast::Expr,
+        _precedence: u8,
+    ) -> Option<Result<crate::ast::Expr, crate::parser::ParserError>> {
+        // Parse REGEXP as an operator
+        if _parser.parse_keyword(Keyword::REGEXP) {
+            Some(Ok(Expr::BinaryOp {
+                left: Box::new(_expr.clone()),
+                op: BinaryOperator::Regexp,
+                right: Box::new(_parser.parse_expr().unwrap()),
+            }))
+        } else {
+            None
+        }
     }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -473,6 +473,7 @@ define_keywords!(
     REFERENCES,
     REFERENCING,
     REGCLASS,
+    REGEXP,
     REGR_AVGX,
     REGR_AVGY,
     REGR_COUNT,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1980,6 +1980,8 @@ impl<'a> Parser<'a> {
     const AND_PREC: u8 = 10;
     const OR_PREC: u8 = 5;
 
+    const REGEXP_OP_PREC: u8 = 17;
+
     /// Get the precedence of the next token
     pub fn get_next_precedence(&self) -> Result<u8, ParserError> {
         // allow the dialect to override precedence logic
@@ -2029,6 +2031,7 @@ impl<'a> Parser<'a> {
             Token::Word(w) if w.keyword == Keyword::ILIKE => Ok(Self::LIKE_PREC),
             Token::Word(w) if w.keyword == Keyword::SIMILAR => Ok(Self::LIKE_PREC),
             Token::Word(w) if w.keyword == Keyword::OPERATOR => Ok(Self::BETWEEN_PREC),
+            Token::Word(w) if w.keyword == Keyword::REGEXP => Ok(Self::REGEXP_OP_PREC),
             Token::Eq
             | Token::Lt
             | Token::LtEq

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1980,8 +1980,6 @@ impl<'a> Parser<'a> {
     const AND_PREC: u8 = 10;
     const OR_PREC: u8 = 5;
 
-    const REGEXP_OP_PREC: u8 = 17;
-
     /// Get the precedence of the next token
     pub fn get_next_precedence(&self) -> Result<u8, ParserError> {
         // allow the dialect to override precedence logic
@@ -2031,7 +2029,7 @@ impl<'a> Parser<'a> {
             Token::Word(w) if w.keyword == Keyword::ILIKE => Ok(Self::LIKE_PREC),
             Token::Word(w) if w.keyword == Keyword::SIMILAR => Ok(Self::LIKE_PREC),
             Token::Word(w) if w.keyword == Keyword::OPERATOR => Ok(Self::BETWEEN_PREC),
-            Token::Word(w) if w.keyword == Keyword::REGEXP => Ok(Self::REGEXP_OP_PREC),
+            Token::Word(w) if w.keyword == Keyword::REGEXP => Ok(Self::LIKE_PREC),
             Token::Eq
             | Token::Lt
             | Token::LtEq

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1411,5 +1411,5 @@ fn parse_string_introducers() {
 #[test]
 fn parse_regexp_infix() {
     // TODO: what's the correct test here? (Is there a test which snapshots the AST?)
-    mysql().verified_stmt(r#"SELECT "foobar" REGEXP "^foo""#);
+    mysql().verified_stmt(r#"SELECT 'Michael!' REGEXP '.*';"#);
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1411,5 +1411,5 @@ fn parse_string_introducers() {
 #[test]
 fn parse_regexp_infix() {
     // TODO: what's the correct test here? (Is there a test which snapshots the AST?)
-    mysql().verified_stmt(r#"SELECT 'Michael!' REGEXP '.*';"#);
+    mysql().verified_stmt(r#"SELECT 'Michael!' REGEXP '.*'"#);
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1410,6 +1410,5 @@ fn parse_string_introducers() {
 
 #[test]
 fn parse_regexp_infix() {
-    // TODO: what's the correct test here? (Is there a test which snapshots the AST?)
     mysql().verified_stmt(r#"SELECT 'Michael!' REGEXP '.*'"#);
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1407,3 +1407,9 @@ fn parse_string_introducers() {
     mysql().one_statement_parses_to("SELECT _utf8mb4'abc'", "SELECT _utf8mb4 'abc'");
     mysql().verified_stmt("SELECT _binary 'abc', _utf8mb4 'abc'");
 }
+
+#[test]
+fn parse_regexp_infix() {
+    // TODO: what's the correct test here? (Is there a test which snapshots the AST?)
+    mysql().verified_stmt(r#"SELECT "foobar" REGEXP "^foo""#);
+}

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -256,3 +256,8 @@ fn sqlite_and_generic() -> TestedDialects {
         options: None,
     }
 }
+
+#[test]
+fn parse_regexp_infix() {
+    mysql().verified_stmt(r#"SELECT 'Michael!' REGEXP '.*'"#);
+}

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -259,5 +259,5 @@ fn sqlite_and_generic() -> TestedDialects {
 
 #[test]
 fn parse_regexp_infix() {
-    mysql().verified_stmt(r#"SELECT 'Michael!' REGEXP '.*'"#);
+    sqlite().verified_stmt(r#"SELECT 'Michael!' REGEXP '.*'"#);
 }


### PR DESCRIPTION
Would replace #868 

But couple of issues:
- I'm getting a test failure. What's the best test for this?
- Should `REGEXP` be a keyword? If not, what would we parse?
- Anything else I'm getting wrong?

