### PR TITLE
accept JSON_TABLE both as an unquoted table name and a table-valued function

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7515,7 +7515,11 @@ impl<'a> Parser<'a> {
                 with_offset,
                 with_offset_alias,
             })
-        } else if self.parse_keyword(Keyword::JSON_TABLE) {
+        } else if matches!(
+            self.peek_token().token, Token::Word(w)
+            if w.keyword == Keyword::JSON_TABLE && self.peek_nth_token(1).token == Token::LParen
+        ) {
+            self.expect_keyword(Keyword::JSON_TABLE)?;
             self.expect_token(&Token::LParen)?;
             let json_expr = self.parse_expr()?;
             self.expect_token(&Token::Comma)?;

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2339,7 +2339,7 @@ fn parse_json_table_is_not_reserved() {
             name: ObjectName(name),
             ..
         } => assert_eq!("JSON_TABLE", name[0].value),
-        _ => unreachable!(),
+        _ => panic!("Expected JSON_TABLE to be parsed as a table name"),
     }
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2332,19 +2332,16 @@ fn test_json() {
 fn parse_json_table_is_not_reserved() {
     // JSON_TABLE is not a reserved keyword in PostgreSQL, even though it is in SQL:2023
     // see: https://en.wikipedia.org/wiki/List_of_SQL_reserved_words
-    match pg().verified_only_select("SELECT * FROM JSON_TABLE") {
-        Select { from, .. } => {
-            assert_eq!(1, from.len());
-            match &from[0].relation {
-                TableFactor::Table {
-                    name: ObjectName(name),
-                    ..
-                } => {
-                    assert_eq!("JSON_TABLE", name[0].value);
-                }
-                _ => unreachable!(),
-            }
+    let Select { from, .. } = pg().verified_only_select("SELECT * FROM JSON_TABLE");
+    assert_eq!(1, from.len());
+    match &from[0].relation {
+        TableFactor::Table {
+            name: ObjectName(name),
+            ..
+        } => {
+            assert_eq!("JSON_TABLE", name[0].value);
         }
+        _ => unreachable!(),
     }
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2338,9 +2338,7 @@ fn parse_json_table_is_not_reserved() {
         TableFactor::Table {
             name: ObjectName(name),
             ..
-        } => {
-            assert_eq!("JSON_TABLE", name[0].value);
-        }
+        } => assert_eq!("JSON_TABLE", name[0].value),
         _ => unreachable!(),
     }
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2339,7 +2339,7 @@ fn parse_json_table_is_not_reserved() {
             name: ObjectName(name),
             ..
         } => assert_eq!("JSON_TABLE", name[0].value),
-        _ => panic!("Expected JSON_TABLE to be parsed as a table name"),
+        other => panic!("Expected JSON_TABLE to be parsed as a table name, but got {other:?}"),
     }
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2329,6 +2329,26 @@ fn test_json() {
 }
 
 #[test]
+fn parse_json_table_is_not_reserved() {
+    // JSON_TABLE is not a reserved keyword in PostgreSQL, even though it is in SQL:2023
+    // see: https://en.wikipedia.org/wiki/List_of_SQL_reserved_words
+    match pg().verified_only_select("SELECT * FROM JSON_TABLE") {
+        Select { from, .. } => {
+            assert_eq!(1, from.len());
+            match &from[0].relation {
+                TableFactor::Table {
+                    name: ObjectName(name),
+                    ..
+                } => {
+                    assert_eq!("JSON_TABLE", name[0].value);
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+#[test]
 fn test_composite_value() {
     let sql = "SELECT (on_hand.item).name FROM on_hand WHERE (on_hand.item).price > 9";
     let select = pg().verified_only_select(sql);

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2332,7 +2332,7 @@ fn test_json() {
 fn parse_json_table_is_not_reserved() {
     // JSON_TABLE is not a reserved keyword in PostgreSQL, even though it is in SQL:2023
     // see: https://en.wikipedia.org/wiki/List_of_SQL_reserved_words
-    let Select { from, .. } = pg().verified_only_select("SELECT * FROM JSON_TABLE");
+    let Select { from, .. } = pg_and_generic().verified_only_select("SELECT * FROM JSON_TABLE");
     assert_eq!(1, from.len());
     match &from[0].relation {
         TableFactor::Table {


### PR DESCRIPTION
This is an alternative to https://github.com/sqlparser-rs/sqlparser-rs/pull/1123

closes https://github.com/sqlparser-rs/sqlparser-rs/pull/1123
related to https://github.com/apache/arrow-datafusion/issues/9122

see https://github.com/sqlparser-rs/sqlparser-rs/pull/1123#issuecomment-1943607093

This makes sqlparser accept both 

```sql
select * from json_table 
```
And
```sql
select * from json_table(t, '$[*]' COLUMNS (id  INT PATH '$.id'))
```

in all dialects