### PR TITLE
Allow string values in pragma commands

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8478,7 +8478,7 @@ impl<'a> Parser<'a> {
             v @ Value::Placeholder(_) => Ok(v),
             _ => {
                 self.prev_token();
-                self.expected("number or string", self.peek_token())
+                self.expected("number or string or ? placeholder", self.peek_token())
             }
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8470,11 +8470,24 @@ impl<'a> Parser<'a> {
         })
     }
 
+    fn parse_pragma_value(&mut self) -> Result<Value, ParserError> {
+        match self.parse_value()? {
+            v @ Value::SingleQuotedString(_) => Ok(v),
+            v @ Value::DoubleQuotedString(_) => Ok(v),
+            v @ Value::Number(_, _) => Ok(v),
+            v @ Value::Placeholder(_) => Ok(v),
+            _ => {
+                self.prev_token();
+                self.expected("number or string", self.peek_token())
+            }
+        }
+    }
+
     // PRAGMA [schema-name '.'] pragma-name [('=' pragma-value) | '(' pragma-value ')']
     pub fn parse_pragma(&mut self) -> Result<Statement, ParserError> {
         let name = self.parse_object_name()?;
         if self.consume_token(&Token::LParen) {
-            let value = self.parse_number_value()?;
+            let value = self.parse_pragma_value()?;
             self.expect_token(&Token::RParen)?;
             Ok(Statement::Pragma {
                 name,
@@ -8484,7 +8497,7 @@ impl<'a> Parser<'a> {
         } else if self.consume_token(&Token::Eq) {
             Ok(Statement::Pragma {
                 name,
-                value: Some(self.parse_number_value()?),
+                value: Some(self.parse_pragma_value()?),
                 is_eq: true,
             })
         } else {

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -87,7 +87,7 @@ fn pragma_eq_string_style() {
 }
 
 #[test]
-fn pragma_eq_paren_string_style() {
+fn pragma_function_string_style() {
     let sql = "PRAGMA table_info(\"sqlite_master\")";
     match sqlite_and_generic().verified_stmt(sql) {
         Statement::Pragma {
@@ -97,6 +97,22 @@ fn pragma_eq_paren_string_style() {
         } => {
             assert_eq!("table_info", name.to_string());
             assert_eq!("\"sqlite_master\"", val.to_string());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn pragma_eq_placehoder_style() {
+    let sql = "PRAGMA table_info = ?";
+    match sqlite_and_generic().verified_stmt(sql) {
+        Statement::Pragma {
+            name,
+            value: Some(val),
+            is_eq: true,
+        } => {
+            assert_eq!("table_info", name.to_string());
+            assert_eq!("?", val.to_string());
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -71,6 +71,38 @@ fn pragma_funciton_style() {
 }
 
 #[test]
+fn pragma_eq_string_style() {
+    let sql = "PRAGMA table_info = 'sqlite_master'";
+    match sqlite_and_generic().verified_stmt(sql) {
+        Statement::Pragma {
+            name,
+            value: Some(val),
+            is_eq: true,
+        } => {
+            assert_eq!("table_info", name.to_string());
+            assert_eq!("'sqlite_master'", val.to_string());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn pragma_eq_paren_string_style() {
+    let sql = "PRAGMA table_info(\"sqlite_master\")";
+    match sqlite_and_generic().verified_stmt(sql) {
+        Statement::Pragma {
+            name,
+            value: Some(val),
+            is_eq: false,
+        } => {
+            assert_eq!("table_info", name.to_string());
+            assert_eq!("\"sqlite_master\"", val.to_string());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_create_table_without_rowid() {
     let sql = "CREATE TABLE t (a INT) WITHOUT ROWID";
     match sqlite_and_generic().verified_stmt(sql) {


### PR DESCRIPTION
Small PR to allow string values in pragma commands

```
PRAGMA table_info('sqlite_master')
PRAGMA table_info = "sqlite_master"
```

Closes #1100 