### PR TITLE
Upgrade bigdecimal to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ json_example = ["serde_json", "serde"]
 visitor = ["sqlparser_derive"]
 
 [dependencies]
-bigdecimal = { version = "0.3", features = ["serde"], optional = true }
+bigdecimal = { version = "0.4.1", features = ["serde"], optional = true }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
 # serde_json is only used in examples/cli, but we have to put it outside


### PR DESCRIPTION
Crate bigdecimal released 0.4.1

In the latest version, BigDecimal can parse i128, u128. 
So i think users prefer to use latest version of bigdecimal.