### PR TITLE
Support SQLite column definitions with no type

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -219,6 +219,8 @@ pub enum DataType {
     /// [hive]: https://docs.cloudera.com/cdw-runtime/cloud/impala-sql-reference/topics/impala-struct.html
     /// [bigquery]: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type
     Struct(Vec<StructField>),
+    /// Specific to SQLite: no type specified (no coercion)
+    Unspecified,
 }
 
 impl fmt::Display for DataType {
@@ -379,6 +381,7 @@ impl fmt::Display for DataType {
                     write!(f, "STRUCT")
                 }
             }
+            DataType::Unspecified => Ok(()),
         }
     }
 }

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -219,7 +219,9 @@ pub enum DataType {
     /// [hive]: https://docs.cloudera.com/cdw-runtime/cloud/impala-sql-reference/topics/impala-struct.html
     /// [bigquery]: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type
     Struct(Vec<StructField>),
-    /// Specific to SQLite: no type specified (no coercion)
+    /// No type specified - only used with
+    /// [`SQLiteDialect`](crate::dialect::SQLiteDialect), from statements such
+    /// as `CREATE TABLE t1 (a)`.
     Unspecified,
 }
 

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -516,7 +516,11 @@ pub struct ColumnDef {
 
 impl fmt::Display for ColumnDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}", self.name, self.data_type)?;
+        if self.data_type == DataType::Unspecified {
+            write!(f, "{}", self.name)?;
+        } else {
+            write!(f, "{} {}", self.name, self.data_type)?;
+        }
         if let Some(collation) = &self.collation {
             write!(f, " COLLATE {collation}")?;
         }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -65,7 +65,9 @@ macro_rules! dialect_of {
 /// encapsulates the parsing differences between dialects.
 ///
 /// [`GenericDialect`] is the most permissive dialect, and parses the union of
-/// all the other dialects, when there is no ambiguity.
+/// all the other dialects, when there is no ambiguity. However, it does not
+/// currently allow `CREATE TABLE` statements without types specified for all
+/// columns; use [`SQLiteDialect`] if you require that.
 ///
 /// # Examples
 /// Most users create a [`Dialect`] directly, as shown on the [module

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -16,6 +16,11 @@ use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
 
 /// A [`Dialect`] for [SQLite](https://www.sqlite.org)
+///
+/// This dialect allows columns in a
+/// [`CREATE TABLE`](https://sqlite.org/lang_createtable.html) statement with no
+/// type specified, as in `CREATE TABLE t1 (a)`. In the AST, these columns will
+/// have the data type [`Unspecified`](crate::ast::DataType::Unspecified).
 #[derive(Debug)]
 pub struct SQLiteDialect {}
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4183,7 +4183,7 @@ impl<'a> Parser<'a> {
 
     pub fn parse_column_def(&mut self) -> Result<ColumnDef, ParserError> {
         let name = self.parse_identifier()?;
-        let data_type = if self.sqlite_untyped_col_helper() {
+        let data_type = if self.is_column_type_sqlite_unspecified() {
             DataType::Unspecified
         } else {
             self.parse_data_type()?
@@ -4223,7 +4223,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn sqlite_untyped_col_helper(&mut self) -> bool {
+    fn is_column_type_sqlite_unspecified(&mut self) -> bool {
         if dialect_of!(self is SQLiteDialect) {
             match self.peek_token().token {
                 Token::Word(word) => matches!(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4226,19 +4226,19 @@ impl<'a> Parser<'a> {
     fn sqlite_untyped_col_helper(&mut self) -> bool {
         if dialect_of!(self is SQLiteDialect) {
             match self.peek_token().token {
-                Token::Word(word) => match word.keyword {
+                Token::Word(word) => matches!(
+                    word.keyword,
                     Keyword::CONSTRAINT
-                    | Keyword::PRIMARY
-                    | Keyword::NOT
-                    | Keyword::UNIQUE
-                    | Keyword::CHECK
-                    | Keyword::DEFAULT
-                    | Keyword::COLLATE
-                    | Keyword::REFERENCES
-                    | Keyword::GENERATED
-                    | Keyword::AS => true,
-                    _ => false,
-                },
+                        | Keyword::PRIMARY
+                        | Keyword::NOT
+                        | Keyword::UNIQUE
+                        | Keyword::CHECK
+                        | Keyword::DEFAULT
+                        | Keyword::COLLATE
+                        | Keyword::REFERENCES
+                        | Keyword::GENERATED
+                        | Keyword::AS
+                ),
                 _ => true, // e.g. comma immediately after column name
             }
         } else {

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -222,6 +222,11 @@ fn parse_create_table_gencol() {
 }
 
 #[test]
+fn parse_create_table_untyped() {
+    sqlite().verified_stmt("CREATE TABLE t1 (a, b AS (a * 2), c NOT NULL)");
+}
+
+#[test]
 fn test_placeholder() {
     // In postgres, this would be the absolute value operator '@' applied to the column 'xxx'
     // But in sqlite, this is a named parameter.


### PR DESCRIPTION
SQLite allows columns with no type information:

```sql
CREATE TABLE t1 (a, b AS (a * 2), c NOT NULL)
```

As far as I know, other SQL databases all expect a data type for each column. So for now I've allowed this only for the SQLite dialect. Should the generic dialect also support it? The docs suggest that it's 'permissive', but I wasn't sure if this would be stretching the point too far. :slightly_smiling_face: 

Closes #743