### PR TITLE
feat: add mysql show status statement

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1955,6 +1955,16 @@ pub enum Statement {
     /// Note: this is a PostgreSQL-specific statement.
     ShowVariable { variable: Vec<Ident> },
     /// ```sql
+    /// SHOW [GLOBAL | SESSION] STATUS [LIKE 'pattern' | WHERE expr]
+    /// ```
+    ///
+    /// Note: this is a MySQL-specific statement.
+    ShowStatus {
+        filter: Option<ShowStatementFilter>,
+        global: bool,
+        session: bool,
+    },
+    /// ```sql
     /// SHOW VARIABLES
     /// ```
     ///
@@ -3384,6 +3394,24 @@ impl fmt::Display for Statement {
                 write!(f, "SHOW")?;
                 if !variable.is_empty() {
                     write!(f, " {}", display_separated(variable, " "))?;
+                }
+                Ok(())
+            }
+            Statement::ShowStatus {
+                filter,
+                global,
+                session,
+            } => {
+                write!(f, "SHOW")?;
+                if *global {
+                    write!(f, " GLOBAL")?;
+                }
+                if *session {
+                    write!(f, " SESSION")?;
+                }
+                write!(f, " STATUS")?;
+                if filter.is_some() {
+                    write!(f, " {}", filter.as_ref().unwrap())?;
                 }
                 Ok(())
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7097,6 +7097,14 @@ impl<'a> Parser<'a> {
                 session,
                 global,
             })
+        } else if self.parse_keyword(Keyword::STATUS)
+            && dialect_of!(self is MySqlDialect | GenericDialect)
+        {
+            Ok(Statement::ShowStatus {
+                filter: self.parse_show_statement_filter()?,
+                session,
+                global,
+            })
         } else {
             Ok(Statement::ShowVariable {
                 variable: self.parse_identifiers()?,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -289,6 +289,36 @@ fn parse_show_columns() {
 }
 
 #[test]
+fn parse_show_status() {
+    assert_eq!(
+        mysql_and_generic().verified_stmt("SHOW SESSION STATUS LIKE 'ssl_cipher'"),
+        Statement::ShowStatus {
+            filter: Some(ShowStatementFilter::Like("ssl_cipher".into())),
+            session: true,
+            global: false
+        }
+    );
+    assert_eq!(
+        mysql_and_generic().verified_stmt("SHOW GLOBAL STATUS LIKE 'ssl_cipher'"),
+        Statement::ShowStatus {
+            filter: Some(ShowStatementFilter::Like("ssl_cipher".into())),
+            session: false,
+            global: true
+        }
+    );
+    assert_eq!(
+        mysql_and_generic().verified_stmt("SHOW STATUS WHERE value = 2"),
+        Statement::ShowStatus {
+            filter: Some(ShowStatementFilter::Where(
+                mysql_and_generic().verified_expr("value = 2")
+            )),
+            session: false,
+            global: false
+        }
+    );
+}
+
+#[test]
 fn parse_show_tables() {
     assert_eq!(
         mysql_and_generic().verified_stmt("SHOW TABLES"),


### PR DESCRIPTION
Hi, 

Wanted to add support for `SHOW [GLOBAL | SESSION] STATUS [LIKE 'pattern' | WHERE expr]`

Taken from: [mysql docs](https://dev.mysql.com/doc/refman/8.0/en/show-status.html)