### PR TITLE
Add test for clickhouse: tokenize `==` as Token::DoubleEq

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -31,6 +31,9 @@ use crate::parser::{Parser, ParserError};
 use crate::tokenizer::Tokenizer;
 use crate::{ast::*, parser::ParserOptions};
 
+#[cfg(test)]
+use pretty_assertions::assert_eq;
+
 /// Tests use the methods on this struct to invoke the parser on one or
 /// multiple dialects.
 pub struct TestedDialects {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1368,7 +1368,7 @@ fn peeking_take_while(chars: &mut State, mut predicate: impl FnMut(char) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dialect::{GenericDialect, MsSqlDialect};
+    use crate::dialect::{ClickHouseDialect, GenericDialect, MsSqlDialect};
 
     #[test]
     fn tokenizer_error_impl() {
@@ -1409,6 +1409,28 @@ mod tests {
             Token::make_keyword("SELECT"),
             Token::Whitespace(Whitespace::Space),
             Token::Number(String::from(".1"), false),
+        ];
+
+        compare(expected, tokens);
+    }
+
+    #[test]
+    fn tokenize_clickhouse_double_equal() {
+        let sql = String::from("SELECT foo=='1'");
+        let dialect = ClickHouseDialect {};
+        let mut tokenizer = Tokenizer::new(&dialect, &sql);
+        let tokens = tokenizer.tokenize().unwrap();
+
+        let expected = vec![
+            Token::make_keyword("SELECT"),
+            Token::Whitespace(Whitespace::Space),
+            Token::Word(Word {
+                value: "foo".to_string(),
+                quote_style: None,
+                keyword: Keyword::NoKeyword,
+            }),
+            Token::DoubleEq,
+            Token::SingleQuotedString("1".to_string()),
         ];
 
         compare(expected, tokens);

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -336,6 +336,14 @@ fn parse_create_table() {
     );
 }
 
+#[test]
+fn parse_double_equal() {
+    clickhouse().one_statement_parses_to(
+        r#"SELECT foo FROM bar WHERE buz == 'buz'"#,
+        r#"SELECT foo FROM bar WHERE buz = 'buz'"#,
+    );
+}
+
 fn clickhouse() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(ClickHouseDialect {})],

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6788,10 +6788,10 @@ fn parse_time_functions() {
 
         // Validating Parenthesis
         let sql_without_parens = format!("SELECT {}", func_name);
-        let mut ast_without_parens = select_localtime_func_call_ast.clone();
+        let mut ast_without_parens = select_localtime_func_call_ast;
         ast_without_parens.special = true;
         assert_eq!(
-            &Expr::Function(ast_without_parens.clone()),
+            &Expr::Function(ast_without_parens),
             expr_from_projection(&verified_only_select(&sql_without_parens).projection[0])
         );
     }


### PR DESCRIPTION
I see that the tokenizer changes were applied for Sqlite, but that PR adds additional tests.