### PR TITLE
Add support for `JSONB` datatype

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -196,8 +196,10 @@ pub enum DataType {
     Timestamp(Option<u64>, TimezoneInfo),
     /// Interval
     Interval,
-    /// JSON type used in BigQuery
+    /// JSON type
     JSON,
+    /// Binary JSON type
+    JSONB,
     /// Regclass used in postgresql serial
     Regclass,
     /// Text
@@ -340,6 +342,7 @@ impl fmt::Display for DataType {
             }
             DataType::Interval => write!(f, "INTERVAL"),
             DataType::JSON => write!(f, "JSON"),
+            DataType::JSONB => write!(f, "JSONB"),
             DataType::Regclass => write!(f, "REGCLASS"),
             DataType::Text => write!(f, "TEXT"),
             DataType::String(size) => format_type_with_optional_length(f, "STRING", size, false),

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -366,6 +366,7 @@ define_keywords!(
     JAR,
     JOIN,
     JSON,
+    JSONB,
     JSONFILE,
     JSON_TABLE,
     JULIAN,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5641,6 +5641,7 @@ impl<'a> Parser<'a> {
                 // parse_interval for a taste.
                 Keyword::INTERVAL => Ok(DataType::Interval),
                 Keyword::JSON => Ok(DataType::JSON),
+                Keyword::JSONB => Ok(DataType::JSONB),
                 Keyword::REGCLASS => Ok(DataType::Regclass),
                 Keyword::STRING => Ok(DataType::String(self.parse_optional_precision()?)),
                 Keyword::TEXT => Ok(DataType::Text),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2172,6 +2172,17 @@ fn parse_cast() {
         },
         expr_from_projection(only(&select.projection))
     );
+
+    let sql = "SELECT CAST(details AS JSONB) FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Cast {
+            expr: Box::new(Expr::Identifier(Ident::new("details"))),
+            data_type: DataType::JSONB,
+            format: None,
+        },
+        expr_from_projection(only(&select.projection))
+    );
 }
 
 #[test]


### PR DESCRIPTION
Minor addition of JSONB (binary json) recognition as a distinct type from JSON. Supported by a number of mainstream databases, such as PostgreSQL[^1] and SQLite (for which JSONB is currently in pre-release [^2][^3], landing soon in 3.45.0).

[^1]: https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-JSONB-OP-TABLE
[^2]: https://sqlite.org/forum/forumpost/fa6f64e3dc1a5d97
[^3]: https://sqlite.org/draft/jsonb.html