### PR TITLE
Support `date` 'key' when using semi structured data

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4659,7 +4659,7 @@ impl<'a> Parser<'a> {
                     )?,
                 },
                 // Case when Snowflake Semi-structured data like key:value
-                Keyword::NoKeyword | Keyword::LOCATION | Keyword::TYPE if dialect_of!(self is SnowflakeDialect | GenericDialect) => {
+                Keyword::NoKeyword | Keyword::LOCATION | Keyword::TYPE | Keyword::DATE if dialect_of!(self is SnowflakeDialect | GenericDialect) => {
                     Ok(Value::UnQuotedString(w.value))
                 }
                 _ => self.expected(

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -208,6 +208,17 @@ fn parse_json_using_colon() {
         select.projection[0]
     );
 
+    let sql = "SELECT a:date FROM t";
+    let select = snowflake().verified_only_select(sql);
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::JsonAccess {
+            left: Box::new(Expr::Identifier(Ident::new("a"))),
+            operator: JsonOperator::Colon,
+            right: Box::new(Expr::Value(Value::UnQuotedString("date".to_string()))),
+        }),
+        select.projection[0]
+    );
+
     snowflake().one_statement_parses_to("SELECT a:b::int FROM t", "SELECT CAST(a:b AS INT) FROM t");
 }
 


### PR DESCRIPTION
Add support to the following query:

```
SELECT JSON_DATA:date::date as date
FROM t1

```