### PR TITLE
Support Snowflake TRIM.

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -496,12 +496,14 @@ pub enum Expr {
     /// ```sql
     /// TRIM([BOTH | LEADING | TRAILING] [<expr> FROM] <expr>)
     /// TRIM(<expr>)
+    /// TRIM(<expr>, [, characters]) -- only Snowflake
     /// ```
     Trim {
         expr: Box<Expr>,
         // ([BOTH | LEADING | TRAILING]
         trim_where: Option<TrimWhereField>,
         trim_what: Option<Box<Expr>>,
+        trim_characters: Option<Vec<Expr>>,
     },
     /// ```sql
     /// OVERLAY(<expr> PLACING <expr> FROM <expr>[ FOR <expr> ]
@@ -895,6 +897,7 @@ impl fmt::Display for Expr {
                 expr,
                 trim_where,
                 trim_what,
+                trim_characters
             } => {
                 write!(f, "TRIM(")?;
                 if let Some(ident) = trim_where {
@@ -904,6 +907,9 @@ impl fmt::Display for Expr {
                     write!(f, "{trim_char} FROM {expr}")?;
                 } else {
                     write!(f, "{expr}")?;
+                }
+                if let Some(characters) = trim_characters {
+                    write!(f, ", {}", display_comma_separated(characters))?;
                 }
 
                 write!(f, ")")

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1302,6 +1302,7 @@ impl<'a> Parser<'a> {
     /// ```sql
     /// TRIM ([WHERE] ['text' FROM] 'text')
     /// TRIM ('text')
+    /// TRIM(<expr>, [, characters]) -- only Snowflake
     /// ```
     pub fn parse_trim_expr(&mut self) -> Result<Expr, ParserError> {
         self.expect_token(&Token::LParen)?;
@@ -1323,6 +1324,16 @@ impl<'a> Parser<'a> {
                 expr: Box::new(expr),
                 trim_where,
                 trim_what: Some(trim_what),
+                trim_characters: None,
+            })
+        } else if self.consume_token(&Token::Comma) && dialect_of!(self is SnowflakeDialect) {
+            let characters = self.parse_comma_separated(Parser::parse_expr)?;
+            self.expect_token(&Token::RParen)?;
+            Ok(Expr::Trim {
+                expr: Box::new(expr),
+                trim_where: None,
+                trim_what: None,
+                trim_characters: Some(characters),
             })
         } else {
             self.expect_token(&Token::RParen)?;
@@ -1330,6 +1341,7 @@ impl<'a> Parser<'a> {
                 expr: Box::new(expr),
                 trim_where,
                 trim_what: None,
+                trim_characters: None,
             })
         }
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -5215,6 +5215,30 @@ fn parse_trim() {
         ParserError::ParserError("Expected ), found: 'xyz'".to_owned()),
         parse_sql_statements("SELECT TRIM(FOO 'xyz' FROM 'xyzfooxyz')").unwrap_err()
     );
+
+    //keep Snowflake TRIM syntax failing
+    let all_expected_snowflake = TestedDialects {
+        dialects: vec![
+            Box::new(GenericDialect {}),
+            Box::new(PostgreSqlDialect {}),
+            Box::new(MsSqlDialect {}),
+            Box::new(AnsiDialect {}),
+            //Box::new(SnowflakeDialect {}),
+            Box::new(HiveDialect {}),
+            Box::new(RedshiftSqlDialect {}),
+            Box::new(MySqlDialect {}),
+            Box::new(BigQueryDialect {}),
+            Box::new(SQLiteDialect {}),
+            Box::new(DuckDbDialect {}),
+        ],
+        options: None,
+    };
+    assert_eq!(
+        ParserError::ParserError("Expected ), found: 'a'\nNear `SELECT TRIM('xyz',`".to_owned()),
+        all_expected_snowflake
+            .parse_sql_statements("SELECT TRIM('xyz', 'a')")
+            .unwrap_err()
+    );
 }
 
 #[test]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1039,3 +1039,28 @@ fn test_snowflake_stage_object_names() {
         }
     }
 }
+
+#[test]
+fn test_snowflake_trim() {
+    let real_sql = r#"SELECT customer_id, TRIM(sub_items.value:item_price_id, '"', "a") AS item_price_id FROM models_staging.subscriptions"#;
+    assert_eq!(snowflake().verified_stmt(real_sql).to_string(), real_sql);
+
+    let sql_only_select = "SELECT TRIM('xyz', 'a')";
+    let select = snowflake().verified_only_select(sql_only_select);
+    assert_eq!(
+        &Expr::Trim {
+            expr: Box::new(Expr::Value(Value::SingleQuotedString("xyz".to_owned()))),
+            trim_where: None,
+            trim_what: None,
+            trim_characters: Some(vec![Expr::Value(Value::SingleQuotedString("a".to_owned()))]),
+        },
+        expr_from_projection(only(&select.projection))
+    );
+
+    // missing comma separation
+    let error_sql = "SELECT TRIM('xyz' 'a')";
+    assert_eq!(
+        ParserError::ParserError("Expected ), found: 'a'\nNear `SELECT TRIM('xyz'`".to_owned()),
+        snowflake().parse_sql_statements(error_sql).unwrap_err()
+    );
+}


### PR DESCRIPTION
# Why
We are getting errors with parsing snowflake `TRIM` expression including removing characters separated by comma.

### Snowflake doc for TRIM
https://docs.snowflake.com/en/sql-reference/functions/trim

### Example of real failing sql
```sql
WITH sub_coupons AS (
    SELECT
        customer_id,
        subscription_id,
        TRIM(coupons.value:coupon_id, '"') AS coupon_id
    FROM model_staging.subscriptions,
    TABLE(FLATTEN(PARSE_JSON(coupons))) AS coupons
)
```