### PR TITLE
truncate: table as optional keyword

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1142,6 +1142,8 @@ pub enum Statement {
         #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
         table_name: ObjectName,
         partitions: Option<Vec<Expr>>,
+        /// TABLE - optional keyword;
+        table: bool,
     },
     /// Msck (Hive)
     Msck {
@@ -1844,8 +1846,10 @@ impl fmt::Display for Statement {
             Statement::Truncate {
                 table_name,
                 partitions,
+                table,
             } => {
-                write!(f, "TRUNCATE TABLE {table_name}")?;
+                let table = if *table { "TABLE " } else { "" };
+                write!(f, "TRUNCATE {table}{table_name}")?;
                 if let Some(ref parts) = partitions {
                     if !parts.is_empty() {
                         write!(f, " PARTITION ({})", display_comma_separated(parts))?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -473,7 +473,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_truncate(&mut self) -> Result<Statement, ParserError> {
-        self.expect_keyword(Keyword::TABLE)?;
+        let table = self.parse_keyword(Keyword::TABLE);
         let table_name = self.parse_object_name()?;
         let mut partitions = None;
         if self.parse_keyword(Keyword::PARTITION) {
@@ -484,6 +484,7 @@ impl<'a> Parser<'a> {
         Ok(Statement::Truncate {
             table_name,
             partitions,
+            table,
         })
     }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2950,3 +2950,16 @@ fn parse_select_group_by_cube() {
         select.group_by
     );
 }
+
+#[test]
+fn parse_truncate() {
+    let truncate = pg_and_generic().verified_stmt("TRUNCATE db.table_name");
+    assert_eq!(
+        Statement::Truncate {
+            table_name: ObjectName(vec![Ident::new("db"), Ident::new("table_name")]),
+            partitions: None,
+            table: false
+        },
+        truncate
+    );
+}


### PR DESCRIPTION
`TABLE` is an optional keyword in Postgres: https://www.postgresql.org/docs/current/sql-truncate.html