### PR TITLE
Fix "BEGIN TRANSACTION" being serialized as "START TRANSACTION"

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1541,7 +1541,10 @@ pub enum Statement {
     /// Note: This is a MySQL-specific statement.
     Use { db_name: Ident },
     /// `{ BEGIN [ TRANSACTION | WORK ] | START TRANSACTION } ...`
-    StartTransaction { modes: Vec<TransactionMode> },
+    StartTransaction {
+        modes: Vec<TransactionMode>,
+        syntax_begin: bool,
+    },
     /// `SET TRANSACTION ...`
     SetTransaction {
         modes: Vec<TransactionMode>,
@@ -2720,8 +2723,15 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::StartTransaction { modes } => {
-                write!(f, "START TRANSACTION")?;
+            Statement::StartTransaction {
+                modes,
+                syntax_begin,
+            } => {
+                if *syntax_begin {
+                    write!(f, "BEGIN TRANSACTION")?;
+                } else {
+                    write!(f, "START TRANSACTION")?;
+                }
                 if !modes.is_empty() {
                     write!(f, " {}", display_comma_separated(modes))?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1540,10 +1540,14 @@ pub enum Statement {
     ///
     /// Note: This is a MySQL-specific statement.
     Use { db_name: Ident },
-    /// `{ BEGIN [ TRANSACTION | WORK ] | START TRANSACTION } ...`
+    /// `START  [ TRANSACTION | WORK ] | START TRANSACTION } ...`
+    /// If `begin` is false.
+    ///
+    /// `BEGIN  [ TRANSACTION | WORK ] | START TRANSACTION } ...`
+    /// If `begin` is true
     StartTransaction {
         modes: Vec<TransactionMode>,
-        syntax_begin: bool,
+        begin: bool,
     },
     /// `SET TRANSACTION ...`
     SetTransaction {
@@ -2725,7 +2729,7 @@ impl fmt::Display for Statement {
             }
             Statement::StartTransaction {
                 modes,
-                syntax_begin,
+                begin: syntax_begin,
             } => {
                 if *syntax_begin {
                     write!(f, "BEGIN TRANSACTION")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6877,7 +6877,7 @@ impl<'a> Parser<'a> {
         self.expect_keyword(Keyword::TRANSACTION)?;
         Ok(Statement::StartTransaction {
             modes: self.parse_transaction_modes()?,
-            syntax_begin: false,
+            begin: false,
         })
     }
 
@@ -6885,7 +6885,7 @@ impl<'a> Parser<'a> {
         let _ = self.parse_one_of_keywords(&[Keyword::TRANSACTION, Keyword::WORK]);
         Ok(Statement::StartTransaction {
             modes: self.parse_transaction_modes()?,
-            syntax_begin: true,
+            begin: true,
         })
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6877,6 +6877,7 @@ impl<'a> Parser<'a> {
         self.expect_keyword(Keyword::TRANSACTION)?;
         Ok(Statement::StartTransaction {
             modes: self.parse_transaction_modes()?,
+            syntax_begin: false,
         })
     }
 
@@ -6884,6 +6885,7 @@ impl<'a> Parser<'a> {
         let _ = self.parse_one_of_keywords(&[Keyword::TRANSACTION, Keyword::WORK]);
         Ok(Statement::StartTransaction {
             modes: self.parse_transaction_modes()?,
+            syntax_begin: true,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -5732,7 +5732,7 @@ fn lateral_derived() {
 #[test]
 fn parse_start_transaction() {
     match verified_stmt("START TRANSACTION READ ONLY, READ WRITE, ISOLATION LEVEL SERIALIZABLE") {
-        Statement::StartTransaction { modes } => assert_eq!(
+        Statement::StartTransaction { modes, .. } => assert_eq!(
             modes,
             vec![
                 TransactionMode::AccessMode(TransactionAccessMode::ReadOnly),
@@ -5749,7 +5749,7 @@ fn parse_start_transaction() {
         "START TRANSACTION READ ONLY READ WRITE ISOLATION LEVEL SERIALIZABLE",
         "START TRANSACTION READ ONLY, READ WRITE, ISOLATION LEVEL SERIALIZABLE",
     ) {
-        Statement::StartTransaction { modes } => assert_eq!(
+        Statement::StartTransaction { modes, .. } => assert_eq!(
             modes,
             vec![
                 TransactionMode::AccessMode(TransactionAccessMode::ReadOnly),
@@ -5761,9 +5761,9 @@ fn parse_start_transaction() {
     }
 
     verified_stmt("START TRANSACTION");
-    one_statement_parses_to("BEGIN", "START TRANSACTION");
-    one_statement_parses_to("BEGIN WORK", "START TRANSACTION");
-    one_statement_parses_to("BEGIN TRANSACTION", "START TRANSACTION");
+    one_statement_parses_to("BEGIN", "BEGIN TRANSACTION");
+    one_statement_parses_to("BEGIN WORK", "BEGIN TRANSACTION");
+    one_statement_parses_to("BEGIN TRANSACTION", "BEGIN TRANSACTION");
 
     verified_stmt("START TRANSACTION ISOLATION LEVEL READ UNCOMMITTED");
     verified_stmt("START TRANSACTION ISOLATION LEVEL READ COMMITTED");


### PR DESCRIPTION
"START TRANSACTION" is not valid in SQLite, which means that valid
SQLite SQL code, when parsed and re-serialized by sqlparser, would become invalid.

Fixes #919
