### PR TITLE
add support for CALL statements

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1437,6 +1437,7 @@ pub enum Statement {
         file_format: Option<FileFormat>,
         source: Box<Query>,
     },
+    Call(Function),
     Copy {
         /// The source of 'COPY TO', or the target of 'COPY FROM'
         source: CopySource,
@@ -1715,7 +1716,9 @@ pub enum Statement {
     ///
     /// Note: this is a PostgreSQL-specific statement,
     /// but may also compatible with other SQL.
-    Discard { object_type: DiscardObject },
+    Discard {
+        object_type: DiscardObject,
+    },
     /// SET `[ SESSION | LOCAL ]` ROLE role_name. Examples: [ANSI][1], [Postgresql][2], [MySQL][3], and [Oracle][4].
     ///
     /// [1]: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#set-role-statement
@@ -1747,7 +1750,10 @@ pub enum Statement {
     ///
     /// Note: this is a PostgreSQL-specific statements
     /// `SET TIME ZONE <value>` is an alias for `SET timezone TO <value>` in PostgreSQL
-    SetTimeZone { local: bool, value: Expr },
+    SetTimeZone {
+        local: bool,
+        value: Expr,
+    },
     /// SET NAMES 'charset_name' [COLLATE 'collation_name']
     ///
     /// Note: this is a MySQL-specific statement.
@@ -1762,13 +1768,17 @@ pub enum Statement {
     /// SHOW FUNCTIONS
     ///
     /// Note: this is a Presto-specific statement.
-    ShowFunctions { filter: Option<ShowStatementFilter> },
+    ShowFunctions {
+        filter: Option<ShowStatementFilter>,
+    },
     /// ```sql
     /// SHOW <variable>
     /// ```
     ///
     /// Note: this is a PostgreSQL-specific statement.
-    ShowVariable { variable: Vec<Ident> },
+    ShowVariable {
+        variable: Vec<Ident>,
+    },
     /// SHOW VARIABLES
     ///
     /// Note: this is a MySQL-specific statement.
@@ -1806,11 +1816,15 @@ pub enum Statement {
     /// SHOW COLLATION
     ///
     /// Note: this is a MySQL-specific statement.
-    ShowCollation { filter: Option<ShowStatementFilter> },
+    ShowCollation {
+        filter: Option<ShowStatementFilter>,
+    },
     /// USE
     ///
     /// Note: This is a MySQL-specific statement.
-    Use { db_name: Ident },
+    Use {
+        db_name: Ident,
+    },
     /// `START  [ TRANSACTION | WORK ] | START TRANSACTION } ...`
     /// If `begin` is false.
     ///
@@ -1838,7 +1852,9 @@ pub enum Statement {
         if_exists: bool,
     },
     /// `COMMIT [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]`
-    Commit { chain: bool },
+    Commit {
+        chain: bool,
+    },
     /// `ROLLBACK [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ] [ TO [ SAVEPOINT ] savepoint_name ]`
     Rollback {
         chain: bool,
@@ -1934,11 +1950,17 @@ pub enum Statement {
     /// `DEALLOCATE [ PREPARE ] { name | ALL }`
     ///
     /// Note: this is a PostgreSQL-specific statement.
-    Deallocate { name: Ident, prepare: bool },
+    Deallocate {
+        name: Ident,
+        prepare: bool,
+    },
     /// `EXECUTE name [ ( parameter [, ...] ) ]`
     ///
     /// Note: this is a PostgreSQL-specific statement.
-    Execute { name: Ident, parameters: Vec<Expr> },
+    Execute {
+        name: Ident,
+        parameters: Vec<Expr>,
+    },
     /// `PREPARE name [ ( data_type [, ...] ) ] AS statement`
     ///
     /// Note: this is a PostgreSQL-specific statement.
@@ -1979,9 +2001,13 @@ pub enum Statement {
         format: Option<AnalyzeFormat>,
     },
     /// SAVEPOINT -- define a new savepoint within the current transaction
-    Savepoint { name: Ident },
+    Savepoint {
+        name: Ident,
+    },
     /// RELEASE \[ SAVEPOINT \] savepoint_name
-    ReleaseSavepoint { name: Ident },
+    ReleaseSavepoint {
+        name: Ident,
+    },
     // MERGE INTO statement, based on Snowflake. See <https://docs.snowflake.com/en/sql-reference/sql/merge.html>
     Merge {
         // optional INTO keyword
@@ -2302,6 +2328,8 @@ impl fmt::Display for Statement {
 
                 Ok(())
             }
+
+            Statement::Call(function) => write!(f, "CALL {function}"),
 
             Statement::Copy {
                 source,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7950,6 +7950,29 @@ fn parse_create_type() {
 }
 
 #[test]
+fn parse_call() {
+    all_dialects().verified_stmt("CALL my_procedure()");
+    all_dialects().verified_stmt("CALL my_procedure(1, 'a')");
+    pg_and_generic().verified_stmt("CALL my_procedure(1, 'a', $1)");
+    all_dialects().verified_stmt("CALL my_procedure");
+    assert_eq!(
+        verified_stmt("CALL my_procedure('a')"),
+        Statement::Call(Function {
+            args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                Value::SingleQuotedString("a".to_string())
+            ))),],
+            name: ObjectName(vec![Ident::new("my_procedure")]),
+            filter: None,
+            null_treatment: None,
+            over: None,
+            distinct: false,
+            special: false,
+            order_by: vec![]
+        })
+    );
+}
+
+#[test]
 fn parse_create_table_collate() {
     pg_and_generic().verified_stmt("CREATE TABLE tbl (foo INT, bar TEXT COLLATE \"de_DE\")");
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1818,6 +1818,14 @@ fn parse_hex_string_introducer() {
 }
 
 #[test]
+fn parse_call() {
+    mysql().verified_stmt("CALL my_procedure()");
+    mysql().verified_stmt("CALL my_procedure(1, 'a')");
+    mysql().verified_stmt("CALL my_procedure(1, 'a', @my_var)");
+    mysql().verified_stmt("CALL my_procedure");
+}
+
+#[test]
 fn parse_string_introducers() {
     mysql().verified_stmt("SELECT _binary 'abc'");
     mysql().one_statement_parses_to("SELECT _utf8'abc'", "SELECT _utf8 'abc'");

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1818,14 +1818,6 @@ fn parse_hex_string_introducer() {
 }
 
 #[test]
-fn parse_call() {
-    mysql().verified_stmt("CALL my_procedure()");
-    mysql().verified_stmt("CALL my_procedure(1, 'a')");
-    mysql().verified_stmt("CALL my_procedure(1, 'a', @my_var)");
-    mysql().verified_stmt("CALL my_procedure");
-}
-
-#[test]
 fn parse_string_introducers() {
     mysql().verified_stmt("SELECT _binary 'abc'");
     mysql().one_statement_parses_to("SELECT _utf8'abc'", "SELECT _utf8 'abc'");


### PR DESCRIPTION
see https://dev.mysql.com/doc/refman/8.0/en/call.html

Adds support for MySQL's CALL statements 
(stored procedure invocation)

This one is very important for [SQLPage](https://github.com/lovasoa/SQLpage) too,
because it allows working around other unsupported syntax
by wrapping logic in stored procedures.