### PR TITLE
Add support for CREATE TYPE (AS) statements

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -715,3 +715,23 @@ impl fmt::Display for ReferentialAction {
         })
     }
 }
+
+/// SQL composite type attribute definition
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct CreateTypeAttrDef {
+    pub name: Ident,
+    pub data_type: DataType,
+    pub collation: Option<ObjectName>,
+}
+
+impl fmt::Display for CreateTypeAttrDef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}", self.name, self.data_type)?;
+        if let Some(collation) = &self.collation {
+            write!(f, " COLLATE {collation}")?;
+        }
+        Ok(())
+    }
+}

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -716,17 +716,37 @@ impl fmt::Display for ReferentialAction {
     }
 }
 
-/// SQL composite type attribute definition
+/// SQL user defined type definition
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
-pub struct CreateTypeAttrDef {
+pub enum UserDefinedTypeRepresentation {
+    Composite {
+        attributes: Vec<UserDefinedTypeCompositeAttributeDef>,
+    },
+}
+
+impl fmt::Display for UserDefinedTypeRepresentation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            UserDefinedTypeRepresentation::Composite { attributes } => {
+                write!(f, "({})", display_comma_separated(attributes))
+            }
+        }
+    }
+}
+
+/// SQL user defined type attribute definition
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct UserDefinedTypeCompositeAttributeDef {
     pub name: Ident,
     pub data_type: DataType,
     pub collation: Option<ObjectName>,
 }
 
-impl fmt::Display for CreateTypeAttrDef {
+impl fmt::Display for UserDefinedTypeCompositeAttributeDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {}", self.name, self.data_type)?;
         if let Some(collation) = &self.collation {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1712,7 +1712,7 @@ pub enum Statement {
         sequence_options: Vec<SequenceOptions>,
         owned_by: Option<ObjectName>,
     },
-    /// CREATE TYPE <name>
+    /// CREATE TYPE `<name>`
     CreateType {
         name: ObjectName,
         representation: UserDefinedTypeRepresentation,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -30,8 +30,8 @@ pub use self::data_type::{
 };
 pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterTableOperation, ColumnDef, ColumnOption,
-    ColumnOptionDef, CreateTypeAttrDef, GeneratedAs, IndexType, KeyOrIndexDisplay,
-    ReferentialAction, TableConstraint,
+    ColumnOptionDef, GeneratedAs, IndexType, KeyOrIndexDisplay, ReferentialAction, TableConstraint,
+    UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation,
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
@@ -1715,7 +1715,7 @@ pub enum Statement {
     /// CREATE TYPE <name>
     CreateType {
         name: ObjectName,
-        attributes: Vec<CreateTypeAttrDef>,
+        representation: UserDefinedTypeRepresentation,
     },
 }
 
@@ -2927,12 +2927,11 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::CreateType { name, attributes } => {
-                write!(
-                    f,
-                    "CREATE TYPE {name} AS ({})",
-                    display_comma_separated(attributes)
-                )
+            Statement::CreateType {
+                name,
+                representation,
+            } => {
+                write!(f, "CREATE TYPE {name} AS {representation}")
             }
         }
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -30,7 +30,8 @@ pub use self::data_type::{
 };
 pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterTableOperation, ColumnDef, ColumnOption,
-    ColumnOptionDef, GeneratedAs, IndexType, KeyOrIndexDisplay, ReferentialAction, TableConstraint,
+    ColumnOptionDef, CreateTypeAttrDef, GeneratedAs, IndexType, KeyOrIndexDisplay,
+    ReferentialAction, TableConstraint,
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
@@ -1711,6 +1712,11 @@ pub enum Statement {
         sequence_options: Vec<SequenceOptions>,
         owned_by: Option<ObjectName>,
     },
+    /// CREATE TYPE <name>
+    CreateType {
+        name: ObjectName,
+        attributes: Vec<CreateTypeAttrDef>,
+    },
 }
 
 impl fmt::Display for Statement {
@@ -2920,6 +2926,13 @@ impl fmt::Display for Statement {
                     )?;
                 }
                 Ok(())
+            }
+            Statement::CreateType { name, attributes } => {
+                write!(
+                    f,
+                    "CREATE TYPE {name} AS ({})",
+                    display_comma_separated(attributes)
+                )
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7062,7 +7062,10 @@ impl<'a> Parser<'a> {
 
         let mut attributes = vec![];
         if !self.consume_token(&Token::LParen) || self.consume_token(&Token::RParen) {
-            return Ok(Statement::CreateType { name, attributes });
+            return Ok(Statement::CreateType {
+                name,
+                representation: UserDefinedTypeRepresentation::Composite { attributes },
+            });
         }
 
         loop {
@@ -7073,7 +7076,7 @@ impl<'a> Parser<'a> {
             } else {
                 None
             };
-            attributes.push(CreateTypeAttrDef {
+            attributes.push(UserDefinedTypeCompositeAttributeDef {
                 name: attr_name,
                 data_type: attr_data_type,
                 collation: attr_collation,
@@ -7087,7 +7090,10 @@ impl<'a> Parser<'a> {
             }
         }
 
-        Ok(Statement::CreateType { name, attributes })
+        Ok(Statement::CreateType {
+            name,
+            representation: UserDefinedTypeRepresentation::Composite { attributes },
+        })
     }
 }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7092,3 +7092,29 @@ fn parse_trailing_comma() {
 
     trailing_commas.verified_stmt("SELECT DISTINCT ON (album_id) name FROM track");
 }
+
+#[test]
+fn parse_create_type() {
+    let create_type =
+        verified_stmt("CREATE TYPE db.type_name AS (foo INT, bar TEXT COLLATE \"de_DE\")");
+    assert_eq!(
+        Statement::CreateType {
+            name: ObjectName(vec![Ident::new("db"), Ident::new("type_name")]),
+            representation: UserDefinedTypeRepresentation::Composite {
+                attributes: vec![
+                    UserDefinedTypeCompositeAttributeDef {
+                        name: Ident::new("foo"),
+                        data_type: DataType::Int(None),
+                        collation: None,
+                    },
+                    UserDefinedTypeCompositeAttributeDef {
+                        name: Ident::new("bar"),
+                        data_type: DataType::Text,
+                        collation: Some(ObjectName(vec![Ident::with_quote('\"', "de_DE")])),
+                    }
+                ]
+            }
+        },
+        create_type
+    );
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2972,27 +2972,3 @@ fn parse_truncate() {
         truncate
     );
 }
-
-#[test]
-fn parse_create_type() {
-    let create_type = pg_and_generic()
-        .verified_stmt("CREATE TYPE db.type_name AS (foo INT, bar TEXT COLLATE \"de_DE\")");
-    assert_eq!(
-        Statement::CreateType {
-            name: ObjectName(vec![Ident::new("db"), Ident::new("type_name")]),
-            attributes: vec![
-                CreateTypeAttrDef {
-                    name: Ident::new("foo"),
-                    data_type: DataType::Int(None),
-                    collation: None,
-                },
-                CreateTypeAttrDef {
-                    name: Ident::new("bar"),
-                    data_type: DataType::Text,
-                    collation: Some(ObjectName(vec![Ident::with_quote('\"', "de_DE")])),
-                }
-            ]
-        },
-        create_type
-    );
-}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2972,3 +2972,27 @@ fn parse_truncate() {
         truncate
     );
 }
+
+#[test]
+fn parse_create_type() {
+    let create_type = pg_and_generic()
+        .verified_stmt("CREATE TYPE db.type_name AS (foo INT, bar TEXT COLLATE \"de_DE\")");
+    assert_eq!(
+        Statement::CreateType {
+            name: ObjectName(vec![Ident::new("db"), Ident::new("type_name")]),
+            attributes: vec![
+                CreateTypeAttrDef {
+                    name: Ident::new("foo"),
+                    data_type: DataType::Int(None),
+                    collation: None,
+                },
+                CreateTypeAttrDef {
+                    name: Ident::new("bar"),
+                    data_type: DataType::Text,
+                    collation: Some(ObjectName(vec![Ident::with_quote('\"', "de_DE")])),
+                }
+            ]
+        },
+        create_type
+    );
+}


### PR DESCRIPTION
Hi,

This patch adds support for parsing `CREATE TYPE <name> AS (...)` (https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_11_51_user_defined_type_definition) statements. I tried my best to align the naming here with the SQL 2016 standard.

I've already introduced an enum that could be extended later to cover other types of `CREATE TYPE` statements, but that is not done here yet mostly because I only require the support for composite types at the moment, and the other statement types are a bit more complex to parse.

Any feedback welcome!