### PR TITLE
Support subquery as function arg w/o parens in Snowflake dialect

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1485,7 +1485,7 @@ impl<'a> Parser<'a> {
                 within_group: false,
             }));
         }
-        // Snowflake defines ORDERY BY in within group instead of inside the function like
+        // Snowflake defines ORDER BY in within group instead of inside the function like
         // ANSI SQL.
         self.expect_token(&Token::RParen)?;
         let within_group = if self.parse_keywords(&[Keyword::WITHIN, Keyword::GROUP]) {
@@ -6874,6 +6874,24 @@ impl<'a> Parser<'a> {
         if self.consume_token(&Token::RParen) {
             Ok((vec![], vec![]))
         } else {
+            // Snowflake permits a subquery to be passed as an argument without
+            // an enclosing set of parens if it's the only argument.
+            if dialect_of!(self is SnowflakeDialect)
+                && self
+                    .parse_one_of_keywords(&[Keyword::WITH, Keyword::SELECT])
+                    .is_some()
+            {
+                self.prev_token();
+                let subquery = self.parse_query()?;
+                self.expect_token(&Token::RParen)?;
+                return Ok((
+                    vec![FunctionArg::Unnamed(FunctionArgExpr::from(
+                        WildcardExpr::Expr(Expr::Subquery(Box::new(subquery))),
+                    ))],
+                    vec![],
+                ));
+            }
+
             let args = self.parse_comma_separated(Parser::parse_function_args)?;
             let order_by = if self.parse_keywords(&[Keyword::ORDER, Keyword::BY]) {
                 self.parse_comma_separated(Parser::parse_order_by_expr)?

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1064,3 +1064,23 @@ fn test_snowflake_trim() {
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
+
+#[test]
+fn parse_subquery_function_argument() {
+    // Snowflake allows passing an unparenthesized subquery as the single
+    // argument to a function.
+    snowflake().one_statement_parses_to(
+        "SELECT parse_json(SELECT '{}')",
+        "SELECT parse_json((SELECT '{}'))",
+    );
+
+    // Subqueries that begin with WITH work too.
+    snowflake().one_statement_parses_to(
+        "SELECT parse_json(WITH q AS (SELECT '{}' AS foo) SELECT foo FROM q)",
+        "SELECT parse_json((WITH q AS (SELECT '{}' AS foo) SELECT foo FROM q))",
+    );
+
+    // Commas are parsed as part of the subquery, not additional arguments to
+    // the function.
+    snowflake().one_statement_parses_to("SELECT func(SELECT 1, 2)", "SELECT func((SELECT 1, 2))");
+}


### PR DESCRIPTION
This adds support for a Snowflake quirk where the enclosing parentheses around a subquery can be omitted if it's the only argument to a function. 