### PR TITLE
Support multiple tables in  `TRUNCATE` command 

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1193,10 +1193,10 @@ pub enum Statement {
         noscan: bool,
         compute_statistics: bool,
     },
-    /// Truncate (Hive)
+    /// Truncate (Hive and PostgreSQL)
     Truncate {
         #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
-        table_name: ObjectName,
+        table_names: Vec<ObjectName>,
         partitions: Option<Vec<Expr>>,
         /// TABLE - optional keyword;
         table: bool,
@@ -1982,12 +1982,20 @@ impl fmt::Display for Statement {
                 Ok(())
             }
             Statement::Truncate {
-                table_name,
+                table_names,
                 partitions,
                 table,
             } => {
                 let table = if *table { "TABLE " } else { "" };
-                write!(f, "TRUNCATE {table}{table_name}")?;
+                write!(
+                    f,
+                    "TRUNCATE {table}{}",
+                    table_names
+                        .iter()
+                        .map(|t| t.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )?;
                 if let Some(ref parts) = partitions {
                     if !parts.is_empty() {
                         write!(f, " PARTITION ({})", display_comma_separated(parts))?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -530,7 +530,7 @@ impl<'a> Parser<'a> {
 
     pub fn parse_truncate(&mut self) -> Result<Statement, ParserError> {
         let table = self.parse_keyword(Keyword::TABLE);
-        let table_name = self.parse_object_name()?;
+        let table_names = self.parse_comma_separated(Parser::parse_object_name)?;
         let mut partitions = None;
         if self.parse_keyword(Keyword::PARTITION) {
             self.expect_token(&Token::LParen)?;
@@ -538,7 +538,7 @@ impl<'a> Parser<'a> {
             self.expect_token(&Token::RParen)?;
         }
         Ok(Statement::Truncate {
-            table_name,
+            table_names,
             partitions,
             table,
         })

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3375,9 +3375,22 @@ fn parse_truncate() {
     let truncate = pg_and_generic().verified_stmt("TRUNCATE db.table_name");
     assert_eq!(
         Statement::Truncate {
-            table_name: ObjectName(vec![Ident::new("db"), Ident::new("table_name")]),
+            table_names: vec![ObjectName(vec![Ident::new("db"), Ident::new("table_name")])],
             partitions: None,
             table: false
+        },
+        truncate
+    );
+
+    let truncate = pg_and_generic().verified_stmt("TRUNCATE TABLE tbl1, db.tbl2");
+    assert_eq!(
+        Statement::Truncate {
+            table_names: vec![
+                ObjectName(vec![Ident::new("tbl1")]),
+                ObjectName(vec![Ident::new("db"), Ident::new("tbl2")])
+            ],
+            partitions: None,
+            table: true
         },
         truncate
     );


### PR DESCRIPTION
The `truncate` command can accept a list of tables (as per the documentation: https://www.postgresql.org/docs/current/sql-truncate.html). This PR fixes the current limitation that only one table can be used in the `TRUNCATE` command.