### PR TITLE
Add support for release and rollback to savepoint syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1802,8 +1802,11 @@ pub enum Statement {
     },
     /// `COMMIT [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]`
     Commit { chain: bool },
-    /// `ROLLBACK [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]`
-    Rollback { chain: bool },
+    /// `ROLLBACK [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ] [ TO [ SAVEPOINT ] savepoint_name ]`
+    Rollback {
+        chain: bool,
+        savepoint: Option<Ident>,
+    },
     /// CREATE SCHEMA
     CreateSchema {
         /// `<schema name> | AUTHORIZATION <schema authorization identifier>  | <schema name>  AUTHORIZATION <schema authorization identifier>`
@@ -1940,6 +1943,8 @@ pub enum Statement {
     },
     /// SAVEPOINT -- define a new savepoint within the current transaction
     Savepoint { name: Ident },
+    /// RELEASE [ SAVEPOINT ] savepoint_name
+    ReleaseSavepoint { name: Ident },
     // MERGE INTO statement, based on Snowflake. See <https://docs.snowflake.com/en/sql-reference/sql/merge.html>
     Merge {
         // optional INTO keyword
@@ -3079,8 +3084,18 @@ impl fmt::Display for Statement {
             Statement::Commit { chain } => {
                 write!(f, "COMMIT{}", if *chain { " AND CHAIN" } else { "" },)
             }
-            Statement::Rollback { chain } => {
-                write!(f, "ROLLBACK{}", if *chain { " AND CHAIN" } else { "" },)
+            Statement::Rollback { chain, savepoint } => {
+                write!(f, "ROLLBACK")?;
+
+                if *chain {
+                    write!(f, " AND CHAIN")?;
+                }
+
+                if let Some(savepoint) = savepoint {
+                    write!(f, " TO SAVEPOINT {savepoint}")?;
+                }
+
+                Ok(())
             }
             Statement::CreateSchema {
                 schema_name,
@@ -3176,6 +3191,9 @@ impl fmt::Display for Statement {
             Statement::Savepoint { name } => {
                 write!(f, "SAVEPOINT ")?;
                 write!(f, "{name}")
+            }
+            Statement::ReleaseSavepoint { name } => {
+                write!(f, "RELEASE SAVEPOINT {name}")
             }
             Statement::Merge {
                 into,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -502,6 +502,7 @@ impl<'a> Parser<'a> {
                 // by at least PostgreSQL and MySQL.
                 Keyword::BEGIN => Ok(self.parse_begin()?),
                 Keyword::SAVEPOINT => Ok(self.parse_savepoint()?),
+                Keyword::RELEASE => Ok(self.parse_release()?),
                 Keyword::COMMIT => Ok(self.parse_commit()?),
                 Keyword::ROLLBACK => Ok(self.parse_rollback()?),
                 Keyword::ASSERT => Ok(self.parse_assert()?),
@@ -745,6 +746,13 @@ impl<'a> Parser<'a> {
     pub fn parse_savepoint(&mut self) -> Result<Statement, ParserError> {
         let name = self.parse_identifier()?;
         Ok(Statement::Savepoint { name })
+    }
+
+    pub fn parse_release(&mut self) -> Result<Statement, ParserError> {
+        let _ = self.parse_keyword(Keyword::SAVEPOINT);
+        let name = self.parse_identifier()?;
+
+        Ok(Statement::ReleaseSavepoint { name })
     }
 
     /// Parse an expression prefix
@@ -7664,9 +7672,10 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_rollback(&mut self) -> Result<Statement, ParserError> {
-        Ok(Statement::Rollback {
-            chain: self.parse_commit_rollback_chain()?,
-        })
+        let chain = self.parse_commit_rollback_chain()?;
+        let savepoint = self.parse_rollback_savepoint()?;
+
+        Ok(Statement::Rollback { chain, savepoint })
     }
 
     pub fn parse_commit_rollback_chain(&mut self) -> Result<bool, ParserError> {
@@ -7677,6 +7686,17 @@ impl<'a> Parser<'a> {
             Ok(chain)
         } else {
             Ok(false)
+        }
+    }
+
+    pub fn parse_rollback_savepoint(&mut self) -> Result<Option<Ident>, ParserError> {
+        if self.parse_keyword(Keyword::TO) {
+            let _ = self.parse_keyword(Keyword::SAVEPOINT);
+            let savepoint = self.parse_identifier()?;
+
+            Ok(Some(savepoint))
+        } else {
+            Ok(None)
         }
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6230,12 +6230,38 @@ fn parse_commit() {
 #[test]
 fn parse_rollback() {
     match verified_stmt("ROLLBACK") {
-        Statement::Rollback { chain: false } => (),
+        Statement::Rollback {
+            chain: false,
+            savepoint: None,
+        } => (),
         _ => unreachable!(),
     }
 
     match verified_stmt("ROLLBACK AND CHAIN") {
-        Statement::Rollback { chain: true } => (),
+        Statement::Rollback {
+            chain: true,
+            savepoint: None,
+        } => (),
+        _ => unreachable!(),
+    }
+
+    match verified_stmt("ROLLBACK TO SAVEPOINT test1") {
+        Statement::Rollback {
+            chain: false,
+            savepoint,
+        } => {
+            assert_eq!(savepoint, Some(Ident::new("test1")));
+        }
+        _ => unreachable!(),
+    }
+
+    match verified_stmt("ROLLBACK AND CHAIN TO SAVEPOINT test1") {
+        Statement::Rollback {
+            chain: true,
+            savepoint,
+        } => {
+            assert_eq!(savepoint, Some(Ident::new("test1")));
+        }
         _ => unreachable!(),
     }
 
@@ -6246,6 +6272,11 @@ fn parse_rollback() {
     one_statement_parses_to("ROLLBACK TRANSACTION AND CHAIN", "ROLLBACK AND CHAIN");
     one_statement_parses_to("ROLLBACK WORK", "ROLLBACK");
     one_statement_parses_to("ROLLBACK TRANSACTION", "ROLLBACK");
+    one_statement_parses_to("ROLLBACK TO test1", "ROLLBACK TO SAVEPOINT test1");
+    one_statement_parses_to(
+        "ROLLBACK AND CHAIN TO test1",
+        "ROLLBACK AND CHAIN TO SAVEPOINT test1",
+    );
 }
 
 #[test]
@@ -7858,4 +7889,26 @@ fn parse_binary_operators_without_whitespace() {
         "SELECT tbl1.field%tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
         "SELECT tbl1.field % tbl2.field FROM tbl1 JOIN tbl2 ON tbl1.id = tbl2.entity_id",
     );
+}
+
+#[test]
+fn test_savepoint() {
+    match verified_stmt("SAVEPOINT test1") {
+        Statement::Savepoint { name } => {
+            assert_eq!(Ident::new("test1"), name);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_release_savepoint() {
+    match verified_stmt("RELEASE SAVEPOINT test1") {
+        Statement::ReleaseSavepoint { name } => {
+            assert_eq!(Ident::new("test1"), name);
+        }
+        _ => unreachable!(),
+    }
+
+    one_statement_parses_to("RELEASE test1", "RELEASE SAVEPOINT test1");
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2086,16 +2086,6 @@ fn test_transaction_statement() {
 }
 
 #[test]
-fn test_savepoint() {
-    match pg().verified_stmt("SAVEPOINT test1") {
-        Statement::Savepoint { name } => {
-            assert_eq!(Ident::new("test1"), name);
-        }
-        _ => unreachable!(),
-    }
-}
-
-#[test]
 fn test_json() {
     let sql = "SELECT params ->> 'name' FROM events";
     let select = pg().verified_only_select(sql);


### PR DESCRIPTION
This PR adds support for:
* `RELEASE SAVEPOINT savepoint_name` statements
* `TO SAVEPOINT savepoint_name` in `ROLLBACK` statements.

Note that support for `SAVEPOINT savepoint_name` statements was already added in https://github.com/sqlparser-rs/sqlparser-rs/pull/438, so I didn't need to include that here.

Both `ROLLBACK ... TO SAVEPOINT savepoint_name` and `RELEASE SAVEPOINT savepoint_name` are part of the SQL grammar (see [here](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_17_8_rollback_statement) and [here](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_17_6_release_savepoint_statement)). At least Postgres (see [here](https://www.postgresql.org/docs/current/sql-rollback-to.html) and [here](https://www.postgresql.org/docs/current/sql-release-savepoint.html)), SQLite (see [here](https://www.sqlite.org/lang_savepoint.html)), and MySQL (see [here](https://dev.mysql.com/doc/refman/8.0/en/savepoint.html)) support savepoints.

The `SAVEPOINT` keyword is optional when used in `ROLLBACK` and `RELEASE` statements in Postgres and SQLite; required in both statements in the SQL grammar; and optional in `ROLLBACK`, but required in `RELEASE` in MySQL. This PR makes the `SAVEPOINT` keyword optional while parsing, but includes it in the canonical format used when printing since all dialects that I've checked so far at least allow for including it.