### PR TITLE
Add support for generated columns skipping 'GENERATED ALWAYS' keywords

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -601,7 +601,7 @@ pub enum ColumnOption {
         generation_expr: Option<Expr>,
         generation_expr_mode: Option<GeneratedExpressionMode>,
         /// false if 'GENERATED ALWAYS' is skipped (option starts with AS)
-        generated_kw: bool,
+        generated_keyword: bool,
     },
 }
 
@@ -643,7 +643,7 @@ impl fmt::Display for ColumnOption {
                 sequence_options,
                 generation_expr,
                 generation_expr_mode,
-                generated_kw,
+                generated_keyword,
             } => {
                 if let Some(expr) = generation_expr {
                     let modifier = match generation_expr_mode {
@@ -651,7 +651,7 @@ impl fmt::Display for ColumnOption {
                         Some(GeneratedExpressionMode::Virtual) => " VIRTUAL",
                         Some(GeneratedExpressionMode::Stored) => " STORED",
                     };
-                    if *generated_kw {
+                    if *generated_keyword {
                         write!(f, "GENERATED ALWAYS AS ({expr}){modifier}")?;
                     } else {
                         write!(f, "AS ({expr}){modifier}")?;

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -600,6 +600,8 @@ pub enum ColumnOption {
         sequence_options: Option<Vec<SequenceOptions>>,
         generation_expr: Option<Expr>,
         generation_expr_mode: Option<GeneratedExpressionMode>,
+        /// false if 'GENERATED ALWAYS' is skipped (option starts with AS)
+        generated_kw: bool,
     },
 }
 
@@ -641,6 +643,7 @@ impl fmt::Display for ColumnOption {
                 sequence_options,
                 generation_expr,
                 generation_expr_mode,
+                generated_kw,
             } => {
                 if let Some(expr) = generation_expr {
                     let modifier = match generation_expr_mode {
@@ -648,7 +651,11 @@ impl fmt::Display for ColumnOption {
                         Some(GeneratedExpressionMode::Virtual) => " VIRTUAL",
                         Some(GeneratedExpressionMode::Stored) => " STORED",
                     };
-                    write!(f, "GENERATED ALWAYS AS ({expr}){modifier}")?;
+                    if *generated_kw {
+                        write!(f, "GENERATED ALWAYS AS ({expr}){modifier}")?;
+                    } else {
+                        write!(f, "AS ({expr}){modifier}")?;
+                    }
                     Ok(())
                 } else {
                     // Like Postgres - generated from sequence

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4304,7 +4304,7 @@ impl<'a> Parser<'a> {
                 sequence_options: Some(sequence_options),
                 generation_expr: None,
                 generation_expr_mode: None,
-                generated_kw: true,
+                generated_keyword: true,
             }))
         } else if self.parse_keywords(&[
             Keyword::BY,
@@ -4322,7 +4322,7 @@ impl<'a> Parser<'a> {
                 sequence_options: Some(sequence_options),
                 generation_expr: None,
                 generation_expr_mode: None,
-                generated_kw: true,
+                generated_keyword: true,
             }))
         } else if self.parse_keywords(&[Keyword::ALWAYS, Keyword::AS]) {
             if self.expect_token(&Token::LParen).is_ok() {
@@ -4347,7 +4347,7 @@ impl<'a> Parser<'a> {
                     sequence_options: None,
                     generation_expr: Some(expr),
                     generation_expr_mode: expr_mode,
-                    generated_kw: true,
+                    generated_keyword: true,
                 }))
             } else {
                 Ok(None)
@@ -4379,7 +4379,7 @@ impl<'a> Parser<'a> {
             sequence_options: None,
             generation_expr: Some(expr),
             generation_expr_mode: expr_mode,
-            generated_kw: false,
+            generated_keyword: false,
         }))
     }
 

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -517,6 +517,10 @@ fn parse_create_table_gencol() {
 
     let sql_stored = "CREATE TABLE t1 (a INT, b INT GENERATED ALWAYS AS (a * 2) STORED)";
     mysql_and_generic().verified_stmt(sql_stored);
+
+    mysql_and_generic().verified_stmt("CREATE TABLE t1 (a INT, b INT AS (a * 2))");
+    mysql_and_generic().verified_stmt("CREATE TABLE t1 (a INT, b INT AS (a * 2) VIRTUAL)");
+    mysql_and_generic().verified_stmt("CREATE TABLE t1 (a INT, b INT AS (a * 2) STORED)");
 }
 
 #[test]

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -215,6 +215,10 @@ fn parse_create_table_gencol() {
 
     let sql_stored = "CREATE TABLE t1 (a INT, b INT GENERATED ALWAYS AS (a * 2) STORED)";
     sqlite_and_generic().verified_stmt(sql_stored);
+
+    sqlite_and_generic().verified_stmt("CREATE TABLE t1 (a INT, b INT AS (a * 2))");
+    sqlite_and_generic().verified_stmt("CREATE TABLE t1 (a INT, b INT AS (a * 2) VIRTUAL)");
+    sqlite_and_generic().verified_stmt("CREATE TABLE t1 (a INT, b INT AS (a * 2) STORED)");
 }
 
 #[test]


### PR DESCRIPTION
SQLite, Mysql and DuckDB all let you skip the words `GENERATED ALWAYS`, and use `AS` to introduce a column generated from an expression. See the links in #1051 for details.

I've introduced an extra field in `ColumnOption::Generated` - `generated_kw` is true if the `GENERATED` keyword is present, and false if the SQL skips directly to `AS`. I'm not sure of the naming, but it's the best I've thought of so far. Currently, if `generation_expr` is None, `generated_kw` can only be true (and is assumed to be when recreating the SQL).

Perhaps a neater design would be to have different `ColumnOption` kinds for generated-from-expression vs. generated-from-sequence vs. whatever else. But that would require an API break again.

Closes #1050.
