### PR TITLE
Support `DROP TEMPORARY TABLE`, MySQL syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1401,6 +1401,8 @@ pub enum Statement {
         /// Hive allows you specify whether the table's stored data will be
         /// deleted along with the dropped table
         purge: bool,
+        /// MySQL-specific "TEMPORARY" keyword
+        temporary: bool,
     },
     /// DROP Function
     DropFunction {
@@ -2565,9 +2567,11 @@ impl fmt::Display for Statement {
                 cascade,
                 restrict,
                 purge,
+                temporary,
             } => write!(
                 f,
-                "DROP {}{} {}{}{}{}",
+                "DROP {}{}{} {}{}{}{}",
+                if *temporary { "TEMPORARY " } else { "" },
                 object_type,
                 if *if_exists { " IF EXISTS" } else { "" },
                 display_comma_separated(names),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3126,6 +3126,10 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_drop(&mut self) -> Result<Statement, ParserError> {
+        // MySQL dialect supports `TEMPORARY`
+        let temporary = dialect_of!(self is MySqlDialect | GenericDialect)
+            && self.parse_keyword(Keyword::TEMPORARY);
+
         let object_type = if self.parse_keyword(Keyword::TABLE) {
             ObjectType::Table
         } else if self.parse_keyword(Keyword::VIEW) {
@@ -3168,6 +3172,7 @@ impl<'a> Parser<'a> {
             cascade,
             restrict,
             purge,
+            temporary,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -5400,6 +5400,7 @@ fn parse_drop_table() {
             names,
             cascade,
             purge: _,
+            temporary,
             ..
         } => {
             assert!(!if_exists);
@@ -5409,6 +5410,7 @@ fn parse_drop_table() {
                 names.iter().map(ToString::to_string).collect::<Vec<_>>()
             );
             assert!(!cascade);
+            assert!(!temporary);
         }
         _ => unreachable!(),
     }
@@ -5421,6 +5423,7 @@ fn parse_drop_table() {
             names,
             cascade,
             purge: _,
+            temporary,
             ..
         } => {
             assert!(if_exists);
@@ -5430,6 +5433,7 @@ fn parse_drop_table() {
                 names.iter().map(ToString::to_string).collect::<Vec<_>>()
             );
             assert!(cascade);
+            assert!(!temporary);
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1597,3 +1597,29 @@ fn parse_string_introducers() {
 fn parse_div_infix() {
     mysql().verified_stmt(r#"SELECT 5 DIV 2"#);
 }
+
+#[test]
+fn parse_drop_temporary_table() {
+    let sql = "DROP TEMPORARY TABLE foo";
+    match mysql().verified_stmt(sql) {
+        Statement::Drop {
+            object_type,
+            if_exists,
+            names,
+            cascade,
+            purge: _,
+            temporary,
+            ..
+        } => {
+            assert!(!if_exists);
+            assert_eq!(ObjectType::Table, object_type);
+            assert_eq!(
+                vec!["foo"],
+                names.iter().map(ToString::to_string).collect::<Vec<_>>()
+            );
+            assert!(!cascade);
+            assert!(temporary);
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
Hi,

This PR adds support for MySQL DROP TEMPORARY TABLE syntax.
