### PR TITLE
common: Make sure + - * / % binary operators work the same in all dialects

### DIFF
--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -27,10 +27,6 @@ impl Dialect for BigQueryDialect {
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        ch.is_ascii_lowercase()
-            || ch.is_ascii_uppercase()
-            || ch.is_ascii_digit()
-            || ch == '_'
-            || ch == '-'
+        ch.is_ascii_lowercase() || ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_'
     }
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -615,8 +615,6 @@ fn parse_table_identifiers() {
         assert!(bigquery().parse_sql_statements(&sql).is_err());
     }
 
-    test_table_ident("da-sh-es", None, vec![Ident::new("da-sh-es")]);
-
     test_table_ident("`spa ce`", None, vec![Ident::with_quote('`', "spa ce")]);
 
     test_table_ident(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7744,3 +7744,61 @@ fn parse_create_type() {
 fn parse_create_table_collate() {
     pg_and_generic().verified_stmt("CREATE TABLE tbl (foo INT, bar TEXT COLLATE \"de_DE\")");
 }
+
+#[test]
+fn parse_binary_operators_without_whitespace() {
+    // x + y
+    all_dialects().one_statement_parses_to(
+        "SELECT field+1000 FROM tbl1",
+        "SELECT field + 1000 FROM tbl1",
+    );
+
+    all_dialects().one_statement_parses_to(
+        "SELECT tbl1.field+tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+        "SELECT tbl1.field + tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+    );
+
+    // x - y
+    all_dialects().one_statement_parses_to(
+        "SELECT field-1000 FROM tbl1",
+        "SELECT field - 1000 FROM tbl1",
+    );
+
+    all_dialects().one_statement_parses_to(
+        "SELECT tbl1.field-tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+        "SELECT tbl1.field - tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+    );
+
+    // x * y
+    all_dialects().one_statement_parses_to(
+        "SELECT field*1000 FROM tbl1",
+        "SELECT field * 1000 FROM tbl1",
+    );
+
+    all_dialects().one_statement_parses_to(
+        "SELECT tbl1.field*tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+        "SELECT tbl1.field * tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+    );
+
+    // x / y
+    all_dialects().one_statement_parses_to(
+        "SELECT field/1000 FROM tbl1",
+        "SELECT field / 1000 FROM tbl1",
+    );
+
+    all_dialects().one_statement_parses_to(
+        "SELECT tbl1.field/tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+        "SELECT tbl1.field / tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+    );
+
+    // x % y
+    all_dialects().one_statement_parses_to(
+        "SELECT field%1000 FROM tbl1",
+        "SELECT field % 1000 FROM tbl1",
+    );
+
+    all_dialects().one_statement_parses_to(
+        "SELECT tbl1.field%tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+        "SELECT tbl1.field % tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
+    );
+}


### PR DESCRIPTION
After https://github.com/sqlparser-rs/sqlparser-rs/pull/1009 is merged this will pass.

From what I see in BigQuery docs, `da-sh-es` is invalid identifier when used without quotes.
https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#unquoted_identifiers