### PR TITLE
add support for `insert into ... select ... returning ...`

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -772,6 +772,7 @@ pub const RESERVED_FOR_COLUMN_ALIAS: &[Keyword] = &[
     Keyword::INTERSECT,
     Keyword::CLUSTER,
     Keyword::DISTRIBUTE,
+    Keyword::RETURNING,
     // Reserved only as a column alias in the `SELECT` clause
     Keyword::FROM,
     Keyword::INTO,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -213,6 +213,25 @@ fn parse_insert_default_values() {
 }
 
 #[test]
+fn parse_insert_select_returning() {
+    verified_stmt("INSERT INTO t SELECT 1 RETURNING 2");
+    let stmt = verified_stmt("INSERT INTO t SELECT x RETURNING x AS y");
+    match stmt {
+        Statement::Insert {
+            returning: Some(ret),
+            source: Some(_),
+            ..
+        } => assert_eq!(ret.len(), 1),
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_returning_as_column_alias() {
+    verified_stmt("SELECT 1 AS RETURNING");
+}
+
+#[test]
 fn parse_insert_sqlite() {
     let dialect = SQLiteDialect {};
 


### PR DESCRIPTION
`insert into test select 1 returning 2` now parses correctly

`select 1 as returning` which is valid only in MySQL and SQL Server and used to parse without error still parses without error (and is now tested)

`select 1 returning`, which is a syntax error in postgres, sqlite and MariaDB, but is valid in MySQL and SQL Server, used to parse without error, and now returns a syntax error.

The `insert into ... select ... returning ...` syntax is quite useful in [SQLPage](https://github.com/lovasoa/SQLpage)
