### PR TITLE
Fix: use Rust idiomatic capitalization for newly added `DataType` enums

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -145,16 +145,16 @@ pub enum DataType {
     Int8(Option<u64>),
     /// Unsigned Int8 with optional display width e.g. INT8 UNSIGNED or INT8(11) UNSIGNED
     UnsignedInt8(Option<u64>),
-    /// FLOAT4 as alias for Real in [postgresql]
+    /// Float4 as alias for Real in [postgresql]
     ///
     /// [postgresql]: https://www.postgresql.org/docs/15/datatype.html
-    FLOAT4,
+    Float4,
     /// Floating point e.g. REAL
     Real,
-    /// FLOAT8 as alias for Double in [postgresql]
+    /// Float8 as alias for Double in [postgresql]
     ///
     /// [postgresql]: https://www.postgresql.org/docs/15/datatype.html
-    FLOAT8,
+    Float8,
     /// Double
     Double,
     /// Double PRECISION e.g. [standard], [postgresql]
@@ -296,9 +296,9 @@ impl fmt::Display for DataType {
                 format_type_with_optional_length(f, "INT8", zerofill, true)
             }
             DataType::Real => write!(f, "REAL"),
-            DataType::FLOAT4 => write!(f, "FLOAT4"),
+            DataType::Float4 => write!(f, "FLOAT4"),
             DataType::Double => write!(f, "DOUBLE"),
-            DataType::FLOAT8 => write!(f, "FLOAT8"),
+            DataType::Float8 => write!(f, "FLOAT8"),
             DataType::DoublePrecision => write!(f, "DOUBLE PRECISION"),
             DataType::Bool => write!(f, "BOOL"),
             DataType::Boolean => write!(f, "BOOLEAN"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4563,8 +4563,8 @@ impl<'a> Parser<'a> {
                 Keyword::BOOL => Ok(DataType::Bool),
                 Keyword::FLOAT => Ok(DataType::Float(self.parse_optional_precision()?)),
                 Keyword::REAL => Ok(DataType::Real),
-                Keyword::FLOAT4 => Ok(DataType::FLOAT4),
-                Keyword::FLOAT8 => Ok(DataType::FLOAT8),
+                Keyword::FLOAT4 => Ok(DataType::Float4),
+                Keyword::FLOAT8 => Ok(DataType::Float8),
                 Keyword::DOUBLE => {
                     if self.parse_keyword(Keyword::PRECISION) {
                         Ok(DataType::DoublePrecision)

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2993,13 +2993,13 @@ fn parse_create_table_with_alias() {
                     },
                     ColumnDef {
                         name: "float8_col".into(),
-                        data_type: DataType::FLOAT8,
+                        data_type: DataType::Float8,
                         collation: None,
                         options: vec![]
                     },
                     ColumnDef {
                         name: "float4_col".into(),
-                        data_type: DataType::FLOAT4,
+                        data_type: DataType::Float4,
                         collation: None,
                         options: vec![]
                     },


### PR DESCRIPTION
In my previous commit https://github.com/sqlparser-rs/sqlparser-rs/issues/931 , I think the handling of case for the PostgreSQL type aliases is incorrect. We should modify it to  first letter capitalized 