### PR TITLE
Fix Rust 1.72 clippy lints

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5881,7 +5881,7 @@ impl<'a> Parser<'a> {
             Some(_) => {
                 let db_name = vec![self.parse_identifier()?];
                 let ObjectName(table_name) = object_name;
-                let object_name = db_name.into_iter().chain(table_name.into_iter()).collect();
+                let object_name = db_name.into_iter().chain(table_name).collect();
                 ObjectName(object_name)
             }
             None => object_name,

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -55,7 +55,7 @@ fn parse_raw_literal() {
     let sql = r#"SELECT R'abc', R"abc", R'f\(abc,(.*),def\)', R"f\(abc,(.*),def\)""#;
     let stmt = bigquery().one_statement_parses_to(
         sql,
-        r#"SELECT R'abc', R'abc', R'f\(abc,(.*),def\)', R'f\(abc,(.*),def\)'"#,
+        r"SELECT R'abc', R'abc', R'f\(abc,(.*),def\)', R'f\(abc,(.*),def\)'",
     );
     if let Statement::Query(query) = stmt {
         if let SetExpr::Select(select) = *query.body {
@@ -69,11 +69,11 @@ fn parse_raw_literal() {
                 expr_from_projection(&select.projection[1])
             );
             assert_eq!(
-                &Expr::Value(Value::RawStringLiteral(r#"f\(abc,(.*),def\)"#.to_string())),
+                &Expr::Value(Value::RawStringLiteral(r"f\(abc,(.*),def\)".to_string())),
                 expr_from_projection(&select.projection[2])
             );
             assert_eq!(
-                &Expr::Value(Value::RawStringLiteral(r#"f\(abc,(.*),def\)"#.to_string())),
+                &Expr::Value(Value::RawStringLiteral(r"f\(abc,(.*),def\)".to_string())),
                 expr_from_projection(&select.projection[3])
             );
             return;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7212,7 +7212,7 @@ fn parse_with_recursion_limit() {
         .expect("tokenize to work")
         .parse_statements();
 
-    assert!(matches!(res, Ok(_)), "{res:?}");
+    assert!(res.is_ok(), "{res:?}");
 
     // limit recursion to something smaller, expect parsing to fail
     let res = Parser::new(&dialect)
@@ -7230,7 +7230,7 @@ fn parse_with_recursion_limit() {
         .with_recursion_limit(50)
         .parse_statements();
 
-    assert!(matches!(res, Ok(_)), "{res:?}");
+    assert!(res.is_ok(), "{res:?}");
 }
 
 #[test]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -634,11 +634,11 @@ fn parse_escaped_backticks_with_no_escape() {
 
 #[test]
 fn parse_unterminated_escape() {
-    let sql = r#"SELECT 'I\'m not fine\'"#;
+    let sql = r"SELECT 'I\'m not fine\'";
     let result = std::panic::catch_unwind(|| mysql().one_statement_parses_to(sql, ""));
     assert!(result.is_err());
 
-    let sql = r#"SELECT 'I\\'m not fine'"#;
+    let sql = r"SELECT 'I\\'m not fine'";
     let result = std::panic::catch_unwind(|| mysql().one_statement_parses_to(sql, ""));
     assert!(result.is_err());
 }
@@ -666,7 +666,7 @@ fn parse_escaped_string_with_escape() {
             _ => unreachable!(),
         };
     }
-    let sql = r#"SELECT 'I\'m fine'"#;
+    let sql = r"SELECT 'I\'m fine'";
     assert_mysql_query_value(sql, "I'm fine");
 
     let sql = r#"SELECT 'I''m fine'"#;
@@ -675,7 +675,7 @@ fn parse_escaped_string_with_escape() {
     let sql = r#"SELECT 'I\"m fine'"#;
     assert_mysql_query_value(sql, "I\"m fine");
 
-    let sql = r#"SELECT 'Testing: \0 \\ \% \_ \b \n \r \t \Z \a \ '"#;
+    let sql = r"SELECT 'Testing: \0 \\ \% \_ \b \n \r \t \Z \a \ '";
     assert_mysql_query_value(sql, "Testing: \0 \\ % _ \u{8} \n \r \t \u{1a} a  ");
 }
 
@@ -702,8 +702,8 @@ fn parse_escaped_string_with_no_escape() {
             _ => unreachable!(),
         };
     }
-    let sql = r#"SELECT 'I\'m fine'"#;
-    assert_mysql_query_value(sql, r#"I\'m fine"#);
+    let sql = r"SELECT 'I\'m fine'";
+    assert_mysql_query_value(sql, r"I\'m fine");
 
     let sql = r#"SELECT 'I''m fine'"#;
     assert_mysql_query_value(sql, r#"I''m fine"#);
@@ -711,8 +711,8 @@ fn parse_escaped_string_with_no_escape() {
     let sql = r#"SELECT 'I\"m fine'"#;
     assert_mysql_query_value(sql, r#"I\"m fine"#);
 
-    let sql = r#"SELECT 'Testing: \0 \\ \% \_ \b \n \r \t \Z \a \ '"#;
-    assert_mysql_query_value(sql, r#"Testing: \0 \\ \% \_ \b \n \r \t \Z \a \ "#);
+    let sql = r"SELECT 'Testing: \0 \\ \% \_ \b \n \r \t \Z \a \ '";
+    assert_mysql_query_value(sql, r"Testing: \0 \\ \% \_ \b \n \r \t \Z \a \ ");
 }
 
 #[test]
@@ -723,7 +723,7 @@ fn check_roundtrip_of_escaped_string() {
         dialects: vec![Box::new(MySqlDialect {})],
         options: options.clone(),
     }
-    .verified_stmt(r#"SELECT 'I\'m fine'"#);
+    .verified_stmt(r"SELECT 'I\'m fine'");
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
         options: options.clone(),
@@ -733,12 +733,12 @@ fn check_roundtrip_of_escaped_string() {
         dialects: vec![Box::new(MySqlDialect {})],
         options: options.clone(),
     }
-    .verified_stmt(r#"SELECT 'I\\\'m fine'"#);
+    .verified_stmt(r"SELECT 'I\\\'m fine'");
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
         options: options.clone(),
     }
-    .verified_stmt(r#"SELECT 'I\\\'m fine'"#);
+    .verified_stmt(r"SELECT 'I\\\'m fine'");
 
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2332,8 +2332,7 @@ fn pg_and_generic() -> TestedDialects {
 
 #[test]
 fn parse_escaped_literal_string() {
-    let sql =
-        r#"SELECT E's1 \n s1', E's2 \\n s2', E's3 \\\n s3', E's4 \\\\n s4', E'\'', E'foo \\'"#;
+    let sql = r"SELECT E's1 \n s1', E's2 \\n s2', E's3 \\\n s3', E's4 \\\\n s4', E'\'', E'foo \\'";
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(6, select.projection.len());
     assert_eq!(
@@ -2361,7 +2360,7 @@ fn parse_escaped_literal_string() {
         expr_from_projection(&select.projection[5])
     );
 
-    let sql = r#"SELECT E'\'"#;
+    let sql = r"SELECT E'\'";
     assert_eq!(
         pg_and_generic()
             .parse_sql_statements(sql)
@@ -2631,7 +2630,7 @@ fn parse_create_role() {
         err => panic!("Failed to parse CREATE ROLE test case: {err:?}"),
     }
 
-    let negatables = vec![
+    let negatables = [
         "BYPASSRLS",
         "CREATEDB",
         "CREATEROLE",

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1004,7 +1004,7 @@ fn test_copy_into_copy_options() {
 
 #[test]
 fn test_snowflake_stage_object_names() {
-    let allowed_formatted_names = vec![
+    let allowed_formatted_names = [
         "my_company.emp_basic",
         "@namespace.%table_name",
         "@namespace.%table_name/path",


### PR DESCRIPTION

Fix clippy:

Rust 1.72 was released yesterday and introduced some new clippy rules

https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html

run `cargo clippy --fix` to fix them