### PR TITLE
Clean up nightly clippy lints

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -5200,7 +5200,13 @@ impl fmt::Display for CopyLegacyCsvOption {
     }
 }
 
+/// `MERGE` Statement
 ///
+/// ```sql
+/// MERGE INTO <target_table> USING <source> ON <join_expr> { matchedClause | notMatchedClause } [ ... ]
+/// ```
+///
+/// See [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/sql/merge)
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -207,8 +207,6 @@ pub fn dialect_from_str(dialect_name: impl AsRef<str>) -> Option<Box<dyn Dialect
 
 #[cfg(test)]
 mod tests {
-    use super::ansi::AnsiDialect;
-    use super::generic::GenericDialect;
     use super::*;
 
     struct DialectHolder<'a> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -30,7 +30,7 @@ use IsOptional::*;
 use crate::ast::helpers::stmt_create_table::{BigQueryTableConfiguration, CreateTableBuilder};
 use crate::ast::*;
 use crate::dialect::*;
-use crate::keywords::{self, Keyword, ALL_KEYWORDS};
+use crate::keywords::{Keyword, ALL_KEYWORDS};
 use crate::tokenizer::*;
 
 mod alter;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1409,7 +1409,7 @@ fn peeking_take_while(chars: &mut State, mut predicate: impl FnMut(char) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dialect::{ClickHouseDialect, GenericDialect, MsSqlDialect};
+    use crate::dialect::{ClickHouseDialect, MsSqlDialect};
 
     #[test]
     fn tokenizer_error_impl() {

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -19,7 +19,6 @@ mod test_utils;
 use test_utils::*;
 
 use sqlparser::ast::Expr::{BinaryOp, Identifier, MapAccess};
-use sqlparser::ast::Ident;
 use sqlparser::ast::SelectItem::UnnamedExpr;
 use sqlparser::ast::TableFactor::Table;
 use sqlparser::ast::*;

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -15,9 +15,8 @@
 //! is also tested (on the inputs it can handle).
 
 use matches::assert_matches;
-use sqlparser::ast::Expr;
+
 use sqlparser::ast::MysqlInsertPriority::{Delayed, HighPriority, LowPriority};
-use sqlparser::ast::Value;
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, MySqlDialect};
 use sqlparser::parser::ParserOptions;

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1305,7 +1305,7 @@ fn test_snowflake_stage_object_names() {
         "@namespace.stage_name/path",
         "@~/path",
     ];
-    let mut allowed_object_names = vec![
+    let mut allowed_object_names = [
         ObjectName(vec![Ident::new("my_company"), Ident::new("emp_basic")]),
         ObjectName(vec![Ident::new("@namespace"), Ident::new("%table_name")]),
         ObjectName(vec![


### PR DESCRIPTION
I noticed the github actions runner was marking these on PRs as the nightly clippy has gotten smarter.

So I ran `cargo clippy +nightly` and fixed the resulting errors