### PR TITLE
Bump version of sqlparser-derive to 0.2.2

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlparser_derive"
 description = "proc macro for sqlparser"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["sqlparser-rs authors"]
 homepage = "https://github.com/sqlparser-rs/sqlparser-rs"
 documentation = "https://docs.rs/sqlparser_derive/"


### PR DESCRIPTION
As pointed out by @dzil123  https://github.com/sqlparser-rs/sqlparser-rs/issues/1054#issuecomment-1874696014 I apparently did not publish a version of sqlparser-derive that uses the new version of `syn`:

> Just letting you know, the latest version of sqlparser-derive 0.2.1 is still on syn 1.0: https://crates.io/crates/sqlparser_derive/0.2.1/dependencies

So let's bump the version and try to publish again
