### PR TITLE
Add support for multiple expressions, order by in aggregations

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3505,7 +3505,7 @@ impl fmt::Display for ListAggOnOverflow {
 pub struct ArrayAgg {
     pub distinct: bool,
     pub expr: Box<Expr>,
-    pub order_by: Option<Box<OrderByExpr>>,
+    pub order_by: Option<Vec<OrderByExpr>>,
     pub limit: Option<Box<Expr>>,
     pub within_group: bool, // order by is used inside a within group or not
 }
@@ -3520,7 +3520,7 @@ impl fmt::Display for ArrayAgg {
         )?;
         if !self.within_group {
             if let Some(order_by) = &self.order_by {
-                write!(f, " ORDER BY {order_by}")?;
+                write!(f, " ORDER BY {}", display_comma_separated(&order_by))?;
             }
             if let Some(limit) = &self.limit {
                 write!(f, " LIMIT {limit}")?;
@@ -3529,7 +3529,7 @@ impl fmt::Display for ArrayAgg {
         write!(f, ")")?;
         if self.within_group {
             if let Some(order_by) = &self.order_by {
-                write!(f, " WITHIN GROUP (ORDER BY {order_by})")?;
+                write!(f, " WITHIN GROUP (ORDER BY {})", display_comma_separated(&order_by))?;
             }
         }
         Ok(())

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3529,7 +3529,11 @@ impl fmt::Display for ArrayAgg {
         write!(f, ")")?;
         if self.within_group {
             if let Some(order_by) = &self.order_by {
-                write!(f, " WITHIN GROUP (ORDER BY {})", display_comma_separated(&order_by))?;
+                write!(
+                    f,
+                    " WITHIN GROUP (ORDER BY {})",
+                    display_comma_separated(&order_by)
+                )?;
             }
         }
         Ok(())

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3520,7 +3520,7 @@ impl fmt::Display for ArrayAgg {
         )?;
         if !self.within_group {
             if let Some(order_by) = &self.order_by {
-                write!(f, " ORDER BY {}", display_comma_separated(&order_by))?;
+                write!(f, " ORDER BY {}", display_comma_separated(order_by))?;
             }
             if let Some(limit) = &self.limit {
                 write!(f, " LIMIT {limit}")?;
@@ -3532,7 +3532,7 @@ impl fmt::Display for ArrayAgg {
                 write!(
                     f,
                     " WITHIN GROUP (ORDER BY {})",
-                    display_comma_separated(&order_by)
+                    display_comma_separated(order_by)
                 )?;
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1369,8 +1369,7 @@ impl<'a> Parser<'a> {
         // ANSI SQL and BigQuery define ORDER BY inside function.
         if !self.dialect.supports_within_after_array_aggregation() {
             let order_by = if self.parse_keywords(&[Keyword::ORDER, Keyword::BY]) {
-                let order_by_expr = self.parse_order_by_expr()?;
-                Some(Box::new(order_by_expr))
+                Some(self.parse_comma_separated(Parser::parse_order_by_expr)?)
             } else {
                 None
             };
@@ -1393,10 +1392,13 @@ impl<'a> Parser<'a> {
         self.expect_token(&Token::RParen)?;
         let within_group = if self.parse_keywords(&[Keyword::WITHIN, Keyword::GROUP]) {
             self.expect_token(&Token::LParen)?;
-            self.expect_keywords(&[Keyword::ORDER, Keyword::BY])?;
-            let order_by_expr = self.parse_order_by_expr()?;
+            let order_by = if self.parse_keywords(&[Keyword::ORDER, Keyword::BY]) {
+                Some(self.parse_comma_separated(Parser::parse_order_by_expr)?)
+            } else {
+                None
+            };
             self.expect_token(&Token::RParen)?;
-            Some(Box::new(order_by_expr))
+            order_by
         } else {
             None
         };

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2065,6 +2065,8 @@ fn parse_array_agg_func() {
         "SELECT ARRAY_AGG(x ORDER BY x) AS a FROM T",
         "SELECT ARRAY_AGG(x ORDER BY x LIMIT 2) FROM tbl",
         "SELECT ARRAY_AGG(DISTINCT x ORDER BY x LIMIT 2) FROM tbl",
+        "SELECT ARRAY_AGG(x ORDER BY x, y) AS a FROM T",
+        "SELECT ARRAY_AGG(x ORDER BY x ASC, y DESC) AS a FROM T",
     ] {
         supported_dialects.verified_stmt(sql);
     }


### PR DESCRIPTION
Closes [#875](https://github.com/sqlparser-rs/sqlparser-rs/issues/875).
With this Pr sqlparser supports array aggregation with lexicographical ordering such as below. 
```sql
SELECT ARRAY_AGG(x ORDER BY x, y) AS a FROM T
```
Previously only single expression were supported as in below.
```sql
SELECT ARRAY_AGG(x ORDER BY x) AS a FROM T
```