### PR TITLE
Add support for == operator for Sqlite

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -885,6 +885,7 @@ impl<'a> Tokenizer<'a> {
                     chars.next(); // consume
                     match chars.peek() {
                         Some('>') => self.consume_and_return(chars, Token::RArrow),
+                        Some('=') => self.consume_and_return(chars, Token::DoubleEq),
                         _ => Ok(Some(Token::Eq)),
                     }
                 }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -62,6 +62,14 @@ fn parse_create_virtual_table() {
 }
 
 #[test]
+fn double_equality_operator() {
+    // Sqlite supports this operator: https://www.sqlite.org/lang_expr.html#binaryops
+    let input = "SELECT a==b FROM t";
+    let expected = "SELECT a = b FROM t";
+    let _ = sqlite_and_generic().one_statement_parses_to(input, expected);
+}
+
+#[test]
 fn parse_create_table_auto_increment() {
     let sql = "CREATE TABLE foo (bar INT PRIMARY KEY AUTOINCREMENT)";
     match sqlite_and_generic().verified_stmt(sql) {


### PR DESCRIPTION
Add support for == operator for Sqlite
`SELECT a == b FROM t`

According to [docs](https://www.sqlite.org/lang_expr.html#binaryops) '==' is fully synonymous to '='