### PR TITLE
Add support for PostgreSQL `^@` starts-with operator

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -131,6 +131,8 @@ pub enum BinaryOperator {
     PGRegexNotMatch,
     /// String does not match regular expression (case insensitively), e.g. `a !~* b` (PostgreSQL-specific)
     PGRegexNotIMatch,
+    /// String "starts with", eg: `a ^@ b` (PostgreSQL-specific)
+    PGStartsWith,
     /// PostgreSQL-specific custom operator.
     ///
     /// See [CREATE OPERATOR](https://www.postgresql.org/docs/current/sql-createoperator.html)
@@ -172,6 +174,7 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::PGRegexIMatch => f.write_str("~*"),
             BinaryOperator::PGRegexNotMatch => f.write_str("!~"),
             BinaryOperator::PGRegexNotIMatch => f.write_str("!~*"),
+            BinaryOperator::PGStartsWith => f.write_str("^@"),
             BinaryOperator::PGCustomBinaryOperator(idents) => {
                 write!(f, "OPERATOR({})", display_separated(idents, "."))
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2196,6 +2196,9 @@ impl<'a> Parser<'a> {
             Token::Overlap if dialect_of!(self is PostgreSqlDialect | GenericDialect) => {
                 Some(BinaryOperator::PGOverlap)
             }
+            Token::CaretAt if dialect_of!(self is PostgreSqlDialect | GenericDialect) => {
+                Some(BinaryOperator::PGStartsWith)
+            }
             Token::Tilde => Some(BinaryOperator::PGRegexMatch),
             Token::TildeAsterisk => Some(BinaryOperator::PGRegexIMatch),
             Token::ExclamationMarkTilde => Some(BinaryOperator::PGRegexNotMatch),
@@ -2630,6 +2633,7 @@ impl<'a> Parser<'a> {
             | Token::LongArrow
             | Token::Arrow
             | Token::Overlap
+            | Token::CaretAt
             | Token::HashArrow
             | Token::HashLongArrow
             | Token::AtArrow

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1728,6 +1728,7 @@ fn parse_pg_binary_ops() {
         (">>", BinaryOperator::PGBitwiseShiftRight, pg_and_generic()),
         ("<<", BinaryOperator::PGBitwiseShiftLeft, pg_and_generic()),
         ("&&", BinaryOperator::PGOverlap, pg()),
+        ("^@", BinaryOperator::PGStartsWith, pg()),
     ];
 
     for (str_op, op, dialects) in binary_ops {


### PR DESCRIPTION
Support PostgreSQL-specific `^@`[^1] starts-with operator...

```sql
"col" ^@ 'xyz'
```
...as `BinaryOperator::PGStartsWith` (and `Token::CaretAt`) for PostgreSqlDialect and GenericDialect. (Also closes #1081, by adding a minor note about byte/bit strings 👍)

[^1]: PostgreSQL string function/op [docs](https://www.postgresql.org/docs/current/functions-string.html#FUNCTIONS-STRING-OTHER).