### PR TITLE
BigQuery: Parse optional `DELETE FROM` statement

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1436,6 +1436,23 @@ impl fmt::Display for CreateTableOptions {
     }
 }
 
+/// A `FROM` clause within a `DELETE` statement.
+///
+/// Syntax
+/// ```sql
+/// [FROM] table
+/// ```
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum FromTable {
+    /// An explicit `FROM` keyword was specified.
+    WithFromKeyword(Vec<TableWithJoins>),
+    /// BigQuery: `FROM` keyword was omitted.
+    /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax#delete_statement>
+    WithoutKeyword(Vec<TableWithJoins>),
+}
+
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1599,7 +1616,7 @@ pub enum Statement {
         /// Multi tables delete are supported in mysql
         tables: Vec<ObjectName>,
         /// FROM
-        from: Vec<TableWithJoins>,
+        from: FromTable,
         /// USING (Snowflake, Postgres, MySQL)
         using: Option<Vec<TableWithJoins>>,
         /// WHERE
@@ -2692,7 +2709,14 @@ impl fmt::Display for Statement {
                 if !tables.is_empty() {
                     write!(f, "{} ", display_comma_separated(tables))?;
                 }
-                write!(f, "FROM {}", display_comma_separated(from))?;
+                match from {
+                    FromTable::WithFromKeyword(from) => {
+                        write!(f, "FROM {}", display_comma_separated(from))?;
+                    }
+                    FromTable::WithoutKeyword(from) => {
+                        write!(f, "{}", display_comma_separated(from))?;
+                    }
+                }
                 if let Some(using) = using {
                     write!(f, " USING {}", display_comma_separated(using))?;
                 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -193,21 +193,35 @@ impl TestedDialects {
     }
 }
 
+/// Returns all available dialects.
 pub fn all_dialects() -> TestedDialects {
+    all_dialects_except(|_| false)
+}
+
+/// Returns available dialects. The `except` predicate is used
+/// to filter out specific dialects.
+pub fn all_dialects_except<F>(except: F) -> TestedDialects
+where
+    F: Fn(&dyn Dialect) -> bool,
+{
+    let all_dialects = vec![
+        Box::new(GenericDialect {}) as Box<dyn Dialect>,
+        Box::new(PostgreSqlDialect {}) as Box<dyn Dialect>,
+        Box::new(MsSqlDialect {}) as Box<dyn Dialect>,
+        Box::new(AnsiDialect {}) as Box<dyn Dialect>,
+        Box::new(SnowflakeDialect {}) as Box<dyn Dialect>,
+        Box::new(HiveDialect {}) as Box<dyn Dialect>,
+        Box::new(RedshiftSqlDialect {}) as Box<dyn Dialect>,
+        Box::new(MySqlDialect {}) as Box<dyn Dialect>,
+        Box::new(BigQueryDialect {}) as Box<dyn Dialect>,
+        Box::new(SQLiteDialect {}) as Box<dyn Dialect>,
+        Box::new(DuckDbDialect {}) as Box<dyn Dialect>,
+    ];
     TestedDialects {
-        dialects: vec![
-            Box::new(GenericDialect {}),
-            Box::new(PostgreSqlDialect {}),
-            Box::new(MsSqlDialect {}),
-            Box::new(AnsiDialect {}),
-            Box::new(SnowflakeDialect {}),
-            Box::new(HiveDialect {}),
-            Box::new(RedshiftSqlDialect {}),
-            Box::new(MySqlDialect {}),
-            Box::new(BigQueryDialect {}),
-            Box::new(SQLiteDialect {}),
-            Box::new(DuckDbDialect {}),
-        ],
+        dialects: all_dialects
+            .into_iter()
+            .filter(|d| !except(d.as_ref()))
+            .collect(),
         options: None,
     }
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -87,6 +87,30 @@ fn parse_raw_literal() {
 }
 
 #[test]
+fn parse_delete_statement() {
+    let sql = "DELETE \"table\" WHERE 1";
+    match bigquery_and_generic().verified_stmt(sql) {
+        Statement::Delete {
+            from: FromTable::WithoutKeyword(from),
+            ..
+        } => {
+            assert_eq!(
+                TableFactor::Table {
+                    name: ObjectName(vec![Ident::with_quote('"', "table")]),
+                    alias: None,
+                    args: None,
+                    with_hints: vec![],
+                    version: None,
+                    partitions: vec![],
+                },
+                from[0].relation
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_create_view_with_options() {
     let sql = concat!(
         "CREATE VIEW myproject.mydataset.newview ",


### PR DESCRIPTION
The `FROM` keyword is optional is a `DELETE` statement for [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax#delete_statement) This adds parser support to handle such statements