### PR TITLE
Add support for UPDATE FROM for SQLite (further to #694)

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8048,7 +8048,7 @@ impl<'a> Parser<'a> {
         self.expect_keyword(Keyword::SET)?;
         let assignments = self.parse_comma_separated(Parser::parse_assignment)?;
         let from = if self.parse_keyword(Keyword::FROM)
-            && dialect_of!(self is GenericDialect | PostgreSqlDialect | DuckDbDialect | BigQueryDialect | SnowflakeDialect | RedshiftSqlDialect | MsSqlDialect)
+            && dialect_of!(self is GenericDialect | PostgreSqlDialect | DuckDbDialect | BigQueryDialect | SnowflakeDialect | RedshiftSqlDialect | MsSqlDialect | SQLiteDialect )
         {
             Some(self.parse_table_and_joins()?)
         } else {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -323,6 +323,7 @@ fn parse_update_set_from() {
             Box::new(SnowflakeDialect {}),
             Box::new(RedshiftSqlDialect {}),
             Box::new(MsSqlDialect {}),
+            Box::new(SQLiteDialect {}),
         ],
         options: None,
     };


### PR DESCRIPTION
"UPDATE-FROM is supported beginning in SQLite version 3.33.0 (2020-08-14)." from https://www.sqlite.org/lang_update.html