### PR TITLE
Break test and coverage test into separate jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,8 +91,6 @@ jobs:
         use-tool-cache: true
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Test
-      run: cargo test --all-features
     - name: Coverage
       run: cargo tarpaulin -o Lcov --output-dir ./coverage
     - name: Coveralls

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,11 +75,27 @@ jobs:
       uses: actions/checkout@v2
     - name: Test
       run: cargo test --all-features
+
+  test-coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Rust
+      uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+    - name: Install Tarpaulin
+      uses: actions-rs/install@v0.1
+      with:
+        crate: cargo-tarpaulin
+        version: 0.14.2
+        use-tool-cache: true
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Test
+      run: cargo test --all-features
     - name: Coverage
-      if: matrix.rust == 'stable'
       run: cargo tarpaulin -o Lcov --output-dir ./coverage
     - name: Coveralls
-      if: matrix.rust == 'stable'
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Rationale: coverage takes a non trivial amount of time and does not reuse the build artifacts from normal test. Thus running them in parallel will improve the speed of CI jobs

Before this PR
* the [test job](https://github.com/sqlparser-rs/sqlparser-rs/actions/runs/5890637664/job/15976156114) on stable takes 2m57s

With this PR the total wallclock time is less than 2m:
* the [test job](https://github.com/sqlparser-rs/sqlparser-rs/actions/runs/5893101296/job/15983893926?pr=949) on stable takes 1m7s
* the [coverage job](https://github.com/sqlparser-rs/sqlparser-rs/actions/runs/5893101296/job/15983894837?pr=949) takes: 1m44s 