### PR TITLE
Support `CONVERT`  expressions

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -128,6 +128,11 @@ pub trait Dialect: Debug + Any {
     fn supports_in_empty_list(&self) -> bool {
         false
     }
+    /// Returns true if the dialect has a CONVERT function which accepts a type first
+    /// and an expression second, e.g. `CONVERT(varchar, 1)`
+    fn convert_type_before_value(&self) -> bool {
+        false
+    }
     /// Dialect-specific prefix parser override
     fn parse_prefix(&self, _parser: &mut Parser) -> Option<Result<Expr, ParserError>> {
         // return None to fall back to the default behavior

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -35,6 +35,12 @@ impl Dialect for MsSqlDialect {
             || ch == '_'
     }
 
+    /// SQL Server has `CONVERT(type, value)` instead of `CONVERT(value, type)`
+    /// <https://learn.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver16>
+    fn convert_type_before_value(&self) -> bool {
+        true
+    }
+
     fn supports_substring_from_for_expr(&self) -> bool {
         false
     }

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -53,4 +53,10 @@ impl Dialect for RedshiftSqlDialect {
         // Extends Postgres dialect with sharp
         PostgreSqlDialect {}.is_identifier_part(ch) || ch == '#'
     }
+
+    /// redshift has `CONVERT(type, value)` instead of `CONVERT(value, type)`
+    /// <https://docs.aws.amazon.com/redshift/latest/dg/r_CONVERT_function.html>
+    fn convert_type_before_value(&self) -> bool {
+        true
+    }
 }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -476,6 +476,13 @@ fn parse_cast_varchar_max() {
 }
 
 #[test]
+fn parse_convert() {
+    ms().verified_expr("CONVERT(VARCHAR(MAX), 'foo')");
+    ms().verified_expr("CONVERT(VARCHAR(10), 'foo')");
+    ms().verified_expr("CONVERT(DECIMAL(10,5), 12.55)");
+}
+
+#[test]
 fn parse_similar_to() {
     fn chk(negated: bool) {
         let sql = &format!(

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1837,3 +1837,18 @@ fn parse_drop_temporary_table() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn parse_convert_using() {
+    // https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#function_convert
+
+    // CONVERT(expr USING transcoding_name)
+    mysql().verified_only_select("SELECT CONVERT('x' USING latin1)");
+    mysql().verified_only_select("SELECT CONVERT(my_column USING utf8mb4) FROM my_table");
+
+    // CONVERT(expr, type)
+    mysql().verified_only_select("SELECT CONVERT('abc', CHAR(60))");
+    mysql().verified_only_select("SELECT CONVERT(123.456, DECIMAL(5,2))");
+    // with a type + a charset
+    mysql().verified_only_select("SELECT CONVERT('test', CHAR CHARACTER SET utf8mb4)");
+}


### PR DESCRIPTION
fixes #1047

adds support for the following CONVERT syntaxes:
 - `CONVERT('héhé' USING utf8mb4)` (MySQL, Postgres)
 - `CONVERT('héhé', CHAR CHARACTER SET utf8mb4)` (MySQL)
 - `CONVERT(DECIMAL(10, 5), 42)` (MSSQL) - the type comes first
