### PR TITLE
Support global and session parts in show variables for mysql and generic dialects

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2986,12 +2986,14 @@ impl fmt::Display for Statement {
                 global,
                 session,
             } => {
-                write!(
-                    f,
-                    "SHOW {global}{session}VARIABLES",
-                    global = if *global { "GLOBAL " } else { "" },
-                    session = if *session { "SESSION " } else { "" }
-                )?;
+                write!(f, "SHOW")?;
+                if *global {
+                    write!(f, " GLOBAL")?;
+                }
+                if *session {
+                    write!(f, " SESSION")?;
+                }
+                write!(f, " VARIABLES")?;
                 if filter.is_some() {
                     write!(f, " {}", filter.as_ref().unwrap())?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1739,7 +1739,11 @@ pub enum Statement {
     /// SHOW VARIABLES
     ///
     /// Note: this is a MySQL-specific statement.
-    ShowVariables { filter: Option<ShowStatementFilter> },
+    ShowVariables {
+        filter: Option<ShowStatementFilter>,
+        global: bool,
+        session: bool,
+    },
     /// SHOW CREATE TABLE
     ///
     /// Note: this is a MySQL-specific statement.
@@ -2977,8 +2981,17 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::ShowVariables { filter } => {
-                write!(f, "SHOW VARIABLES")?;
+            Statement::ShowVariables {
+                filter,
+                global,
+                session,
+            } => {
+                write!(
+                    f,
+                    "SHOW {global}{session}VARIABLES",
+                    global = if *global { "GLOBAL " } else { "" },
+                    session = if *session { "SESSION " } else { "" }
+                )?;
                 if filter.is_some() {
                     write!(f, " {}", filter.as_ref().unwrap())?;
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6330,6 +6330,8 @@ impl<'a> Parser<'a> {
     pub fn parse_show(&mut self) -> Result<Statement, ParserError> {
         let extended = self.parse_keyword(Keyword::EXTENDED);
         let full = self.parse_keyword(Keyword::FULL);
+        let session = self.parse_keyword(Keyword::SESSION);
+        let global = self.parse_keyword(Keyword::GLOBAL);
         if self
             .parse_one_of_keywords(&[Keyword::COLUMNS, Keyword::FIELDS])
             .is_some()
@@ -6350,9 +6352,10 @@ impl<'a> Parser<'a> {
         } else if self.parse_keyword(Keyword::VARIABLES)
             && dialect_of!(self is MySqlDialect | GenericDialect)
         {
-            // TODO: Support GLOBAL|SESSION
             Ok(Statement::ShowVariables {
                 filter: self.parse_show_statement_filter()?,
+                session,
+                global,
             })
         } else {
             Ok(Statement::ShowVariable {

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1503,6 +1503,12 @@ fn parse_show_variables() {
     mysql_and_generic().verified_stmt("SHOW VARIABLES");
     mysql_and_generic().verified_stmt("SHOW VARIABLES LIKE 'admin%'");
     mysql_and_generic().verified_stmt("SHOW VARIABLES WHERE value = '3306'");
+    mysql_and_generic().verified_stmt("SHOW GLOBAL VARIABLES");
+    mysql_and_generic().verified_stmt("SHOW GLOBAL VARIABLES LIKE 'admin%'");
+    mysql_and_generic().verified_stmt("SHOW GLOBAL VARIABLES WHERE value = '3306'");
+    mysql_and_generic().verified_stmt("SHOW SESSION VARIABLES");
+    mysql_and_generic().verified_stmt("SHOW SESSION VARIABLES LIKE 'admin%'");
+    mysql_and_generic().verified_stmt("SHOW GLOBAL VARIABLES WHERE value = '3306'");
 }
 
 #[test]


### PR DESCRIPTION
Examples: 
    mysql_and_generic().verified_stmt("SHOW GLOBAL VARIABLES");
    mysql_and_generic().verified_stmt("SHOW GLOBAL VARIABLES LIKE 'admin%'");
    mysql_and_generic().verified_stmt("SHOW GLOBAL VARIABLES WHERE value = '3306'");
    mysql_and_generic().verified_stmt("SHOW SESSION VARIABLES");
    mysql_and_generic().verified_stmt("SHOW SESSION VARIABLES LIKE 'admin%'");
    mysql_and_generic().verified_stmt("SHOW GLOBAL VARIABLES WHERE value = '3306'");