### PR TITLE
Add support for mixed BigQuery table name quoting

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5024,6 +5024,27 @@ impl<'a> Parser<'a> {
                 break;
             }
         }
+
+        // BigQuery accepts any number of quoted identifiers of a table name.
+        // https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#quoted_identifiers
+        if dialect_of!(self is BigQueryDialect)
+            && idents.iter().any(|ident| ident.value.contains('.'))
+        {
+            idents = idents
+                .into_iter()
+                .flat_map(|ident| {
+                    ident
+                        .value
+                        .split('.')
+                        .map(|value| Ident {
+                            value: value.into(),
+                            quote_style: ident.quote_style,
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        }
+
         Ok(ObjectName(idents))
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -159,6 +159,24 @@ impl TestedDialects {
         }
     }
 
+    /// Ensures that `sql` parses as a single [`Select`], and that additionally:
+    ///
+    /// 1. parsing `sql` results in the same [`Statement`] as parsing
+    /// `canonical`.
+    ///
+    /// 2. re-serializing the result of parsing `sql` produces the same
+    /// `canonical` sql string
+    pub fn verified_only_select_with_canonical(&self, query: &str, canonical: &str) -> Select {
+        let q = match self.one_statement_parses_to(query, canonical) {
+            Statement::Query(query) => *query,
+            _ => panic!("Expected Query"),
+        };
+        match *q.body {
+            SetExpr::Select(s) => *s,
+            _ => panic!("Expected SetExpr::Select"),
+        }
+    }
+
     /// Ensures that `sql` parses as an [`Expr`], and that
     /// re-serializing the parse result produces the same `sql`
     /// string (is not modified after a serialization round-trip).


### PR DESCRIPTION
As described in the gh issue, BigQuery accepts arbitrary quoting identifiers within table names - such that e.g: `'a.b.c'` == `'a'.'b'.'c'` == `'a.b'.'c'` are all equivalent.

This adds support for such syntax

Fixes #889