### PR TITLE
Use `Option<Expr>` for Min and Max vals in Seq Opts, fix alter col seq display

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -354,17 +354,13 @@ impl fmt::Display for AlterColumnOperation {
 
                 write!(f, "ADD GENERATED{generated_as} AS IDENTITY",)?;
                 if let Some(options) = sequence_options {
-                    if !options.is_empty() {
-                        write!(f, " (")?;
-                    }
+                    write!(f, " (")?;
 
                     for sequence_option in options {
                         write!(f, "{sequence_option}")?;
                     }
 
-                    if !options.is_empty() {
-                        write!(f, " )")?;
-                    }
+                    write!(f, " )")?;
                 }
                 Ok(())
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3734,8 +3734,8 @@ impl fmt::Display for Statement {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum SequenceOptions {
     IncrementBy(Expr, bool),
-    MinValue(MinMaxValue),
-    MaxValue(MinMaxValue),
+    MinValue(Option<Expr>),
+    MaxValue(Option<Expr>),
     StartWith(Expr, bool),
     Cache(Expr),
     Cycle(bool),
@@ -3752,28 +3752,18 @@ impl fmt::Display for SequenceOptions {
                     increment = increment
                 )
             }
-            SequenceOptions::MinValue(value) => match value {
-                MinMaxValue::Empty => {
-                    write!(f, "")
-                }
-                MinMaxValue::None => {
-                    write!(f, " NO MINVALUE")
-                }
-                MinMaxValue::Some(minvalue) => {
-                    write!(f, " MINVALUE {minvalue}")
-                }
+            SequenceOptions::MinValue(Some(expr)) => {
+                write!(f, " MINVALUE {expr}")
             },
-            SequenceOptions::MaxValue(value) => match value {
-                MinMaxValue::Empty => {
-                    write!(f, "")
-                }
-                MinMaxValue::None => {
-                    write!(f, " NO MAXVALUE")
-                }
-                MinMaxValue::Some(maxvalue) => {
-                    write!(f, " MAXVALUE {maxvalue}")
-                }
+            SequenceOptions::MinValue(None) => {
+                write!(f, " NO MINVALUE")
+            }
+            SequenceOptions::MaxValue(Some(expr)) => {
+                write!(f, " MAXVALUE {expr}")
             },
+            SequenceOptions::MaxValue(None) => {
+                write!(f, " NO MAXVALUE")
+            }
             SequenceOptions::StartWith(start, with) => {
                 write!(
                     f,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3754,13 +3754,13 @@ impl fmt::Display for SequenceOptions {
             }
             SequenceOptions::MinValue(Some(expr)) => {
                 write!(f, " MINVALUE {expr}")
-            },
+            }
             SequenceOptions::MinValue(None) => {
                 write!(f, " NO MINVALUE")
             }
             SequenceOptions::MaxValue(Some(expr)) => {
                 write!(f, " MAXVALUE {expr}")
-            },
+            }
             SequenceOptions::MaxValue(None) => {
                 write!(f, " NO MAXVALUE")
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8602,13 +8602,12 @@ impl<'a> Parser<'a> {
             )));
         }
         // [ [ NO ] CYCLE ]
-        if self.parse_keywords(&[Keyword::NO]) {
-            if self.parse_keywords(&[Keyword::CYCLE]) {
-                sequence_options.push(SequenceOptions::Cycle(true));
-            }
+        if self.parse_keywords(&[Keyword::NO, Keyword::CYCLE]) {
+            sequence_options.push(SequenceOptions::Cycle(true));
         } else if self.parse_keywords(&[Keyword::CYCLE]) {
             sequence_options.push(SequenceOptions::Cycle(false));
         }
+
         Ok(sequence_options)
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8563,24 +8563,21 @@ impl<'a> Parser<'a> {
         }
         //[ MINVALUE minvalue | NO MINVALUE ]
         if self.parse_keyword(Keyword::MINVALUE) {
-            sequence_options.push(SequenceOptions::MinValue(MinMaxValue::Some(Expr::Value(
+            sequence_options.push(SequenceOptions::MinValue(Some(Expr::Value(
                 self.parse_number_value()?,
             ))));
         } else if self.parse_keywords(&[Keyword::NO, Keyword::MINVALUE]) {
-            sequence_options.push(SequenceOptions::MinValue(MinMaxValue::None));
-        } else {
-            sequence_options.push(SequenceOptions::MinValue(MinMaxValue::Empty));
+            sequence_options.push(SequenceOptions::MinValue(None));
         }
         //[ MAXVALUE maxvalue | NO MAXVALUE ]
         if self.parse_keywords(&[Keyword::MAXVALUE]) {
-            sequence_options.push(SequenceOptions::MaxValue(MinMaxValue::Some(Expr::Value(
+            sequence_options.push(SequenceOptions::MaxValue(Some(Expr::Value(
                 self.parse_number_value()?,
             ))));
         } else if self.parse_keywords(&[Keyword::NO, Keyword::MAXVALUE]) {
-            sequence_options.push(SequenceOptions::MaxValue(MinMaxValue::None));
-        } else {
-            sequence_options.push(SequenceOptions::MaxValue(MinMaxValue::Empty));
+            sequence_options.push(SequenceOptions::MaxValue(None));
         }
+
         //[ START [ WITH ] start ]
         if self.parse_keywords(&[Keyword::START]) {
             if self.parse_keywords(&[Keyword::WITH]) {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -16,8 +16,6 @@
 
 #[macro_use]
 mod test_utils;
-
-use std::assert_matches::assert_matches;
 use test_utils::*;
 
 use sqlparser::ast::*;
@@ -277,11 +275,6 @@ fn parse_create_sequence() {
     pg().one_statement_parses_to(
         sql6,
         "CREATE TEMPORARY SEQUENCE IF NOT EXISTS name3 INCREMENT 1 NO MINVALUE MAXVALUE 20 OWNED BY NONE",
-    );
-
-    assert!(
-        matches!(
-        pg().parse_sql_statements("CREATE SEQUENCE foo INCREMENT 1 NO MINVALUE NO"), Err(ParserError::ParserError(_)))
     );
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -16,6 +16,8 @@
 
 #[macro_use]
 mod test_utils;
+
+use std::assert_matches::assert_matches;
 use test_utils::*;
 
 use sqlparser::ast::*;
@@ -275,6 +277,11 @@ fn parse_create_sequence() {
     pg().one_statement_parses_to(
         sql6,
         "CREATE TEMPORARY SEQUENCE IF NOT EXISTS name3 INCREMENT 1 NO MINVALUE MAXVALUE 20 OWNED BY NONE",
+    );
+
+    assert!(
+        matches!(
+        pg().parse_sql_statements("CREATE SEQUENCE foo INCREMENT 1 NO MINVALUE NO"), Err(ParserError::ParserError(_)))
     );
 }
 


### PR DESCRIPTION

Changes:
1. Display for alter col with sequence options now only relies on presence of Sequence option lists. Control for parentheses is done via Some/None check.
2. Changed Minvalue and Maxvalue in Sequence Option to use Option<expr> instead of ternary some, none, empty. Presence is checked through the option list.

Fixes #1105