### PR TITLE
Support `IN ()` syntax of SQLite, alternate proposal

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -124,6 +124,10 @@ pub trait Dialect: Debug + Any {
     fn supports_substring_from_for_expr(&self) -> bool {
         true
     }
+    /// Returns true if the dialect supports `(NOT) IN ()` expressions
+    fn supports_in_empty_list(&self) -> bool {
+        false
+    }
     /// Dialect-specific prefix parser override
     fn parse_prefix(&self, _parser: &mut Parser) -> Option<Result<Expr, ParserError>> {
         // return None to fall back to the default behavior

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -52,4 +52,8 @@ impl Dialect for SQLiteDialect {
             None
         }
     }
+
+    fn supports_in_empty_list(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
This is an alternate proposal for supporting `IN ()` from SQLite, based on https://github.com/sqlparser-rs/sqlparser-rs/pull/1005 from @lewiszlw 

![image](https://github.com/sqlparser-rs/sqlparser-rs/assets/17514693/479931f7-8ab8-4668-88d5-efe1868e7c08)
SQLite3 supports in empty list expression.

Closes https://github.com/sqlparser-rs/sqlparser-rs/pull/1005

This PR
1. Passes all tests from https://github.com/sqlparser-rs/sqlparser-rs/pull/1005
2. Is substantially fewer lines of code
3. Includes a negative test