### PR TITLE
BigQuery: support of CREATE VIEW IF NOT EXISTS

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3482,7 +3482,7 @@ impl<'a> Parser<'a> {
     ) -> Result<Statement, ParserError> {
         let materialized = self.parse_keyword(Keyword::MATERIALIZED);
         self.expect_keyword(Keyword::VIEW)?;
-        let if_not_exists = dialect_of!(self is SQLiteDialect|GenericDialect)
+        let if_not_exists = dialect_of!(self is BigQueryDialect|SQLiteDialect|GenericDialect)
             && self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
         // Many dialects support `OR ALTER` right after `CREATE`, but we don't (yet).
         // ANSI SQL and Postgres support RECURSIVE here, but we don't support it either.

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -151,6 +151,36 @@ fn parse_create_view_with_options() {
         _ => unreachable!(),
     }
 }
+#[test]
+fn parse_create_view_if_not_exists() {
+    let sql = "CREATE VIEW IF NOT EXISTS mydataset.newview AS SELECT foo FROM bar";
+    match bigquery().verified_stmt(sql) {
+        Statement::CreateView {
+            name,
+            columns,
+            query,
+            or_replace,
+            materialized,
+            options,
+            cluster_by,
+            with_no_schema_binding: late_binding,
+            if_not_exists,
+            temporary,
+        } => {
+            assert_eq!("mydataset.newview", name.to_string());
+            assert_eq!(Vec::<ViewColumnDef>::new(), columns);
+            assert_eq!("SELECT foo FROM bar", query.to_string());
+            assert!(!materialized);
+            assert!(!or_replace);
+            assert_eq!(options, CreateTableOptions::None);
+            assert_eq!(cluster_by, vec![]);
+            assert!(!late_binding);
+            assert!(if_not_exists);
+            assert!(!temporary);
+        }
+        _ => unreachable!(),
+    }
+}
 
 #[test]
 fn parse_create_table_with_options() {


### PR DESCRIPTION
There is support for `CREATE VIEW IF NOT EXISTS` for general and sqlite dialects (only).

This PR adds a [support it for BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_view_statement)