### PR TITLE
`ANY` and `ALL` contains their operators 

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -419,10 +419,18 @@ pub enum Expr {
         pattern: Box<Expr>,
         escape_char: Option<char>,
     },
-    /// Any operation e.g. `1 ANY (1)` or `foo > ANY(bar)`, It will be wrapped in the right side of BinaryExpr
-    AnyOp(Box<Expr>),
-    /// ALL operation e.g. `1 ALL (1)` or `foo > ALL(bar)`, It will be wrapped in the right side of BinaryExpr
-    AllOp(Box<Expr>),
+    /// Any operation e.g. `foo > ANY(bar)`, comparison operator is one of [=, >, <, =>, =<, !=]
+    AnyOp{
+        left: Box<Expr>,
+        compare_op: BinaryOperator,
+        right: Box<Expr>
+    },
+    /// ALL operation e.g. `foo > ALL(bar)`, comparison operator is one of [=, >, <, =>, =<, !=]
+    AllOp{
+        left: Box<Expr>,
+        compare_op: BinaryOperator,
+        right: Box<Expr>
+    },
     /// Unary operation e.g. `NOT foo`
     UnaryOp { op: UnaryOperator, expr: Box<Expr> },
     /// CAST an expression to a different data type e.g. `CAST(foo AS VARCHAR(123))`
@@ -724,8 +732,8 @@ impl fmt::Display for Expr {
                     pattern
                 ),
             },
-            Expr::AnyOp(expr) => write!(f, "ANY({expr})"),
-            Expr::AllOp(expr) => write!(f, "ALL({expr})"),
+            Expr::AnyOp { left, compare_op, right } => write!(f, "{left} {compare_op} ANY({right})"),
+            Expr::AllOp { left, compare_op, right } => write!(f, "{left} {compare_op} ALL({right})"),
             Expr::UnaryOp { op, expr } => {
                 if op == &UnaryOperator::PGPostfixFactorial {
                     write!(f, "{expr}{op}")

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -420,16 +420,16 @@ pub enum Expr {
         escape_char: Option<char>,
     },
     /// Any operation e.g. `foo > ANY(bar)`, comparison operator is one of [=, >, <, =>, =<, !=]
-    AnyOp{
+    AnyOp {
         left: Box<Expr>,
         compare_op: BinaryOperator,
-        right: Box<Expr>
+        right: Box<Expr>,
     },
     /// ALL operation e.g. `foo > ALL(bar)`, comparison operator is one of [=, >, <, =>, =<, !=]
-    AllOp{
+    AllOp {
         left: Box<Expr>,
         compare_op: BinaryOperator,
-        right: Box<Expr>
+        right: Box<Expr>,
     },
     /// Unary operation e.g. `NOT foo`
     UnaryOp { op: UnaryOperator, expr: Box<Expr> },
@@ -732,8 +732,16 @@ impl fmt::Display for Expr {
                     pattern
                 ),
             },
-            Expr::AnyOp { left, compare_op, right } => write!(f, "{left} {compare_op} ANY({right})"),
-            Expr::AllOp { left, compare_op, right } => write!(f, "{left} {compare_op} ALL({right})"),
+            Expr::AnyOp {
+                left,
+                compare_op,
+                right,
+            } => write!(f, "{left} {compare_op} ANY({right})"),
+            Expr::AllOp {
+                left,
+                compare_op,
+                right,
+            } => write!(f, "{left} {compare_op} ALL({right})"),
             Expr::UnaryOp { op, expr } => {
                 if op == &UnaryOperator::PGPostfixFactorial {
                     write!(f, "{expr}{op}")

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1773,17 +1773,41 @@ impl<'a> Parser<'a> {
                 let right = self.parse_subexpr(precedence)?;
                 self.expect_token(&Token::RParen)?;
 
-                let right = match keyword {
-                    Keyword::ALL => Box::new(Expr::AllOp(Box::new(right))),
-                    Keyword::ANY => Box::new(Expr::AnyOp(Box::new(right))),
-                    _ => unreachable!(),
-                };
+                if !matches!(op,
+                    BinaryOperator::Gt | BinaryOperator::Lt |
+                    BinaryOperator::GtEq | BinaryOperator::LtEq |
+                    BinaryOperator::Eq | BinaryOperator::NotEq)
+                    {
+                        return parser_err!(format!("Expected one of [=, >, <, =>, =<, !=] as comparison operator, found: {op}"))    
+                    };
 
-                Ok(Expr::BinaryOp {
-                    left: Box::new(expr),
-                    op,
-                    right,
+                // let right = match keyword {
+                //     Keyword::ALL => Box::new(Expr::AllOp(Box::new(right))),
+                //     Keyword::ANY => Box::new(Expr::AnyOp(Box::new(right))),
+                //     _ => unreachable!(),
+                // };
+
+                // Ok(Expr::BinaryOp {
+                //     left: Box::new(expr),
+                //     op,
+                //     right,
+                // })
+
+
+                Ok(match keyword {
+                    Keyword::ALL => Expr::AllOp{
+                        left: Box::new(expr),
+                        compare_op: op,
+                        right: Box::new(right),
+                    },
+                    Keyword::ANY => Expr::AnyOp{
+                        left: Box::new(expr),
+                        compare_op: op,
+                        right: Box::new(right),
+                    },
+                    _ => unreachable!(),
                 })
+
             } else {
                 Ok(Expr::BinaryOp {
                     left: Box::new(expr),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1773,41 +1773,33 @@ impl<'a> Parser<'a> {
                 let right = self.parse_subexpr(precedence)?;
                 self.expect_token(&Token::RParen)?;
 
-                if !matches!(op,
-                    BinaryOperator::Gt | BinaryOperator::Lt |
-                    BinaryOperator::GtEq | BinaryOperator::LtEq |
-                    BinaryOperator::Eq | BinaryOperator::NotEq)
-                    {
-                        return parser_err!(format!("Expected one of [=, >, <, =>, =<, !=] as comparison operator, found: {op}"))    
-                    };
-
-                // let right = match keyword {
-                //     Keyword::ALL => Box::new(Expr::AllOp(Box::new(right))),
-                //     Keyword::ANY => Box::new(Expr::AnyOp(Box::new(right))),
-                //     _ => unreachable!(),
-                // };
-
-                // Ok(Expr::BinaryOp {
-                //     left: Box::new(expr),
-                //     op,
-                //     right,
-                // })
-
+                if !matches!(
+                    op,
+                    BinaryOperator::Gt
+                        | BinaryOperator::Lt
+                        | BinaryOperator::GtEq
+                        | BinaryOperator::LtEq
+                        | BinaryOperator::Eq
+                        | BinaryOperator::NotEq
+                ) {
+                    return parser_err!(format!(
+                        "Expected one of [=, >, <, =>, =<, !=] as comparison operator, found: {op}"
+                    ));
+                };
 
                 Ok(match keyword {
-                    Keyword::ALL => Expr::AllOp{
+                    Keyword::ALL => Expr::AllOp {
                         left: Box::new(expr),
                         compare_op: op,
                         right: Box::new(right),
                     },
-                    Keyword::ANY => Expr::AnyOp{
+                    Keyword::ANY => Expr::AnyOp {
                         left: Box::new(expr),
                         compare_op: op,
                         right: Box::new(right),
                     },
                     _ => unreachable!(),
                 })
-
             } else {
                 Ok(Expr::BinaryOp {
                     left: Box::new(expr),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1553,10 +1553,10 @@ fn parse_bitwise_ops() {
 fn parse_binary_any() {
     let select = verified_only_select("SELECT a = ANY(b)");
     assert_eq!(
-        SelectItem::UnnamedExpr(Expr::BinaryOp {
+        SelectItem::UnnamedExpr(Expr::AnyOp {
             left: Box::new(Expr::Identifier(Ident::new("a"))),
-            op: BinaryOperator::Eq,
-            right: Box::new(Expr::AnyOp(Box::new(Expr::Identifier(Ident::new("b"))))),
+            compare_op: BinaryOperator::Eq,
+            right: Box::new(Expr::Identifier(Ident::new("b"))),
         }),
         select.projection[0]
     );
@@ -1566,10 +1566,10 @@ fn parse_binary_any() {
 fn parse_binary_all() {
     let select = verified_only_select("SELECT a = ALL(b)");
     assert_eq!(
-        SelectItem::UnnamedExpr(Expr::BinaryOp {
+        SelectItem::UnnamedExpr(Expr::AllOp {
             left: Box::new(Expr::Identifier(Ident::new("a"))),
-            op: BinaryOperator::Eq,
-            right: Box::new(Expr::AllOp(Box::new(Expr::Identifier(Ident::new("b"))))),
+            compare_op: BinaryOperator::Eq,
+            right: Box::new(Expr::Identifier(Ident::new("b"))),
         }),
         select.projection[0]
     );


### PR DESCRIPTION
Changes `Expr::AllOp` and `Expr::AnyOp` to contain the operator which precedes them, rather than be contained by them. This fixes an issue I had as a polars user:  https://github.com/pola-rs/polars/issues/10081.

The rational for this is that despite the order the syntax demands, the conditional operator modifies the behavior of the `ANY` command, and not vice versa.  Similar to `NOT` as with `NOT IN`, the negation modifies the behavior of the `IN`, and the `IN` is the real operation.  In both cases, its more convenient to parse the real operation than the modifier(s).

I did not find any uses the the old `ANY` or `ALL` commands in any of DataFusion, LocustDB, Ballista, GlueSQL or Opteryx. This might still briefly break their builds however. 

If more unit tests are required, please let me know. 

Fixes: https://github.com/sqlparser-rs/sqlparser-rs/issues/936