### PR TITLE
feat: add `ALTER ROLE` syntax of PostgreSQL and MS SQL Server

### DIFF
--- a/src/ast/dcl.rs
+++ b/src/ast/dcl.rs
@@ -1,0 +1,84 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! AST types specific to GRANT/REVOKE/ROLE variants of [`Statement`](crate::ast::Statement)
+//! (commonly referred to as Data Control Language, or DCL)
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::fmt;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "visitor")]
+use sqlparser_derive::{Visit, VisitMut};
+
+use crate::ast::ObjectName;
+
+/// An option in `ROLE` statement.
+///
+/// <https://www.postgresql.org/docs/current/sql-createrole.html>
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum RoleOption {
+    SuperUser(bool),
+    CreateDB(bool),
+    BypassRls(bool),
+}
+
+impl fmt::Display for RoleOption {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RoleOption::SuperUser(value) => {
+                write!(f, "{}", if *value { "SUPERUSER" } else { "NOSUPERUSER" })
+            }
+            RoleOption::CreateDB(value) => {
+                write!(f, "{}", if *value { "CREATEDB" } else { "NOCREATEDB" })
+            }
+            RoleOption::BypassRls(value) => {
+                write!(f, "{}", if *value { "BYPASSRLS" } else { "NOBYPASSRLS" })
+            }
+        }
+    }
+}
+
+/// An `ALTER ROLE` (`Statement::AlterRole`) operation
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum AlterRoleOperation {
+    RenameRole { role_name: ObjectName },
+    WithOptions { options: Vec<RoleOption> },
+}
+
+impl fmt::Display for AlterRoleOperation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AlterRoleOperation::RenameRole { role_name } => {
+                write!(f, "RENAME TO {role_name}")
+            }
+            AlterRoleOperation::WithOptions { options } => {
+                write!(
+                    f,
+                    "WITH {}",
+                    options
+                        .iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                )
+            }
+        }
+    }
+}

--- a/src/ast/dcl.rs
+++ b/src/ast/dcl.rs
@@ -14,7 +14,7 @@
 //! (commonly referred to as Data Control Language, or DCL)
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::fmt;
 
 #[cfg(feature = "serde")]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1402,7 +1402,7 @@ pub enum Statement {
     },
     /// ALTER ROLE
     AlterRole {
-        name: ObjectName,
+        name: Ident,
         operation: AlterRoleOperation,
     },
     /// DROP

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -28,6 +28,7 @@ use sqlparser_derive::{Visit, VisitMut};
 pub use self::data_type::{
     CharLengthUnits, CharacterLength, DataType, ExactNumberInfo, TimezoneInfo,
 };
+pub use self::dcl::{AlterRoleOperation, RoleOption};
 pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterTableOperation, ColumnDef, ColumnOption,
     ColumnOptionDef, GeneratedAs, IndexType, KeyOrIndexDisplay, ProcedureParam, ReferentialAction,
@@ -52,6 +53,7 @@ use crate::ast::helpers::stmt_data_loading::{
 pub use visitor::*;
 
 mod data_type;
+mod dcl;
 mod ddl;
 pub mod helpers;
 mod operator;
@@ -1398,6 +1400,11 @@ pub enum Statement {
         query: Box<Query>,
         with_options: Vec<SqlOption>,
     },
+    /// ALTER ROLE
+    AlterRole {
+        name: ObjectName,
+        operation: AlterRoleOperation,
+    },
     /// DROP
     Drop {
         /// The type of the object to drop: TABLE, VIEW, etc.
@@ -2584,6 +2591,9 @@ impl fmt::Display for Statement {
                     write!(f, " ({})", display_comma_separated(columns))?;
                 }
                 write!(f, " AS {query}")
+            }
+            Statement::AlterRole { name, operation } => {
+                write!(f, "ALTER ROLE {name} {operation}")
             }
             Statement::Drop {
                 object_type,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -28,7 +28,7 @@ use sqlparser_derive::{Visit, VisitMut};
 pub use self::data_type::{
     CharLengthUnits, CharacterLength, DataType, ExactNumberInfo, TimezoneInfo,
 };
-pub use self::dcl::{AlterRoleOperation, RoleOption};
+pub use self::dcl::{AlterRoleOperation, ResetConfig, RoleOption, SetConfigValue};
 pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterTableOperation, ColumnDef, ColumnOption,
     ColumnOptionDef, GeneratedAs, IndexType, KeyOrIndexDisplay, ProcedureParam, ReferentialAction,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -508,6 +508,7 @@ define_keywords!(
     REPEATABLE,
     REPLACE,
     REPLICATION,
+    RESET,
     RESTRICT,
     RESULT,
     RETAIN,

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -10,7 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! SQL Parser for role
+//! SQL Parser for ALTER
 
 use super::{Parser, ParserError};
 use crate::{

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -12,6 +12,9 @@
 
 //! SQL Parser for ALTER
 
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+
 use super::{Parser, ParserError};
 use crate::{
     ast::{AlterRoleOperation, Expr, Password, ResetConfig, RoleOption, SetConfigValue, Statement},
@@ -29,7 +32,7 @@ impl<'a> Parser<'a> {
         }
 
         Err(ParserError::ParserError(
-            "ALTER ROLE is only support for PostgreSqlDialect, MsSqlDialect".to_string(),
+            "ALTER ROLE is only support for PostgreSqlDialect, MsSqlDialect".into(),
         ))
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -33,6 +33,8 @@ use crate::dialect::*;
 use crate::keywords::{self, Keyword};
 use crate::tokenizer::*;
 
+mod role;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParserError {
     TokenizerError(String),
@@ -3990,8 +3992,12 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_alter(&mut self) -> Result<Statement, ParserError> {
-        let object_type =
-            self.expect_one_of_keywords(&[Keyword::VIEW, Keyword::TABLE, Keyword::INDEX])?;
+        let object_type = self.expect_one_of_keywords(&[
+            Keyword::VIEW,
+            Keyword::TABLE,
+            Keyword::INDEX,
+            Keyword::ROLE,
+        ])?;
         match object_type {
             Keyword::VIEW => self.parse_alter_view(),
             Keyword::TABLE => {
@@ -4186,6 +4192,7 @@ impl<'a> Parser<'a> {
                     operation,
                 })
             }
+            Keyword::ROLE => self.parse_alter_role(),
             // unreachable because expect_one_of_keywords used above
             _ => unreachable!(),
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -33,7 +33,7 @@ use crate::dialect::*;
 use crate::keywords::{self, Keyword};
 use crate::tokenizer::*;
 
-mod role;
+mod alter;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParserError {

--- a/src/parser/role.rs
+++ b/src/parser/role.rs
@@ -1,0 +1,90 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SQL Parser for role
+
+use super::{Parser, ParserError};
+use crate::{
+    ast::{AlterRoleOperation, RoleOption, Statement},
+    keywords::Keyword,
+};
+
+impl<'a> Parser<'a> {
+    pub fn parse_alter_role(&mut self) -> Result<Statement, ParserError> {
+        let role_name = self.parse_object_name()?;
+
+        // [ IN DATABASE _`database_name`_ ]
+        let database_name = if self.parse_keywords(&[Keyword::IN, Keyword::DATABASE]) {
+            self.parse_object_name().ok()
+        } else {
+            None
+        };
+
+        let operation = if self.parse_keyword(Keyword::RENAME) {
+            if self.parse_keyword(Keyword::TO) {
+                let role_name = self.parse_object_name()?;
+                AlterRoleOperation::RenameRole { role_name }
+            } else {
+                return self.expected("TO after RENAME", self.peek_token());
+            }
+        // } else if self.parse_keyword(Keyword::SET) {
+        //     let config_param = self.parse_identifier()?;
+        // self.parse_one_of_keywords(&[Keyword::TO, Keyword::QUALIFY]);
+        // AlterRoleOperation::RenameRole { role_name }
+        } else {
+            // [ WITH ]
+            let _ = self.parse_keyword(Keyword::WITH);
+            // option
+            let mut options = vec![];
+            while let Some(opt) = self.maybe_parse(|parser| parser.parse_role_option()) {
+                options.push(opt);
+            }
+            println!("with options: {options:#?}");
+            AlterRoleOperation::WithOptions { options }
+        };
+
+        Ok(Statement::AlterRole {
+            name: role_name,
+            operation,
+        })
+    }
+
+    fn parse_role_option(&mut self) -> Result<RoleOption, ParserError> {
+        let option = match self.parse_one_of_keywords(&[
+            Keyword::BYPASSRLS,
+            Keyword::NOBYPASSRLS,
+            Keyword::CONNECTION,
+            Keyword::CREATEDB,
+            Keyword::NOCREATEDB,
+            Keyword::CREATEROLE,
+            Keyword::NOCREATEROLE,
+            Keyword::INHERIT,
+            Keyword::NOINHERIT,
+            Keyword::LOGIN,
+            Keyword::NOLOGIN,
+            Keyword::PASSWORD,
+            Keyword::REPLICATION,
+            Keyword::NOREPLICATION,
+            Keyword::SUPERUSER,
+            Keyword::NOSUPERUSER,
+            Keyword::VALID,
+        ]) {
+            Some(Keyword::BYPASSRLS) => RoleOption::BypassRls(true),
+            Some(Keyword::NOBYPASSRLS) => RoleOption::BypassRls(false),
+            Some(Keyword::CREATEDB) => RoleOption::CreateDB(true),
+            Some(Keyword::NOCREATEDB) => RoleOption::CreateDB(false),
+            _ => self.expected("option", self.peek_token())?,
+        };
+
+        Ok(option)
+    }
+}

--- a/src/parser/role.rs
+++ b/src/parser/role.rs
@@ -15,15 +15,55 @@
 use super::{Parser, ParserError};
 use crate::{
     ast::{AlterRoleOperation, RoleOption, Statement},
+    dialect::{MsSqlDialect, PostgreSqlDialect},
     keywords::Keyword,
+    tokenizer::Token,
 };
 
 impl<'a> Parser<'a> {
     pub fn parse_alter_role(&mut self) -> Result<Statement, ParserError> {
+        if dialect_of!(self is PostgreSqlDialect) {
+            return self.parse_pg_alter_role();
+        } else if dialect_of!(self is MsSqlDialect) {
+            return self.parse_mssql_alter_role();
+        }
+
+        Err(ParserError::ParserError(
+            "ALTER ROLE is only support for PostgreSqlDialect, MsSqlDialect".to_string(),
+        ))
+    }
+
+    fn parse_mssql_alter_role(&mut self) -> Result<Statement, ParserError> {
+        let role_name = self.parse_object_name()?;
+
+        let operation = if self.parse_keywords(&[Keyword::ADD, Keyword::MEMBER]) {
+            let member_name = self.parse_object_name()?;
+            AlterRoleOperation::AddMember { member_name }
+        } else if self.parse_keywords(&[Keyword::DROP, Keyword::MEMBER]) {
+            let member_name = self.parse_object_name()?;
+            AlterRoleOperation::DropMember { member_name }
+        } else if self.parse_keywords(&[Keyword::WITH, Keyword::NAME]) {
+            if self.consume_token(&Token::Eq) {
+                let role_name = self.parse_object_name()?;
+                AlterRoleOperation::RenameRole { role_name }
+            } else {
+                return self.expected("= after WITH NAME ", self.peek_token());
+            }
+        } else {
+            return self.expected("TO after RENAME", self.peek_token());
+        };
+
+        Ok(Statement::AlterRole {
+            name: role_name,
+            operation,
+        })
+    }
+
+    fn parse_pg_alter_role(&mut self) -> Result<Statement, ParserError> {
         let role_name = self.parse_object_name()?;
 
         // [ IN DATABASE _`database_name`_ ]
-        let database_name = if self.parse_keywords(&[Keyword::IN, Keyword::DATABASE]) {
+        let in_database = if self.parse_keywords(&[Keyword::IN, Keyword::DATABASE]) {
             self.parse_object_name().ok()
         } else {
             None
@@ -36,19 +76,65 @@ impl<'a> Parser<'a> {
             } else {
                 return self.expected("TO after RENAME", self.peek_token());
             }
-        // } else if self.parse_keyword(Keyword::SET) {
-        //     let config_param = self.parse_identifier()?;
-        // self.parse_one_of_keywords(&[Keyword::TO, Keyword::QUALIFY]);
-        // AlterRoleOperation::RenameRole { role_name }
+        // SET
+        } else if self.parse_keyword(Keyword::SET) {
+            let config_param = self.parse_object_name()?;
+            // FROM CURRENT
+            if self.parse_keywords(&[Keyword::FROM, Keyword::CURRENT]) {
+                AlterRoleOperation::Set {
+                    config_param,
+                    default_value: false,
+                    from_current: true,
+                    in_database,
+                    value: None,
+                }
+            // { TO | = } { value | DEFAULT }
+            } else if self.consume_token(&Token::Eq) || self.parse_keyword(Keyword::TO) {
+                if self.parse_keyword(Keyword::DEFAULT) {
+                    AlterRoleOperation::Set {
+                        config_param,
+                        default_value: true,
+                        from_current: false,
+                        in_database,
+                        value: None,
+                    }
+                } else if let Ok(expr) = self.parse_expr() {
+                    AlterRoleOperation::Set {
+                        config_param,
+                        default_value: false,
+                        from_current: false,
+                        in_database,
+                        value: Some(expr),
+                    }
+                } else {
+                    self.expected("variable value", self.peek_token())?
+                }
+            } else {
+                self.expected("variable value", self.peek_token())?
+            }
+        // RESET
+        } else if self.parse_keyword(Keyword::RESET) {
+            if self.parse_keyword(Keyword::ALL) {
+                AlterRoleOperation::Reset {
+                    config_param: None,
+                    all: true,
+                }
+            } else {
+                let config_param = self.parse_object_name()?;
+                AlterRoleOperation::Reset {
+                    config_param: Some(config_param),
+                    all: false,
+                }
+            }
+        // option
         } else {
             // [ WITH ]
             let _ = self.parse_keyword(Keyword::WITH);
             // option
             let mut options = vec![];
-            while let Some(opt) = self.maybe_parse(|parser| parser.parse_role_option()) {
+            while let Some(opt) = self.maybe_parse(|parser| parser.parse_pg_role_option()) {
                 options.push(opt);
             }
-            println!("with options: {options:#?}");
             AlterRoleOperation::WithOptions { options }
         };
 
@@ -58,7 +144,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_role_option(&mut self) -> Result<RoleOption, ParserError> {
+    fn parse_pg_role_option(&mut self) -> Result<RoleOption, ParserError> {
         let option = match self.parse_one_of_keywords(&[
             Keyword::BYPASSRLS,
             Keyword::NOBYPASSRLS,

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -219,32 +219,35 @@ fn parse_mssql_create_role() {
 #[test]
 fn parse_alter_role() {
     let sql = "ALTER ROLE old_name WITH NAME = new_name";
-    match ms().parse_sql_statements(sql).as_deref() {
-        Ok(
-            [Statement::AlterRole {
-                name,
-                operation: AlterRoleOperation::RenameRole { role_name },
-            }],
-        ) => {
-            assert_eq!("old_name", name.to_string());
-            assert_eq!("new_name", role_name.to_string());
-        }
-        err => panic!("Failed to parse ALTER ROLE test case: {err:?}"),
-    }
+    assert_eq!(
+        ms().parse_sql_statements(sql).unwrap(),
+        [Statement::AlterRole {
+            name: Ident {
+                value: "old_name".into(),
+                quote_style: None
+            },
+            operation: AlterRoleOperation::RenameRole {
+                role_name: Ident {
+                    value: "new_name".into(),
+                    quote_style: None
+                }
+            },
+        }]
+    );
 
     let sql = "ALTER ROLE role_name ADD MEMBER new_member";
     assert_eq!(
         ms().verified_stmt(sql),
         Statement::AlterRole {
-            name: ObjectName(vec![Ident {
+            name: Ident {
                 value: "role_name".into(),
                 quote_style: None
-            }]),
+            },
             operation: AlterRoleOperation::AddMember {
-                member_name: ObjectName(vec![Ident {
+                member_name: Ident {
                     value: "new_member".into(),
                     quote_style: None
-                }])
+                }
             },
         }
     );
@@ -253,15 +256,15 @@ fn parse_alter_role() {
     assert_eq!(
         ms().verified_stmt(sql),
         Statement::AlterRole {
-            name: ObjectName(vec![Ident {
+            name: Ident {
                 value: "role_name".into(),
                 quote_style: None
-            }]),
+            },
             operation: AlterRoleOperation::DropMember {
-                member_name: ObjectName(vec![Ident {
+                member_name: Ident {
                     value: "old_member".into(),
                     quote_style: None
-                }])
+                }
             },
         }
     );

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2448,6 +2448,33 @@ fn parse_create_role() {
 }
 
 #[test]
+fn parse_alter_role() {
+    let sql = "ALTER ROLE old_name RENAME TO new_name";
+    match pg().verified_stmt(sql) {
+        Statement::AlterRole {
+            name,
+            operation: AlterRoleOperation::RenameRole { role_name },
+        } => {
+            assert_eq!("old_name", name.to_string());
+            assert_eq!("new_name", role_name.to_string());
+        }
+        _ => unreachable!(),
+    }
+
+    let sql = "ALTER ROLE role_name WITH BYPASSRLS CREATEDB";
+    match pg().verified_stmt(sql) {
+        Statement::AlterRole {
+            name,
+            operation: AlterRoleOperation::WithOptions { options },
+        } => {
+            assert_eq!("role_name", name.to_string());
+            assert_eq_vec(&["BYPASSRLS", "CREATEDB"], &options);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_delimited_identifiers() {
     // check that quoted identifiers in any position remain quoted after serialization
     let select = pg().verified_only_select(


### PR DESCRIPTION
# Background

Close #941 

# What changes are included in this PR

- [x] add `ALTER ROLE` syntax of PostgreSQL  ✅
- [x] add `ALTER ROLE` syntax of MS SQL Server  ✅
- [x] add parser tests  ✅

# Addtional Context

See #941 