### PR TITLE
feat: comments for all operators

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -28,8 +28,11 @@ use super::display_separated;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum UnaryOperator {
+    /// Plus, e.g. `+9`
     Plus,
+    /// Minus, e.g. `-9`
     Minus,
+    /// Not, e.g. `NOT(true)`
     Not,
     /// Bitwise Not, e.g. `~9` (PostgreSQL-specific)
     PGBitwiseNot,
@@ -66,24 +69,43 @@ impl fmt::Display for UnaryOperator {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum BinaryOperator {
+    /// Plus, e.g. `a + b`
     Plus,
+    /// Minus, e.g. `a - b`
     Minus,
+    /// Multiply, e.g. `a * b`
     Multiply,
+    /// Divide, e.g. `a / b`
     Divide,
+    /// Modulo, e.g. `a % b`
     Modulo,
+    /// String/Array Concat operator, e.g. `a || b`
     StringConcat,
+    /// Greater than, e.g. `a > b`
     Gt,
+    /// Less than, e.g. `a < b`
     Lt,
+    /// Greater equal, e.g. `a >= b`
     GtEq,
+    /// Less equal, e.g. `a <= b`
     LtEq,
+    /// Spaceship, e.g. `a <=> b`
     Spaceship,
+    /// Equal, e.g. `a = b`
     Eq,
+    /// Not equal, e.g. `a <> b`
     NotEq,
+    /// And, e.g. `a AND b`
     And,
+    /// Or, e.g. `a OR b`
     Or,
+    /// XOR, e.g. `a XOR b`
     Xor,
+    /// Bitwise or, e.g. `a | b`
     BitwiseOr,
+    /// Bitwise and, e.g. `a & b`
     BitwiseAnd,
+    /// Bitwise XOR, e.g. `a ^ b`
     BitwiseXor,
     /// Integer division operator `//` in DuckDB
     DuckIntegerDivide,
@@ -91,14 +113,23 @@ pub enum BinaryOperator {
     MyIntegerDivide,
     /// Support for custom operators (built by parsers outside this crate)
     Custom(String),
+    /// Bitwise XOR, e.g. `a # b` (PostgreSQL-specific)
     PGBitwiseXor,
+    /// Bitwise shift left, e.g. `a << b` (PostgreSQL-specific)
     PGBitwiseShiftLeft,
+    /// Bitwise shift right, e.g. `a >> b` (PostgreSQL-specific)
     PGBitwiseShiftRight,
+    /// Exponent, e.g. `a ^ b` (PostgreSQL-specific)
     PGExp,
+    /// Overlap operator, e.g. `a && b` (PostgreSQL-specific)
     PGOverlap,
+    /// String matches regular expression (case sensitively), e.g. `a ~ b` (PostgreSQL-specific)
     PGRegexMatch,
+    /// String matches regular expression (case insensitively), e.g. `a ~* b` (PostgreSQL-specific)
     PGRegexIMatch,
+    /// String does not match regular expression (case sensitively), e.g. `a !~ b` (PostgreSQL-specific)
     PGRegexNotMatch,
+    /// String does not match regular expression (case insensitively), e.g. `a !~* b` (PostgreSQL-specific)
     PGRegexNotIMatch,
     /// PostgreSQL-specific custom operator.
     ///


### PR DESCRIPTION
Adding comments for all unary and binary operators to be more clear about the operator itself.