### PR TITLE
Add support for DuckDB's CREATE MACRO statements

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1580,6 +1580,32 @@ pub enum Statement {
         params: CreateFunctionBody,
     },
     /// ```sql
+    /// CREATE MACRO
+    /// ```
+    ///
+    /// Supported variants:
+    /// 1. [DuckDB](https://duckdb.org/docs/sql/statements/create_macro)
+    CreateMacro {
+        or_replace: bool,
+        temporary: bool,
+        name: ObjectName,
+        args: Option<Vec<OperateMacroArg>>,
+        expr: Expr,
+    },
+    /// ```sql
+    /// CREATE MACRO
+    /// ```
+    ///
+    /// Supported variants:
+    /// 1. [DuckDB](https://duckdb.org/docs/sql/statements/create_macro)
+    CreateTableMacro {
+        or_replace: bool,
+        temporary: bool,
+        name: ObjectName,
+        args: Option<Vec<OperateMacroArg>>,
+        query: Query,
+    },
+    /// ```sql
     /// CREATE STAGE
     /// ```
     /// See <https://docs.snowflake.com/en/sql-reference/sql/create-stage>
@@ -2096,6 +2122,44 @@ impl fmt::Display for Statement {
                     write!(f, " RETURNS {return_type}")?;
                 }
                 write!(f, "{params}")?;
+                Ok(())
+            }
+            Statement::CreateMacro {
+                or_replace,
+                temporary,
+                name,
+                args,
+                expr,
+            } => {
+                write!(
+                    f,
+                    "CREATE {or_replace}{temp}MACRO {name}",
+                    temp = if *temporary { "TEMPORARY " } else { "" },
+                    or_replace = if *or_replace { "OR REPLACE " } else { "" },
+                )?;
+                if let Some(args) = args {
+                    write!(f, "({})", display_comma_separated(args))?;
+                }
+                write!(f, " AS {expr}")?;
+                Ok(())
+            }
+            Statement::CreateTableMacro {
+                or_replace,
+                temporary,
+                name,
+                args,
+                query,
+            } => {
+                write!(
+                    f,
+                    "CREATE {or_replace}{temp}MACRO {name} ",
+                    temp = if *temporary { "TEMPORARY " } else { "" },
+                    or_replace = if *or_replace { "OR REPLACE " } else { "" },
+                )?;
+                if let Some(args) = args {
+                    write!(f, "({})", display_comma_separated(args))?;
+                }
+                write!(f, " AS TABLE {query}")?;
                 Ok(())
             }
             Statement::CreateView {
@@ -4301,6 +4365,39 @@ impl fmt::Display for CreateFunctionUsing {
             CreateFunctionUsing::File(uri) => write!(f, "FILE '{uri}'"),
             CreateFunctionUsing::Archive(uri) => write!(f, "ARCHIVE '{uri}'"),
         }
+    }
+}
+
+/// DuckDB specific feature.
+///
+/// See [Create Macro - DuckDB](https://duckdb.org/docs/sql/statements/create_macro)
+/// for more details
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct OperateMacroArg {
+    pub name: Ident,
+    pub default_expr: Option<Expr>,
+}
+
+impl OperateMacroArg {
+    /// Returns an argument with name.
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.into(),
+            default_expr: None,
+        }
+    }
+}
+
+
+impl fmt::Display for OperateMacroArg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.name)?;
+        if let Some(default_expr) = &self.default_expr {
+            write!(f, " := {default_expr}")?;
+        }
+        Ok(())
     }
 }
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -347,6 +347,7 @@ define_keywords!(
     LOCKED,
     LOGIN,
     LOWER,
+    MACRO,
     MANAGEDLOCATION,
     MATCH,
     MATCHED,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -114,6 +114,8 @@ pub enum Token {
     Colon,
     /// DoubleColon `::` (used for casting in postgresql)
     DoubleColon,
+    /// Assignment `:=` (used for keyword argument in DuckDB macros)
+    DuckAssignment,
     /// SemiColon `;` used as separator for COPY and payload
     SemiColon,
     /// Backslash `\` used in terminating the COPY payload with `\.`
@@ -222,6 +224,7 @@ impl fmt::Display for Token {
             Token::Period => f.write_str("."),
             Token::Colon => f.write_str(":"),
             Token::DoubleColon => f.write_str("::"),
+            Token::DuckAssignment => f.write_str(":="),
             Token::SemiColon => f.write_str(";"),
             Token::Backslash => f.write_str("\\"),
             Token::LBracket => f.write_str("["),
@@ -847,6 +850,7 @@ impl<'a> Tokenizer<'a> {
                     chars.next();
                     match chars.peek() {
                         Some(':') => self.consume_and_return(chars, Token::DoubleColon),
+                        Some('=') => self.consume_and_return(chars, Token::DuckAssignment),
                         _ => Ok(Some(Token::Colon)),
                     }
                 }


### PR DESCRIPTION
- support scalar and table macros
- separate from related but different and already complex functions
  parsing to avoid plenty of runtime dialect switches