### PR TITLE
Add Postgres operators for the LIKE expression variants

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -131,6 +131,14 @@ pub enum BinaryOperator {
     PGRegexNotMatch,
     /// String does not match regular expression (case insensitively), e.g. `a !~* b` (PostgreSQL-specific)
     PGRegexNotIMatch,
+    /// String matches pattern (case sensitively), e.g. `a ~~ b` (PostgreSQL-specific)
+    PGLikeMatch,
+    /// String matches pattern (case insensitively), e.g. `a ~~* b` (PostgreSQL-specific)
+    PGILikeMatch,
+    /// String does not match pattern (case sensitively), e.g. `a !~~ b` (PostgreSQL-specific)
+    PGNotLikeMatch,
+    /// String does not match pattern (case insensitively), e.g. `a !~~* b` (PostgreSQL-specific)
+    PGNotILikeMatch,
     /// String "starts with", eg: `a ^@ b` (PostgreSQL-specific)
     PGStartsWith,
     /// PostgreSQL-specific custom operator.
@@ -174,6 +182,10 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::PGRegexIMatch => f.write_str("~*"),
             BinaryOperator::PGRegexNotMatch => f.write_str("!~"),
             BinaryOperator::PGRegexNotIMatch => f.write_str("!~*"),
+            BinaryOperator::PGLikeMatch => f.write_str("~~"),
+            BinaryOperator::PGILikeMatch => f.write_str("~~*"),
+            BinaryOperator::PGNotLikeMatch => f.write_str("!~~"),
+            BinaryOperator::PGNotILikeMatch => f.write_str("!~~*"),
             BinaryOperator::PGStartsWith => f.write_str("^@"),
             BinaryOperator::PGCustomBinaryOperator(idents) => {
                 write!(f, "OPERATOR({})", display_separated(idents, "."))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2203,6 +2203,10 @@ impl<'a> Parser<'a> {
             Token::TildeAsterisk => Some(BinaryOperator::PGRegexIMatch),
             Token::ExclamationMarkTilde => Some(BinaryOperator::PGRegexNotMatch),
             Token::ExclamationMarkTildeAsterisk => Some(BinaryOperator::PGRegexNotIMatch),
+            Token::DoubleTilde => Some(BinaryOperator::PGLikeMatch),
+            Token::DoubleTildeAsterisk => Some(BinaryOperator::PGILikeMatch),
+            Token::ExclamationMarkDoubleTilde => Some(BinaryOperator::PGNotLikeMatch),
+            Token::ExclamationMarkDoubleTildeAsterisk => Some(BinaryOperator::PGNotILikeMatch),
             Token::Word(w) => match w.keyword {
                 Keyword::AND => Some(BinaryOperator::And),
                 Keyword::OR => Some(BinaryOperator::Or),
@@ -2618,6 +2622,10 @@ impl<'a> Parser<'a> {
             | Token::TildeAsterisk
             | Token::ExclamationMarkTilde
             | Token::ExclamationMarkTildeAsterisk
+            | Token::DoubleTilde
+            | Token::DoubleTildeAsterisk
+            | Token::ExclamationMarkDoubleTilde
+            | Token::ExclamationMarkDoubleTildeAsterisk
             | Token::Spaceship => Ok(20),
             Token::Pipe => Ok(21),
             Token::Caret | Token::Sharp | Token::ShiftRight | Token::ShiftLeft => Ok(22),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1805,6 +1805,28 @@ fn parse_pg_regex_match_ops() {
 }
 
 #[test]
+fn parse_pg_like_match_ops() {
+    let pg_like_match_ops = &[
+        ("~~", BinaryOperator::PGLikeMatch),
+        ("~~*", BinaryOperator::PGILikeMatch),
+        ("!~~", BinaryOperator::PGNotLikeMatch),
+        ("!~~*", BinaryOperator::PGNotILikeMatch),
+    ];
+
+    for (str_op, op) in pg_like_match_ops {
+        let select = pg().verified_only_select(&format!("SELECT 'abc' {} 'a_c%'", &str_op));
+        assert_eq!(
+            SelectItem::UnnamedExpr(Expr::BinaryOp {
+                left: Box::new(Expr::Value(Value::SingleQuotedString("abc".into()))),
+                op: op.clone(),
+                right: Box::new(Expr::Value(Value::SingleQuotedString("a_c%".into()))),
+            }),
+            select.projection[0]
+        );
+    }
+}
+
+#[test]
 fn parse_array_index_expr() {
     let num: Vec<Expr> = (0..=10)
         .map(|s| Expr::Value(number(&s.to_string())))


### PR DESCRIPTION
Closes #1095

Extends the `Token` and `BinaryOperator` enums with variants representing `~~`, `~~*`, `!~~`, `!~~*`, in accordance with the present regular expression tokens/operators.