### PR TITLE
Fixes `1103` - disallow dangling NO in create sequence options

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8602,13 +8602,12 @@ impl<'a> Parser<'a> {
             )));
         }
         // [ [ NO ] CYCLE ]
-        if self.parse_keywords(&[Keyword::NO]) {
-            if self.parse_keywords(&[Keyword::CYCLE]) {
-                sequence_options.push(SequenceOptions::Cycle(true));
-            }
+        if self.parse_keywords(&[Keyword::NO, Keyword::CYCLE]) {
+            sequence_options.push(SequenceOptions::Cycle(true));
         } else if self.parse_keywords(&[Keyword::CYCLE]) {
             sequence_options.push(SequenceOptions::Cycle(false));
         }
+
         Ok(sequence_options)
     }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -276,6 +276,11 @@ fn parse_create_sequence() {
         sql6,
         "CREATE TEMPORARY SEQUENCE IF NOT EXISTS name3 INCREMENT 1 NO MINVALUE MAXVALUE 20 OWNED BY NONE",
     );
+
+    assert!(
+        matches!(
+        pg().parse_sql_statements("CREATE SEQUENCE foo INCREMENT 1 NO MINVALUE NO"), Err(ParserError::ParserError(_)))
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes a bug where a `NO` meant for `NO CACHE` in create options would be consumed without being followed by `CACHE`.

Changelog: Fixes: `#1103`