### PR TITLE
Support  `SELECT * EXCEPT/REPLACE` syntax from ClickHouse

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -431,11 +431,13 @@ pub struct WildcardAdditionalOptions {
     /// `[EXCLUDE...]`.
     pub opt_exclude: Option<ExcludeSelectItem>,
     /// `[EXCEPT...]`.
+    ///  Clickhouse syntax: <https://clickhouse.com/docs/en/sql-reference/statements/select#except>
     pub opt_except: Option<ExceptSelectItem>,
     /// `[RENAME ...]`.
     pub opt_rename: Option<RenameSelectItem>,
     /// `[REPLACE]`
     ///  BigQuery syntax: <https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace>
+    ///  Clickhouse syntax: <https://clickhouse.com/docs/en/sql-reference/statements/select#replace>
     pub opt_replace: Option<ReplaceSelectItem>,
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6935,7 +6935,8 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
-        let opt_except = if dialect_of!(self is GenericDialect | BigQueryDialect) {
+        let opt_except = if dialect_of!(self is GenericDialect | BigQueryDialect | ClickHouseDialect)
+        {
             self.parse_optional_select_item_except()?
         } else {
             None
@@ -6946,7 +6947,8 @@ impl<'a> Parser<'a> {
             None
         };
 
-        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect) {
+        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect | ClickHouseDialect)
+        {
             self.parse_optional_select_item_replace()?
         } else {
             None

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -361,6 +361,14 @@ fn parse_select_star_except() {
 }
 
 #[test]
+fn parse_select_star_except_no_parens() {
+    clickhouse().one_statement_parses_to(
+        "SELECT * EXCEPT prev_status FROM anomalies",
+        "SELECT * EXCEPT (prev_status) FROM anomalies",
+    );
+}
+
+#[test]
 fn parse_select_star_replace() {
     clickhouse().verified_stmt("SELECT * REPLACE (i + 1 AS i) FROM columns_transformers");
 }

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -355,6 +355,16 @@ fn parse_limit_by() {
     );
 }
 
+#[test]
+fn parse_select_star_except() {
+    clickhouse().verified_stmt("SELECT * EXCEPT (prev_status) FROM anomalies");
+}
+
+#[test]
+fn parse_select_star_replace() {
+    clickhouse().verified_stmt("SELECT * REPLACE (i + 1 AS i) FROM columns_transformers");
+}
+
 fn clickhouse() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(ClickHouseDialect {})],


### PR DESCRIPTION
Clickhouse supports much more advanced column meta-level operations which I would consider for future PRs:

```
SELECT * REPLACE(i + 1 AS i) EXCEPT (j) APPLY(sum) from columns_transformers;
```

[1] https://clickhouse.com/docs/en/sql-reference/statements/select#modifier-combinations