### PR TITLE
Add APIs to reuse token buffers in `Tokenizer`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8698,7 +8698,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Consume the parser and return its underlying token buffer
-    pub fn tokens(self) -> Vec<TokenWithLocation> {
+    pub fn into_tokens(self) -> Vec<TokenWithLocation> {
         self.tokens
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8682,6 +8682,11 @@ impl<'a> Parser<'a> {
         self.expect_token(&Token::RParen)?;
         Ok(partitions)
     }
+
+    /// consume the parser and return its underlying token buffer
+    pub fn tokens(self) -> Vec<TokenWithLocation> {
+        self.tokens
+    }
 }
 
 impl Word {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8683,7 +8683,7 @@ impl<'a> Parser<'a> {
         Ok(partitions)
     }
 
-    /// consume the parser and return its underlying token buffer
+    /// Consume the parser and return its underlying token buffer
     pub fn tokens(self) -> Vec<TokenWithLocation> {
         self.tokens
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -539,21 +539,29 @@ impl<'a> Tokenizer<'a> {
 
     /// Tokenize the statement and produce a vector of tokens with location information
     pub fn tokenize_with_location(&mut self) -> Result<Vec<TokenWithLocation>, TokenizerError> {
+        let mut tokens: Vec<TokenWithLocation> = vec![];
+        self.tokenize_with_location_into(&mut tokens)
+            .map(|_| tokens)
+    }
+
+    /// Tokenize the statement and append tokens with location information into the provided buffer
+    pub fn tokenize_with_location_into(
+        &mut self,
+        buf: &mut Vec<TokenWithLocation>,
+    ) -> Result<(), TokenizerError> {
         let mut state = State {
             peekable: self.query.chars().peekable(),
             line: 1,
             col: 1,
         };
 
-        let mut tokens: Vec<TokenWithLocation> = vec![];
-
         let mut location = state.location();
         while let Some(token) = self.next_token(&mut state)? {
-            tokens.push(TokenWithLocation { token, location });
+            buf.push(TokenWithLocation { token, location });
 
             location = state.location();
         }
-        Ok(tokens)
+        Ok(())
     }
 
     // Tokenize the identifer or keywords in `ch`

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -544,13 +544,13 @@ impl<'a> Tokenizer<'a> {
     /// Tokenize the statement and produce a vector of tokens with location information
     pub fn tokenize_with_location(&mut self) -> Result<Vec<TokenWithLocation>, TokenizerError> {
         let mut tokens: Vec<TokenWithLocation> = vec![];
-        self.tokenize_with_location_into(&mut tokens)
+        self.tokenize_with_location_into_buf(&mut tokens)
             .map(|_| tokens)
     }
-    
+
     /// Tokenize the statement and append tokens with location information into the provided buffer.
     /// If an error is thrown, the buffer will contain all tokens that were successfully parsed before the error.
-    pub fn tokenize_with_location_into(
+    pub fn tokenize_with_location_into_buf(
         &mut self,
         buf: &mut Vec<TokenWithLocation>,
     ) -> Result<(), TokenizerError> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -547,8 +547,9 @@ impl<'a> Tokenizer<'a> {
         self.tokenize_with_location_into(&mut tokens)
             .map(|_| tokens)
     }
-
-    /// Tokenize the statement and append tokens with location information into the provided buffer
+    
+    /// Tokenize the statement and append tokens with location information into the provided buffer.
+    /// If an error is thrown, the buffer will contain all tokens that were successfully parsed before the error.
     pub fn tokenize_with_location_into(
         &mut self,
         buf: &mut Vec<TokenWithLocation>,


### PR DESCRIPTION
This is a super simple PR that adds two new methods to aid in the reuse of token buffers.

- `Tokenizer::tokenize_with_location_into`: operates identically to `Tokenizer::tokenize_with_location` except it allows you to supply your own buffer to use.
- `Parser::tokens`: allows you to retrieve the token buffer from a parser after you're done with it.