### PR TITLE
Support for `(+)` outer join syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -713,6 +713,21 @@ pub enum Expr {
     /// Qualified wildcard, e.g. `alias.*` or `schema.table.*`.
     /// (Same caveats apply to `QualifiedWildcard` as to `Wildcard`.)
     QualifiedWildcard(ObjectName),
+    /// Some dialects support an older syntax for outer joins where columns are
+    /// marked with the `(+)` operator in the WHERE clause, for example:
+    ///
+    /// ```sql
+    /// SELECT t1.c1, t2.c2 FROM t1, t2 WHERE t1.c1 = t2.c2 (+)
+    /// ```
+    ///
+    /// which is equivalent to
+    ///
+    /// ```sql
+    /// SELECT t1.c1, t2.c2 FROM t1 LEFT OUTER JOIN t2 ON t1.c1 = t2.c2
+    /// ```
+    ///
+    /// See <https://docs.snowflake.com/en/sql-reference/constructs/where#joins-in-the-where-clause>.
+    OuterJoin(Box<Expr>),
 }
 
 impl fmt::Display for CastFormat {
@@ -1173,6 +1188,9 @@ impl fmt::Display for Expr {
                 }
 
                 Ok(())
+            }
+            Expr::OuterJoin(expr) => {
+                write!(f, "{expr} (+)")
             }
         }
     }


### PR DESCRIPTION
Snowflake supports a peculiar alternative syntax for outer joins using the `(+)` operator. For example, the following two queries are logically equivalent:

```sql
SELECT t1.c1, t2.c2
FROM t1, t2
WHERE t1.c1 = t2.c2 (+);
```

```sql
SELECT t1.c1, t2.c2
FROM t1 LEFT OUTER JOIN t2
        ON t1.c1 = t2.c2;
```

This adds support to the parser for this syntax. I've only tested on Snowflake, but a web search suggested that MS SQL also supports this syntax, so I permitted it on that dialect as well.