### PR TITLE
feat: support more Postgres index syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1354,6 +1354,7 @@ pub enum Statement {
         using: Option<Ident>,
         columns: Vec<OrderByExpr>,
         unique: bool,
+        concurrently: bool,
         if_not_exists: bool,
     },
     /// CREATE ROLE
@@ -2464,12 +2465,14 @@ impl fmt::Display for Statement {
                 using,
                 columns,
                 unique,
+                concurrently,
                 if_not_exists,
             } => {
                 write!(
                     f,
-                    "CREATE {unique}INDEX {if_not_exists}{name} ON {table_name}",
+                    "CREATE {unique}INDEX {concurrently}{if_not_exists}{name} ON {table_name}",
                     unique = if *unique { "UNIQUE " } else { "" },
+                    concurrently = if *concurrently { "CONCURRENTLY " } else { "" },
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
                     name = name,
                     table_name = table_name

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2493,8 +2493,8 @@ impl fmt::Display for Statement {
                 if !include.is_empty() {
                     write!(f, " INCLUDE ({})", display_separated(include, ","))?;
                 }
-                if *nulls_distinct {
-                    write!(f, " NULLS DISTINCT")?;
+                if !nulls_distinct {
+                    write!(f, " NULLS NOT DISTINCT")?;
                 }
                 if let Some(predicate) = predicate {
                     write!(f, " WHERE {predicate}")?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2476,16 +2476,15 @@ impl fmt::Display for Statement {
             } => {
                 write!(
                     f,
-                    "CREATE {unique}INDEX {concurrently}{if_not_exists}{name}ON {table_name}",
+                    "CREATE {unique}INDEX {concurrently}{if_not_exists}",
                     unique = if *unique { "UNIQUE " } else { "" },
                     concurrently = if *concurrently { "CONCURRENTLY " } else { "" },
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
-                    name = match name {
-                        Some(name) => format!("{} ", name),
-                        None => "".to_string(),
-                    },
-                    table_name = table_name,
                 )?;
+                if let Some(value) = name {
+                    write!(f, "{value} ")?;
+                }
+                write!(f, "ON {table_name}")?;
                 if let Some(value) = using {
                     write!(f, " USING {value} ")?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1356,6 +1356,7 @@ pub enum Statement {
         unique: bool,
         concurrently: bool,
         if_not_exists: bool,
+        nulls_distinct: bool,
         predicate: Option<Expr>,
     },
     /// CREATE ROLE
@@ -2468,6 +2469,7 @@ impl fmt::Display for Statement {
                 unique,
                 concurrently,
                 if_not_exists,
+                nulls_distinct,
                 predicate,
             } => {
                 write!(
@@ -2486,6 +2488,9 @@ impl fmt::Display for Statement {
                     write!(f, " USING {value} ")?;
                 }
                 write!(f, "({})", display_separated(columns, ","))?;
+                if *nulls_distinct {
+                    write!(f, " NULLS DISTINCT")?;
+                }
                 if let Some(predicate) = predicate {
                     write!(f, " WHERE {predicate}")?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1356,6 +1356,7 @@ pub enum Statement {
         unique: bool,
         concurrently: bool,
         if_not_exists: bool,
+        predicate: Option<Expr>,
     },
     /// CREATE ROLE
     /// See [postgres](https://www.postgresql.org/docs/current/sql-createrole.html)
@@ -2467,6 +2468,7 @@ impl fmt::Display for Statement {
                 unique,
                 concurrently,
                 if_not_exists,
+                predicate,
             } => {
                 write!(
                     f,
@@ -2478,12 +2480,16 @@ impl fmt::Display for Statement {
                         Some(name) => format!("{} ", name),
                         None => "".to_string(),
                     },
-                    table_name = table_name
+                    table_name = table_name,
                 )?;
                 if let Some(value) = using {
                     write!(f, " USING {value} ")?;
                 }
-                write!(f, "({})", display_separated(columns, ","))
+                write!(f, "({})", display_separated(columns, ","))?;
+                if let Some(predicate) = predicate {
+                    write!(f, " WHERE {predicate}")?;
+                }
+                Ok(())
             }
             Statement::CreateRole {
                 names,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1356,6 +1356,7 @@ pub enum Statement {
         unique: bool,
         concurrently: bool,
         if_not_exists: bool,
+        include: Vec<Ident>,
         nulls_distinct: bool,
         predicate: Option<Expr>,
     },
@@ -2469,6 +2470,7 @@ impl fmt::Display for Statement {
                 unique,
                 concurrently,
                 if_not_exists,
+                include,
                 nulls_distinct,
                 predicate,
             } => {
@@ -2488,6 +2490,9 @@ impl fmt::Display for Statement {
                     write!(f, " USING {value} ")?;
                 }
                 write!(f, "({})", display_separated(columns, ","))?;
+                if !include.is_empty() {
+                    write!(f, " INCLUDE ({})", display_separated(include, ","))?;
+                }
                 if *nulls_distinct {
                     write!(f, " NULLS DISTINCT")?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1348,7 +1348,7 @@ pub enum Statement {
     /// CREATE INDEX
     CreateIndex {
         /// index name
-        name: ObjectName,
+        name: Option<ObjectName>,
         #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
         table_name: ObjectName,
         using: Option<Ident>,
@@ -2470,11 +2470,14 @@ impl fmt::Display for Statement {
             } => {
                 write!(
                     f,
-                    "CREATE {unique}INDEX {concurrently}{if_not_exists}{name} ON {table_name}",
+                    "CREATE {unique}INDEX {concurrently}{if_not_exists}{name}ON {table_name}",
                     unique = if *unique { "UNIQUE " } else { "" },
                     concurrently = if *concurrently { "CONCURRENTLY " } else { "" },
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
-                    name = name,
+                    name = match name {
+                        Some(name) => format!("{} ", name),
+                        None => "".to_string(),
+                    },
                     table_name = table_name
                 )?;
                 if let Some(value) = using {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1357,7 +1357,7 @@ pub enum Statement {
         concurrently: bool,
         if_not_exists: bool,
         include: Vec<Ident>,
-        nulls_distinct: bool,
+        nulls_distinct: Option<bool>,
         predicate: Option<Expr>,
     },
     /// CREATE ROLE
@@ -2492,8 +2492,12 @@ impl fmt::Display for Statement {
                 if !include.is_empty() {
                     write!(f, " INCLUDE ({})", display_separated(include, ","))?;
                 }
-                if !nulls_distinct {
-                    write!(f, " NULLS NOT DISTINCT")?;
+                if let Some(value) = nulls_distinct {
+                    if *value {
+                        write!(f, " NULLS DISTINCT")?;
+                    } else {
+                        write!(f, " NULLS NOT DISTINCT")?;
+                    }
                 }
                 if let Some(predicate) = predicate {
                     write!(f, " WHERE {predicate}")?;

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -311,6 +311,7 @@ define_keywords!(
     ILIKE,
     IMMUTABLE,
     IN,
+    INCLUDE,
     INCREMENT,
     INDEX,
     INDICATOR,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -153,6 +153,7 @@ define_keywords!(
     COMMITTED,
     COMPRESSION,
     COMPUTE,
+    CONCURRENTLY,
     CONDITION,
     CONFLICT,
     CONNECT,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3370,6 +3370,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_create_index(&mut self, unique: bool) -> Result<Statement, ParserError> {
+        let concurrently = self.parse_keyword(Keyword::CONCURRENTLY);
         let if_not_exists = self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
         let index_name = self.parse_object_name()?;
         self.expect_keyword(Keyword::ON)?;
@@ -3388,6 +3389,7 @@ impl<'a> Parser<'a> {
             using,
             columns,
             unique,
+            concurrently,
             if_not_exists,
         })
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3403,7 +3403,7 @@ impl<'a> Parser<'a> {
             self.expect_keyword(Keyword::DISTINCT)?;
             !not
         } else {
-            false
+            true
         };
 
         let predicate = if self.parse_keyword(Keyword::WHERE) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3388,6 +3388,13 @@ impl<'a> Parser<'a> {
         self.expect_token(&Token::LParen)?;
         let columns = self.parse_comma_separated(Parser::parse_order_by_expr)?;
         self.expect_token(&Token::RParen)?;
+
+        let predicate = if self.parse_keyword(Keyword::WHERE) {
+            Some(self.parse_expr()?)
+        } else {
+            None
+        };
+
         Ok(Statement::CreateIndex {
             name: index_name,
             table_name,
@@ -3396,6 +3403,7 @@ impl<'a> Parser<'a> {
             unique,
             concurrently,
             if_not_exists,
+            predicate,
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3372,8 +3372,13 @@ impl<'a> Parser<'a> {
     pub fn parse_create_index(&mut self, unique: bool) -> Result<Statement, ParserError> {
         let concurrently = self.parse_keyword(Keyword::CONCURRENTLY);
         let if_not_exists = self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
-        let index_name = self.parse_object_name()?;
-        self.expect_keyword(Keyword::ON)?;
+        let index_name = if if_not_exists || !self.parse_keyword(Keyword::ON) {
+            let index_name = self.parse_object_name()?;
+            self.expect_keyword(Keyword::ON)?;
+            Some(index_name)
+        } else {
+            None
+        };
         let table_name = self.parse_object_name()?;
         let using = if self.parse_keyword(Keyword::USING) {
             Some(self.parse_identifier()?)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3389,6 +3389,13 @@ impl<'a> Parser<'a> {
         let columns = self.parse_comma_separated(Parser::parse_order_by_expr)?;
         self.expect_token(&Token::RParen)?;
 
+        let nulls_distinct = if self.parse_keyword(Keyword::NULLS) {
+            let not = self.parse_keyword(Keyword::NOT);
+            self.expect_keyword(Keyword::DISTINCT)?;
+            !not
+        } else {
+            false
+        };
         let predicate = if self.parse_keyword(Keyword::WHERE) {
             Some(self.parse_expr()?)
         } else {
@@ -3403,6 +3410,7 @@ impl<'a> Parser<'a> {
             unique,
             concurrently,
             if_not_exists,
+            nulls_distinct,
             predicate,
         })
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3401,9 +3401,9 @@ impl<'a> Parser<'a> {
         let nulls_distinct = if self.parse_keyword(Keyword::NULLS) {
             let not = self.parse_keyword(Keyword::NOT);
             self.expect_keyword(Keyword::DISTINCT)?;
-            !not
+            Some(!not)
         } else {
-            true
+            None
         };
 
         let predicate = if self.parse_keyword(Keyword::WHERE) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3389,6 +3389,15 @@ impl<'a> Parser<'a> {
         let columns = self.parse_comma_separated(Parser::parse_order_by_expr)?;
         self.expect_token(&Token::RParen)?;
 
+        let include = if self.parse_keyword(Keyword::INCLUDE) {
+            self.expect_token(&Token::LParen)?;
+            let columns = self.parse_comma_separated(Parser::parse_identifier)?;
+            self.expect_token(&Token::RParen)?;
+            columns
+        } else {
+            vec![]
+        };
+
         let nulls_distinct = if self.parse_keyword(Keyword::NULLS) {
             let not = self.parse_keyword(Keyword::NOT);
             self.expect_keyword(Keyword::DISTINCT)?;
@@ -3396,6 +3405,7 @@ impl<'a> Parser<'a> {
         } else {
             false
         };
+
         let predicate = if self.parse_keyword(Keyword::WHERE) {
             Some(self.parse_expr()?)
         } else {
@@ -3410,6 +3420,7 @@ impl<'a> Parser<'a> {
             unique,
             concurrently,
             if_not_exists,
+            include,
             nulls_distinct,
             predicate,
         })

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6020,6 +6020,7 @@ fn test_create_index_with_using_function() {
             using,
             columns,
             unique,
+            concurrently,
             if_not_exists,
         } => {
             assert_eq!("idx_name", name.to_string());
@@ -6027,6 +6028,7 @@ fn test_create_index_with_using_function() {
             assert_eq!("btree", using.unwrap().to_string());
             assert_eq!(indexed_columns, columns);
             assert!(unique);
+            assert!(!concurrently);
             assert!(if_not_exists)
         }
         _ => unreachable!(),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6022,6 +6022,7 @@ fn test_create_index_with_using_function() {
             unique,
             concurrently,
             if_not_exists,
+            include,
             nulls_distinct,
             predicate: None,
         } => {
@@ -6032,6 +6033,7 @@ fn test_create_index_with_using_function() {
             assert!(unique);
             assert!(!concurrently);
             assert!(if_not_exists);
+            assert!(include.is_empty());
             assert!(!nulls_distinct)
         }
         _ => unreachable!(),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6023,7 +6023,7 @@ fn test_create_index_with_using_function() {
             concurrently,
             if_not_exists,
             include,
-            nulls_distinct,
+            nulls_distinct: None,
             predicate: None,
         } => {
             assert_eq!("idx_name", name.to_string());
@@ -6034,7 +6034,6 @@ fn test_create_index_with_using_function() {
             assert!(!concurrently);
             assert!(if_not_exists);
             assert!(include.is_empty());
-            assert!(nulls_distinct)
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6022,6 +6022,7 @@ fn test_create_index_with_using_function() {
             unique,
             concurrently,
             if_not_exists,
+            predicate: None,
         } => {
             assert_eq!("idx_name", name.to_string());
             assert_eq!("test", table_name.to_string());

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -5981,7 +5981,7 @@ fn parse_create_index() {
     ];
     match verified_stmt(sql) {
         Statement::CreateIndex {
-            name,
+            name: Some(name),
             table_name,
             columns,
             unique,
@@ -6015,7 +6015,7 @@ fn test_create_index_with_using_function() {
     ];
     match verified_stmt(sql) {
         Statement::CreateIndex {
-            name,
+            name: Some(name),
             table_name,
             using,
             columns,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6022,6 +6022,7 @@ fn test_create_index_with_using_function() {
             unique,
             concurrently,
             if_not_exists,
+            nulls_distinct,
             predicate: None,
         } => {
             assert_eq!("idx_name", name.to_string());
@@ -6030,7 +6031,8 @@ fn test_create_index_with_using_function() {
             assert_eq!(indexed_columns, columns);
             assert!(unique);
             assert!(!concurrently);
-            assert!(if_not_exists)
+            assert!(if_not_exists);
+            assert!(!nulls_distinct)
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6034,7 +6034,7 @@ fn test_create_index_with_using_function() {
             assert!(!concurrently);
             assert!(if_not_exists);
             assert!(include.is_empty());
-            assert!(!nulls_distinct)
+            assert!(nulls_distinct)
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1762,6 +1762,56 @@ fn parse_array_index_expr() {
 }
 
 #[test]
+fn parse_create_index() {
+    let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2)";
+    match pg().verified_stmt(sql) {
+        Statement::CreateIndex {
+            name: ObjectName(name),
+            table_name: ObjectName(table_name),
+            using,
+            columns,
+            unique,
+            concurrently,
+            if_not_exists,
+        } => {
+            assert_eq_vec(&["my_index"], &name);
+            assert_eq_vec(&["my_table"], &table_name);
+            assert_eq!(None, using);
+            assert!(!unique);
+            assert!(!concurrently);
+            assert!(if_not_exists);
+            assert_eq_vec(&["col1", "col2"], &columns);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_index_concurrently() {
+    let sql = "CREATE INDEX CONCURRENTLY IF NOT EXISTS my_index ON my_table(col1,col2)";
+    match pg().verified_stmt(sql) {
+        Statement::CreateIndex {
+            name: ObjectName(name),
+            table_name: ObjectName(table_name),
+            using,
+            columns,
+            unique,
+            concurrently,
+            if_not_exists,
+        } => {
+            assert_eq_vec(&["my_index"], &name);
+            assert_eq_vec(&["my_table"], &table_name);
+            assert_eq!(None, using);
+            assert!(!unique);
+            assert!(concurrently);
+            assert!(if_not_exists);
+            assert_eq_vec(&["col1", "col2"], &columns);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_array_subquery_expr() {
     let sql = "SELECT ARRAY(SELECT 1 UNION SELECT 2)";
     let select = pg().verified_only_select(sql);

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1773,7 +1773,7 @@ fn parse_create_index() {
             unique,
             concurrently,
             if_not_exists,
-            nulls_distinct,
+            nulls_distinct: None,
             include,
             predicate: None,
         } => {
@@ -1785,7 +1785,6 @@ fn parse_create_index() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(nulls_distinct)
         }
         _ => unreachable!(),
     }
@@ -1804,7 +1803,7 @@ fn parse_create_anonymous_index() {
             concurrently,
             if_not_exists,
             include,
-            nulls_distinct,
+            nulls_distinct: None,
             predicate: None,
         } => {
             assert_eq!(None, name);
@@ -1815,7 +1814,6 @@ fn parse_create_anonymous_index() {
             assert!(!if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(nulls_distinct);
         }
         _ => unreachable!(),
     }
@@ -1834,7 +1832,7 @@ fn parse_create_index_concurrently() {
             concurrently,
             if_not_exists,
             include,
-            nulls_distinct,
+            nulls_distinct: None,
             predicate: None,
         } => {
             assert_eq_vec(&["my_index"], &name);
@@ -1845,7 +1843,6 @@ fn parse_create_index_concurrently() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(nulls_distinct);
         }
         _ => unreachable!(),
     }
@@ -1864,7 +1861,7 @@ fn parse_create_index_with_predicate() {
             concurrently,
             if_not_exists,
             include,
-            nulls_distinct,
+            nulls_distinct: None,
             predicate: Some(_),
         } => {
             assert_eq_vec(&["my_index"], &name);
@@ -1875,7 +1872,6 @@ fn parse_create_index_with_predicate() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(nulls_distinct);
         }
         _ => unreachable!(),
     }
@@ -1894,7 +1890,7 @@ fn parse_create_index_with_include() {
             concurrently,
             if_not_exists,
             include,
-            nulls_distinct,
+            nulls_distinct: None,
             predicate: None,
         } => {
             assert_eq_vec(&["my_index"], &name);
@@ -1905,7 +1901,6 @@ fn parse_create_index_with_include() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert_eq_vec(&["col3"], &include);
-            assert!(nulls_distinct)
         }
         _ => unreachable!(),
     }
@@ -1924,7 +1919,7 @@ fn parse_create_index_with_nulls_distinct() {
             concurrently,
             if_not_exists,
             include,
-            nulls_distinct,
+            nulls_distinct: Some(nulls_distinct),
             predicate: None,
         } => {
             assert_eq_vec(&["my_index"], &name);
@@ -1935,7 +1930,34 @@ fn parse_create_index_with_nulls_distinct() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(!nulls_distinct)
+            assert!(!nulls_distinct);
+        }
+        _ => unreachable!(),
+    }
+
+    let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2) NULLS DISTINCT";
+    match pg().verified_stmt(sql) {
+        Statement::CreateIndex {
+            name: Some(ObjectName(name)),
+            table_name: ObjectName(table_name),
+            using,
+            columns,
+            unique,
+            concurrently,
+            if_not_exists,
+            include,
+            nulls_distinct: Some(nulls_distinct),
+            predicate: None,
+        } => {
+            assert_eq_vec(&["my_index"], &name);
+            assert_eq_vec(&["my_table"], &table_name);
+            assert_eq!(None, using);
+            assert!(!unique);
+            assert!(!concurrently);
+            assert!(if_not_exists);
+            assert_eq_vec(&["col1", "col2"], &columns);
+            assert!(include.is_empty());
+            assert!(nulls_distinct);
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1773,6 +1773,7 @@ fn parse_create_index() {
             unique,
             concurrently,
             if_not_exists,
+            nulls_distinct,
             predicate: None,
         } => {
             assert_eq_vec(&["my_index"], &name);
@@ -1782,6 +1783,7 @@ fn parse_create_index() {
             assert!(!concurrently);
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
+            assert!(!nulls_distinct)
         }
         _ => unreachable!(),
     }
@@ -1799,6 +1801,7 @@ fn parse_create_anonymous_index() {
             unique,
             concurrently,
             if_not_exists,
+            nulls_distinct,
             predicate: None,
         } => {
             assert_eq!(None, name);
@@ -1808,6 +1811,7 @@ fn parse_create_anonymous_index() {
             assert!(!concurrently);
             assert!(!if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
+            assert!(!nulls_distinct);
         }
         _ => unreachable!(),
     }
@@ -1825,6 +1829,7 @@ fn parse_create_index_concurrently() {
             unique,
             concurrently,
             if_not_exists,
+            nulls_distinct,
             predicate: None,
         } => {
             assert_eq_vec(&["my_index"], &name);
@@ -1834,6 +1839,7 @@ fn parse_create_index_concurrently() {
             assert!(concurrently);
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
+            assert!(!nulls_distinct);
         }
         _ => unreachable!(),
     }
@@ -1851,6 +1857,7 @@ fn parse_create_index_with_predicate() {
             unique,
             concurrently,
             if_not_exists,
+            nulls_distinct,
             predicate: Some(_),
         } => {
             assert_eq_vec(&["my_index"], &name);
@@ -1860,6 +1867,35 @@ fn parse_create_index_with_predicate() {
             assert!(!concurrently);
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
+            assert!(!nulls_distinct);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_index_with_nulls_distinct() {
+    let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2) NULLS DISTINCT";
+    match pg().verified_stmt(sql) {
+        Statement::CreateIndex {
+            name: Some(ObjectName(name)),
+            table_name: ObjectName(table_name),
+            using,
+            columns,
+            unique,
+            concurrently,
+            if_not_exists,
+            nulls_distinct,
+            predicate: None,
+        } => {
+            assert_eq_vec(&["my_index"], &name);
+            assert_eq_vec(&["my_table"], &table_name);
+            assert_eq!(None, using);
+            assert!(!unique);
+            assert!(!concurrently);
+            assert!(if_not_exists);
+            assert_eq_vec(&["col1", "col2"], &columns);
+            assert!(nulls_distinct)
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1785,7 +1785,7 @@ fn parse_create_index() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(!nulls_distinct)
+            assert!(nulls_distinct)
         }
         _ => unreachable!(),
     }
@@ -1815,7 +1815,7 @@ fn parse_create_anonymous_index() {
             assert!(!if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(!nulls_distinct);
+            assert!(nulls_distinct);
         }
         _ => unreachable!(),
     }
@@ -1845,7 +1845,7 @@ fn parse_create_index_concurrently() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(!nulls_distinct);
+            assert!(nulls_distinct);
         }
         _ => unreachable!(),
     }
@@ -1875,7 +1875,7 @@ fn parse_create_index_with_predicate() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(!nulls_distinct);
+            assert!(nulls_distinct);
         }
         _ => unreachable!(),
     }
@@ -1905,7 +1905,7 @@ fn parse_create_index_with_include() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert_eq_vec(&["col3"], &include);
-            assert!(!nulls_distinct)
+            assert!(nulls_distinct)
         }
         _ => unreachable!(),
     }
@@ -1913,7 +1913,7 @@ fn parse_create_index_with_include() {
 
 #[test]
 fn parse_create_index_with_nulls_distinct() {
-    let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2) NULLS DISTINCT";
+    let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2) NULLS NOT DISTINCT";
     match pg().verified_stmt(sql) {
         Statement::CreateIndex {
             name: Some(ObjectName(name)),
@@ -1935,7 +1935,7 @@ fn parse_create_index_with_nulls_distinct() {
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
             assert!(include.is_empty());
-            assert!(nulls_distinct)
+            assert!(!nulls_distinct)
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1773,6 +1773,7 @@ fn parse_create_index() {
             unique,
             concurrently,
             if_not_exists,
+            predicate: None,
         } => {
             assert_eq_vec(&["my_index"], &name);
             assert_eq_vec(&["my_table"], &table_name);
@@ -1798,6 +1799,7 @@ fn parse_create_anonymous_index() {
             unique,
             concurrently,
             if_not_exists,
+            predicate: None,
         } => {
             assert_eq!(None, name);
             assert_eq_vec(&["my_table"], &table_name);
@@ -1823,12 +1825,39 @@ fn parse_create_index_concurrently() {
             unique,
             concurrently,
             if_not_exists,
+            predicate: None,
         } => {
             assert_eq_vec(&["my_index"], &name);
             assert_eq_vec(&["my_table"], &table_name);
             assert_eq!(None, using);
             assert!(!unique);
             assert!(concurrently);
+            assert!(if_not_exists);
+            assert_eq_vec(&["col1", "col2"], &columns);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_index_with_predicate() {
+    let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2) WHERE col3 IS NULL";
+    match pg().verified_stmt(sql) {
+        Statement::CreateIndex {
+            name: Some(ObjectName(name)),
+            table_name: ObjectName(table_name),
+            using,
+            columns,
+            unique,
+            concurrently,
+            if_not_exists,
+            predicate: Some(_),
+        } => {
+            assert_eq_vec(&["my_index"], &name);
+            assert_eq_vec(&["my_table"], &table_name);
+            assert_eq!(None, using);
+            assert!(!unique);
+            assert!(!concurrently);
             assert!(if_not_exists);
             assert_eq_vec(&["col1", "col2"], &columns);
         }


### PR DESCRIPTION
Postgres `CREATE INDEX` statements have the following syntax:

```
CREATE [ UNIQUE ] INDEX [ CONCURRENTLY ] [ [ IF NOT EXISTS ] name ] ON [ ONLY ] table_name [ USING method ]
    ( { column_name | ( expression ) } [ COLLATE collation ] [ opclass [ ( opclass_parameter = value [, ... ] ) ] ] [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] )
    [ INCLUDE ( column_name [, ...] ) ]
    [ NULLS [ NOT ] DISTINCT ]
    [ WITH ( storage_parameter [= value] [, ... ] ) ]
    [ TABLESPACE tablespace_name ]
    [ WHERE predicate ]
```

> source: https://www.postgresql.org/docs/15/sql-createindex.html

This PR adds support for:

- `CONCURRENTLY` - When this option is used, PostgreSQL will build the index without taking any locks that prevent concurrent inserts, updates, or deletes on the table.
- Anonymous indexes - if you do not have `IF NOT EXISTS`, the index name is optional.
- `INCLUDE ( column_name [, ...] )`- The optional INCLUDE clause specifies a list of columns which will be included in the index as non-key columns.
- `NULLS NOT DISTINCT` - Specifies whether for a unique index, null values should be considered distinct (not equal). The default is that they are distinct, so that a unique index could contain multiple null values in a column.
- `WHERE predicate` - The constraint expression for a partial index.

Questions:

1. For Postgres, the default is `NULLS DISTINCT`, so I made that implicit and did not include it in the generated SQL. An alternative would be to make it `nulls_distinct: Option<bool>` and have it set to `None` by default and `Some(true)`/`Some(false)` for `NULLS DISTINCT`/`NULLS NOT DISTINCT` respectively.
2. Many db engines don't support all these features. Should these be made Postgres specific in some way, or is it ok that you can parse a statement like `CREATE INDEX CONCURRENTLY ON my_table(my_col)` even when using SQLite as your dialect.

P.S. I ran `cargo test && cargo fmt && cargo clippy` and found no issues.