### PR TITLE
Surface location in parse errors

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -1,0 +1,181 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helpers for annotating parse errors with the source query.
+
+use crate::{parser::ParserError, tokenizer::TokenizerError};
+use std::fmt::Write;
+
+/// Generates a string containing the orginal query annotated with the error
+/// message.
+///
+/// In cases where the parser error does not contain location information, or
+/// the location isn't valid, the returned string will just be the error string
+/// itself.
+pub fn annotate_with_error(query: &str, err: ParserError) -> String {
+    // Pull out the message and location...
+    let (msg, loc) = match &err {
+        ParserError::TokenizerError(TokenizerError { message, location }) => (message, location),
+        ParserError::ParserError { message, location } => match location {
+            Some(loc) if loc.line > 0 && loc.column > 0 => (message, loc),
+            _ => return err.to_string(),
+        },
+        ParserError::RecursionLimitExceeded => return err.to_string(),
+    };
+
+    let lines: Vec<_> = query.lines().collect();
+
+    let top_lines = match lines.get(0..loc.line as usize) {
+        Some(lines) => lines,
+        None => return err.to_string(),
+    };
+
+    let mut buf = String::with_capacity(query.len());
+
+    // Write lines before the annotation (including the line where the error
+    // ocurred).
+    for line in top_lines {
+        buf.push_str(line);
+        buf.push('\n');
+    }
+
+    // Write the error message left padded with spaces to line it up with where
+    // the error ocurred.
+    let pad = (loc.column - 1) as usize;
+    write!(buf, "{:<1$}", "", pad).unwrap();
+    write!(buf, "^ {msg}").unwrap();
+
+    let remaining_lines = lines.get(loc.line as usize..).unwrap_or_default();
+
+    for line in remaining_lines {
+        buf.push('\n');
+        buf.push_str(line);
+    }
+    buf.push('\n');
+
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ast::Statement, dialect::GenericDialect, parser::Parser, tokenizer::Tokenizer};
+
+    use super::*;
+
+    fn test_parse(sql: &str) -> Result<Vec<Statement>, ParserError> {
+        let dialect = &GenericDialect {};
+        let mut tokenizer = Tokenizer::new(dialect, sql);
+        let tokens = tokenizer.tokenize_with_location()?;
+        Parser::new(dialect)
+            .with_tokens_with_locations(tokens)
+            .parse_statements()
+    }
+
+    fn assert_eq_with_print(expected: impl Into<String>, got: impl Into<String>) {
+        let expected = expected.into();
+        let got = got.into();
+        assert_eq!(expected, got, "\nexpected ---\n{expected}\ngot ---\n{got}");
+    }
+
+    #[test]
+    fn not_a_sql_statement() {
+        let sql = "hello";
+        let err = test_parse(sql).unwrap_err();
+
+        let expected = ["hello", "^ Expected an SQL statement, found: hello"].join("\n");
+        let got = annotate_with_error(sql, err);
+
+        assert_eq_with_print(expected, got);
+    }
+
+    #[test]
+    fn single_line() {
+        let sql = "select 1 order by a from b";
+        let err = test_parse(sql).unwrap_err();
+
+        let expected = [
+            "select 1 order by a from b",
+            "                    ^ Expected end of statement, found: from",
+        ]
+        .join("\n");
+        let got = annotate_with_error(sql, err);
+
+        assert_eq_with_print(expected, got);
+    }
+
+    #[test]
+    fn multiline_with_error_in_middle() {
+        let sql = [
+            "select",
+            "    a,",
+            "    b,,",
+            "from public.letters",
+            "order by b",
+        ]
+        .join("\n");
+        let err = test_parse(&sql).unwrap_err();
+
+        let expected = [
+            "select",
+            "    a,",
+            "    b,,",
+            "      ^ Expected an expression:, found: ,",
+            "from public.letters",
+            "order by b",
+        ]
+        .join("\n");
+        let got = annotate_with_error(&sql, err);
+
+        assert_eq_with_print(expected, got);
+    }
+
+    #[test]
+    fn multiline_with_error_last_line() {
+        let sql = [
+            "select a, b, c, d",
+            "from public.letters",
+            "order by b",
+            "limit a from public.letters",
+        ]
+        .join("\n");
+        let err = test_parse(&sql).unwrap_err();
+
+        let expected = [
+            "select a, b, c, d",
+            "from public.letters",
+            "order by b",
+            "limit a from public.letters",
+            "        ^ Expected end of statement, found: from",
+        ]
+        .join("\n");
+        let got = annotate_with_error(&sql, err);
+
+        assert_eq_with_print(expected, got);
+    }
+
+    #[test]
+    fn different_query_annotated() {
+        let sql = [
+            "select a, b, c, d",
+            "from public.letters",
+            "order by b",
+            "limit a from public.letters",
+        ]
+        .join("\n");
+        let err = test_parse(&sql).unwrap_err();
+        let expected =
+            "sql parser error: Expected end of statement, found: from at Line: 4, Column 9";
+        let got = annotate_with_error("select 1, 2", err);
+
+        assert_eq_with_print(expected, got);
+    }
+}

--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -341,7 +341,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 order_by,
                 strict,
             }),
-            _ => Err(ParserError::ParserError(format!(
+            _ => Err(ParserError::new_parser_error(format!(
                 "Expected create table statement, but received: {stmt}"
             ))),
         }
@@ -369,7 +369,7 @@ mod tests {
 
         assert_eq!(
             CreateTableBuilder::try_from(stmt).unwrap_err(),
-            ParserError::ParserError(
+            ParserError::new_parser_error(
                 "Expected create table statement, but received: COMMIT".to_owned()
             )
         );

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -320,7 +320,7 @@ fn parse_select_items_for_data_load(
         match next_token.token {
             Token::Placeholder(w) => {
                 file_col_num = w.to_string().split_off(1).parse::<i32>().map_err(|e| {
-                    ParserError::ParserError(format!("Could not parse '{w}' as i32: {e}"))
+                    ParserError::new_parser_error(format!("Could not parse '{w}' as i32: {e}"))
                 })?;
                 Ok(())
             }
@@ -338,7 +338,7 @@ fn parse_select_items_for_data_load(
             match col_num_token.token {
                 Token::Placeholder(w) => {
                     file_col_num = w.to_string().split_off(1).parse::<i32>().map_err(|e| {
-                        ParserError::ParserError(format!("Could not parse '{w}' as i32: {e}"))
+                        ParserError::new_parser_error(format!("Could not parse '{w}' as i32: {e}"))
                     })?;
                     Ok(())
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ extern crate pretty_assertions;
 pub mod ast;
 #[macro_use]
 pub mod dialect;
+pub mod annotate;
 pub mod keywords;
 pub mod parser;
 pub mod tokenizer;

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -31,8 +31,8 @@ impl<'a> Parser<'a> {
             return self.parse_mssql_alter_role();
         }
 
-        Err(ParserError::ParserError(
-            "ALTER ROLE is only support for PostgreSqlDialect, MsSqlDialect".into(),
+        Err(ParserError::new_parser_error(
+            "ALTER ROLE is only support for PostgreSqlDialect, MsSqlDialect",
         ))
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -90,9 +90,9 @@ impl TestedDialects {
             if let Some(options) = &self.options {
                 tokenizer = tokenizer.with_unescape(options.unescape);
             }
-            let tokens = tokenizer.tokenize()?;
+            let tokens = tokenizer.tokenize_with_location()?;
             self.new_parser(dialect)
-                .with_tokens(tokens)
+                .with_tokens_with_locations(tokens)
                 .parse_statements()
         })
         // To fail the `ensure_multiple_dialects_are_tested` test:

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -411,7 +411,7 @@ impl fmt::Display for TokenWithLocation {
 }
 
 /// Tokenizer error
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TokenizerError {
     pub message: String,
     pub location: Location,

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -22,6 +22,7 @@ use sqlparser::ast::{
 use sqlparser::dialect::{GenericDialect, HiveDialect};
 use sqlparser::parser::{ParserError, ParserOptions};
 use sqlparser::test_utils::*;
+use sqlparser::tokenizer::Location;
 
 #[test]
 fn parse_table_create() {
@@ -251,8 +252,9 @@ fn set_statement_with_minus() {
 
     assert_eq!(
         hive().parse_sql_statements("SET hive.tez.java.opts = -"),
-        Err(ParserError::ParserError(
-            "Expected variable value, found: EOF".to_string()
+        Err(ParserError::new_parser_error_with_location(
+            "Expected variable value, found: EOF".to_string(),
+            Location { line: 0, column: 0 }
         ))
     )
 }
@@ -287,15 +289,22 @@ fn parse_create_function() {
 
     assert_eq!(
         generic(None).parse_sql_statements(sql).unwrap_err(),
-        ParserError::ParserError(
-            "Expected an object type after CREATE, found: FUNCTION".to_string()
+        ParserError::new_parser_error_with_location(
+            "Expected an object type after CREATE, found: FUNCTION".to_string(),
+            Location {
+                line: 1,
+                column: 18
+            }
         )
     );
 
     let sql = "CREATE TEMPORARY FUNCTION mydb.myfunc AS 'org.random.class.Name' USING JAR";
     assert_eq!(
         hive().parse_sql_statements(sql).unwrap_err(),
-        ParserError::ParserError("Expected literal string, found: EOF".to_string()),
+        ParserError::new_parser_error_with_location(
+            "Expected literal string, found: EOF".to_string(),
+            Location { line: 0, column: 0 }
+        ),
     );
 }
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -157,7 +157,7 @@ fn test_single_table_in_parenthesis_with_alias() {
 
     let res = snowflake().parse_sql_statements("SELECT * FROM (a b) c");
     assert_eq!(
-        ParserError::ParserError("duplicate alias b".to_string()),
+        ParserError::new_parser_error("duplicate alias b".to_string()),
         res.unwrap_err()
     );
 }
@@ -412,9 +412,13 @@ fn test_array_agg_func() {
     let result = snowflake().parse_sql_statements(sql);
     assert_eq!(
         result,
-        Err(ParserError::ParserError(String::from(
-            "Expected ), found: order"
-        )))
+        Err(ParserError::new_parser_error_with_location(
+            "Expected ), found: order",
+            Location {
+                line: 1,
+                column: 20,
+            },
+        ))
     )
 }
 
@@ -519,7 +523,7 @@ fn test_select_wildcard_with_exclude_and_rename() {
             .parse_sql_statements("SELECT * RENAME col_a AS col_b EXCLUDE col_z FROM data")
             .unwrap_err()
             .to_string(),
-        "sql parser error: Expected end of statement, found: EXCLUDE"
+        "sql parser error: Expected end of statement, found: EXCLUDE at Line: 1, Column 32"
     );
 }
 
@@ -1083,7 +1087,13 @@ fn test_snowflake_trim() {
     // missing comma separation
     let error_sql = "SELECT TRIM('xyz' 'a')";
     assert_eq!(
-        ParserError::ParserError("Expected ), found: 'a'".to_owned()),
+        ParserError::new_parser_error_with_location(
+            "Expected ), found: 'a'",
+            Location {
+                line: 1,
+                column: 19,
+            }
+        ),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -414,7 +414,7 @@ fn invalid_empty_list() {
     let sql = "SELECT * FROM t1 WHERE a IN (,,)";
     let sqlite = sqlite_with_options(ParserOptions::new().with_trailing_commas(true));
     assert_eq!(
-        "sql parser error: Expected an expression:, found: ,",
+        "sql parser error: Expected an expression:, found: , at Line: 1, Column 30",
         sqlite.parse_sql_statements(sql).unwrap_err().to_string()
     );
 }


### PR DESCRIPTION
Surfaces location in `ParserError` to allow library users to be able to enrich error messages that are shown to end users. The `annotate_with_error` shows an example use case where we can generate an error string that shows the full query with the error displayed inline.

For example, if I submit the following query:

```
select
    a,
    b,,
from public.letters
order by b
```

I can take the error from parsing that, and use the extra location info to be able to generate the following:

```
select
    a,
    b,,
      ^ Expected an expression:, found: ,
from public.letters
order by b
```

---

This is a breaking change as it's touching `ParserError`, and downstream projects (datafusion) would be impacted by this (the custom sql parser in particular). I added in `ParserError::new_parser_error` to make the changes need relatively straightforward.

Longer term, I think `ParserError` can be improved a bit more to allow even better diagnostics to be displayed to the end user. What I'm thinking:

```rust
pub struct ParserError<'a> {
    /// The kind of the error, parsing, tokenenizing, recursion limit, etc.
    pub kind: ParserErrorKind,

    /// Error message to show the user.
    pub msg: String,

    /// The query currently being parsed.
    pub query: &'a str,

    /// Location context (or a span if that gets threaded around).
    pub location: Option<Location>,
}
```

Obviously that's an even more breaking change, but I think it'd be worth it to make the errors returned to users very informative.