### PR TITLE
Support "with" identifiers surrounded by backticks in `GenericDialect`

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -92,7 +92,7 @@ pub trait Dialect: Debug + Any {
     /// MySQL, MS SQL, and sqlite). You can accept one of characters listed
     /// in `Word::matching_end_quote` here
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
-        ch == '"'
+        ch == '"' || ch == '`'
     }
     /// Determine if quoted characters are proper for identifier
     fn is_proper_identifier_inside_quotes(&self, mut _chars: Peekable<Chars<'_>>) -> bool {


### PR DESCRIPTION
I'm reviving this patch from https://github.com/sqlparser-rs/sqlparser-rs/pull/652

Please let me know what I'd need to do to make this merge-able. I'd like to be able to stop operating a fork of `sqlparser-rs` for parsing our Hive/Athena SQL so any direction you can give is much appreciated.

`parse_describe` validates the behavior for the hive and generic dialects.