### PR TITLE
Snowflake - Support lateral flatten

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -268,6 +268,7 @@ define_keywords!(
     FILTER,
     FIRST,
     FIRST_VALUE,
+    FLATTEN,
     FLOAT,
     FLOAT4,
     FLOAT8,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6319,10 +6319,8 @@ impl<'a> Parser<'a> {
     pub fn parse_table_factor(&mut self) -> Result<TableFactor, ParserError> {
         // Allow Support in Snowflake: "FROM lateral flatten(input => f.value:business) f1;"
         // Snowflake also supports LATERAL (query) so we need to idenitify this exact case
-        let flatten = match self.peek_nth_token(1).token {
-            Token::Word(w) if w.keyword == Keyword::FLATTEN => true,
-            _ => false,
-        };
+        let flatten =
+            matches!(self.peek_nth_token(1).token, Token::Word(w) if w.keyword == Keyword::FLATTEN);
 
         if self.parse_keyword(Keyword::LATERAL) && !flatten {
             // LATERAL must always be followed by a subquery.

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1092,3 +1092,11 @@ fn parse_subquery_function_argument() {
     // the function.
     snowflake().one_statement_parses_to("SELECT func(SELECT 1, 2)", "SELECT func((SELECT 1, 2))");
 }
+
+#[test]
+fn parse_flatten_with_lateral() {
+    snowflake().one_statement_parses_to(
+        "SELECT f.value AS Contact FROM t1, lateral flatten(input => p.c, path => 'contact') AS f",
+        "SELECT f.value AS Contact FROM t1, flatten(input => p.c, path => 'contact') AS f",
+    );
+}


### PR DESCRIPTION
Snowflake has the possibility to use the keywords [lateral flatten](https://docs.snowflake.com/en/sql-reference/functions/flatten):

`f.value AS "Contact",
  f1.value:type AS "Type",
  FROM persons p,
  lateral flatten(input => p.c, path => 'contact') f,
  lateral flatten(input => f.value:business) f1;`

While it seems `lateral` is only indicating that it's based on the line above, I found it simple enough just to ignore it.