### PR TITLE
fix: unary negation operator with operators: `Mul`, `Div` and `Mod`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -794,7 +794,7 @@ impl<'a> Parser<'a> {
                 };
                 Ok(Expr::UnaryOp {
                     op,
-                    expr: Box::new(self.parse_subexpr(Self::PLUS_MINUS_PREC)?),
+                    expr: Box::new(self.parse_subexpr(Self::MUL_DIV_MOD_OP_PREC)?),
                 })
             }
             tok @ Token::DoubleExclamationMark
@@ -1959,6 +1959,7 @@ impl<'a> Parser<'a> {
     }
 
     // use https://www.postgresql.org/docs/7.0/operators.htm#AEN2026 as a reference
+    const MUL_DIV_MOD_OP_PREC: u8 = 40;
     const PLUS_MINUS_PREC: u8 = 30;
     const XOR_PREC: u8 = 24;
     const TIME_ZONE_PREC: u8 = 20;
@@ -1968,8 +1969,6 @@ impl<'a> Parser<'a> {
     const UNARY_NOT_PREC: u8 = 15;
     const AND_PREC: u8 = 10;
     const OR_PREC: u8 = 5;
-
-    const DIV_OP_PREC: u8 = 40;
 
     /// Get the precedence of the next token
     pub fn get_next_precedence(&self) -> Result<u8, ParserError> {
@@ -2020,7 +2019,7 @@ impl<'a> Parser<'a> {
             Token::Word(w) if w.keyword == Keyword::ILIKE => Ok(Self::LIKE_PREC),
             Token::Word(w) if w.keyword == Keyword::SIMILAR => Ok(Self::LIKE_PREC),
             Token::Word(w) if w.keyword == Keyword::OPERATOR => Ok(Self::BETWEEN_PREC),
-            Token::Word(w) if w.keyword == Keyword::DIV => Ok(Self::DIV_OP_PREC),
+            Token::Word(w) if w.keyword == Keyword::DIV => Ok(Self::MUL_DIV_MOD_OP_PREC),
             Token::Eq
             | Token::Lt
             | Token::LtEq
@@ -2038,7 +2037,7 @@ impl<'a> Parser<'a> {
             Token::Ampersand => Ok(23),
             Token::Plus | Token::Minus => Ok(Self::PLUS_MINUS_PREC),
             Token::Mul | Token::Div | Token::DuckIntDiv | Token::Mod | Token::StringConcat => {
-                Ok(40)
+                Ok(Self::MUL_DIV_MOD_OP_PREC)
             }
             Token::DoubleColon => Ok(50),
             Token::Colon => Ok(50),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1074,7 +1074,7 @@ fn parse_compound_expr_2() {
 }
 
 #[test]
-fn parse_unary_math() {
+fn parse_unary_math_with_plus() {
     use self::Expr::*;
     let sql = "-a + -b";
     assert_eq!(
@@ -1084,6 +1084,26 @@ fn parse_unary_math() {
                 expr: Box::new(Identifier(Ident::new("a"))),
             }),
             op: BinaryOperator::Plus,
+            right: Box::new(UnaryOp {
+                op: UnaryOperator::Minus,
+                expr: Box::new(Identifier(Ident::new("b"))),
+            }),
+        },
+        verified_expr(sql)
+    );
+}
+
+#[test]
+fn parse_unary_math_with_multiply() {
+    use self::Expr::*;
+    let sql = "-a * -b";
+    assert_eq!(
+        BinaryOp {
+            left: Box::new(UnaryOp {
+                op: UnaryOperator::Minus,
+                expr: Box::new(Identifier(Ident::new("a"))),
+            }),
+            op: BinaryOperator::Multiply,
             right: Box::new(UnaryOp {
                 op: UnaryOperator::Minus,
                 expr: Box::new(Identifier(Ident::new("b"))),


### PR DESCRIPTION
One part of https://github.com/apache/arrow-datafusion/issues/6649.
Unary operator does not work correctly with operators: `Mul`, `Div` and `Mod`.
For example (Arrow-Datafusion):
```
❯ select - 1234 % 12 % 3 * 1545 % 23;
+------------------------------------------------------------------+
| (- Int64(1234) % Int64(12) % Int64(3) * Int64(1545) % Int64(23)) |
+------------------------------------------------------------------+
| -4                                                               |
+------------------------------------------------------------------+
1 row in set. Query took 0.023 seconds.
```
But should be:
```
❯ select - 1234 % 12 % 3 * 1545 % 23;
+------------------------------------------------------------------+
| (- Int64(1234) % Int64(12) % Int64(3) * Int64(1545) % Int64(23)) |
+------------------------------------------------------------------+
| -17                                                              |
+------------------------------------------------------------------+
1 row in set. Query took 0.023 seconds.
```

The main problem is the wrong precedence (See https://github.com/sqlparser-rs/sqlparser-rs/blob/main/src/parser.rs#L797)