### PR TITLE
Support for unquoted hyphenated identifiers on bigquery

### DIFF
--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -82,7 +82,7 @@ fn parse_lock_tables(parser: &mut Parser) -> Result<Statement, ParserError> {
 
 // tbl_name [[AS] alias] lock_type
 fn parse_lock_table(parser: &mut Parser) -> Result<LockTable, ParserError> {
-    let table = parser.parse_identifier()?;
+    let table = parser.parse_identifier(false)?;
     let alias =
         parser.parse_optional_alias(&[Keyword::READ, Keyword::WRITE, Keyword::LOW_PRIORITY])?;
     let lock_type = parse_lock_tables_type(parser)?;

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -57,11 +57,11 @@ pub fn parse_comment(parser: &mut Parser) -> Result<Statement, ParserError> {
 
     let (object_type, object_name) = match token.token {
         Token::Word(w) if w.keyword == Keyword::COLUMN => {
-            let object_name = parser.parse_object_name()?;
+            let object_name = parser.parse_object_name(false)?;
             (CommentObject::Column, object_name)
         }
         Token::Word(w) if w.keyword == Keyword::TABLE => {
-            let object_name = parser.parse_object_name()?;
+            let object_name = parser.parse_object_name(false)?;
             (CommentObject::Table, object_name)
         }
         _ => parser.expected("comment object_type", token)?,

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -91,7 +91,7 @@ pub fn parse_create_stage(
 ) -> Result<Statement, ParserError> {
     //[ IF NOT EXISTS ]
     let if_not_exists = parser.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
-    let name = parser.parse_object_name()?;
+    let name = parser.parse_object_name(false)?;
     let mut directory_table_params = Vec::new();
     let mut file_format = Vec::new();
     let mut copy_options = Vec::new();
@@ -181,7 +181,7 @@ pub fn parse_snowflake_stage_name(parser: &mut Parser) -> Result<ObjectName, Par
         }
         _ => {
             parser.prev_token();
-            Ok(parser.parse_object_name()?)
+            Ok(parser.parse_object_name(false)?)
         }
     }
 }
@@ -219,7 +219,7 @@ pub fn parse_copy_into(parser: &mut Parser) -> Result<Statement, ParserError> {
         }
         _ => {
             parser.prev_token();
-            from_stage = parser.parse_object_name()?;
+            from_stage = parser.parse_object_name(false)?;
             stage_params = parse_stage_params(parser)?;
 
             // as

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6029,8 +6029,8 @@ impl<'a> Parser<'a> {
             Token::Word(w) => {
                 let mut ident = w.to_ident();
 
-                // On BigQuery, unquoted identifiers support hyphenated identifiers when referenced
-                // in a FROM or TABLE clause [0].
+                // On BigQuery, hyphens are permitted in unquoted identifiers inside of a FROM or
+                // TABLE clause [0].
                 //
                 // The first segment must be an ordinary unquoted identifier, e.g. it must not start
                 // with a digit. Subsequent segments are either must either be valid identifiers or

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5888,6 +5888,10 @@ impl<'a> Parser<'a> {
 
     /// Parse a possibly qualified, possibly quoted identifier, e.g.
     /// `foo` or `myschema."table"
+    ///
+    /// The `in_table_clause` parameter indicates whether the object name is a table in a FROM, JOIN,
+    /// or similar table clause. Currently, this is used only to support unquoted hyphenated identifiers
+    /// in this context on BigQuery.
     pub fn parse_object_name(&mut self, in_table_clause: bool) -> Result<ObjectName, ParserError> {
         let mut idents = vec![];
         loop {
@@ -6023,6 +6027,10 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a simple one-word identifier (possibly quoted, possibly a keyword)
+    ///
+    /// The `in_table_clause` parameter indicates whether the identifier is a table in a FROM, JOIN, or
+    /// similar table clause. Currently, this is used only to support unquoted hyphenated identifiers in
+    //  this context on BigQuery.
     pub fn parse_identifier(&mut self, in_table_clause: bool) -> Result<Ident, ParserError> {
         let next_token = self.next_token();
         match next_token.token {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -716,6 +716,27 @@ fn parse_table_identifiers() {
             Ident::with_quote('`', "da-sh-es"),
         ],
     );
+
+    test_table_ident(
+        "foo-bar.baz-123",
+        Some("foo-bar.baz-123"),
+        vec![Ident::new("foo-bar"), Ident::new("baz-123")],
+    );
+
+    test_table_ident_err("foo-`bar`");
+    test_table_ident_err("`foo`-bar");
+    test_table_ident_err("foo-123a");
+    test_table_ident_err("foo - bar");
+    test_table_ident_err("123-bar");
+    test_table_ident_err("bar-");
+}
+
+#[test]
+fn parse_hyphenated_table_identifiers() {
+    bigquery().one_statement_parses_to(
+        "select * from foo-bar f join baz-qux b on f.id = b.id",
+        "SELECT * FROM foo-bar AS f JOIN baz-qux AS b ON f.id = b.id",
+    );
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -507,14 +507,15 @@ fn parse_select_with_table_alias() {
 
 #[test]
 fn parse_invalid_table_name() {
-    let ast = all_dialects()
-        .run_parser_method("db.public..customer", |parser| parser.parse_object_name());
+    let ast = all_dialects().run_parser_method("db.public..customer", |parser| {
+        parser.parse_object_name(false)
+    });
     assert!(ast.is_err());
 }
 
 #[test]
 fn parse_no_table_name() {
-    let ast = all_dialects().run_parser_method("", |parser| parser.parse_object_name());
+    let ast = all_dialects().run_parser_method("", |parser| parser.parse_object_name(false));
     assert!(ast.is_err());
 }
 


### PR DESCRIPTION
This adds support for unquoted hyphenated identifiers on bigquery, e.g. `select * from foo-bar f join baz-qux b on f.id = b.id`. These are only allowed in contexts where they are unambiguous, such as in a `FROM` or `JOIN` clause. (There may be other cases where they are allowed, I only tested these two.)