### PR TITLE
Support postgres style `CREATE FUNCTION` in `GenericDialect`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3317,7 +3317,7 @@ impl<'a> Parser<'a> {
                 return_type: None,
                 params,
             })
-        } else if dialect_of!(self is PostgreSqlDialect) {
+        } else if dialect_of!(self is PostgreSqlDialect | GenericDialect) {
             let name = self.parse_object_name(false)?;
             self.expect_token(&Token::LParen)?;
             let args = if self.consume_token(&Token::RParen) {

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -19,7 +19,7 @@ use sqlparser::ast::{
     CreateFunctionBody, CreateFunctionUsing, Expr, Function, FunctionDefinition, Ident, ObjectName,
     SelectItem, Statement, TableFactor, UnaryOperator, Value,
 };
-use sqlparser::dialect::{GenericDialect, HiveDialect};
+use sqlparser::dialect::{GenericDialect, HiveDialect, MsSqlDialect};
 use sqlparser::parser::{ParserError, ParserOptions};
 use sqlparser::test_utils::*;
 
@@ -285,8 +285,14 @@ fn parse_create_function() {
         _ => unreachable!(),
     }
 
+    // Test error in dialect that doesn't support parsing CREATE FUNCTION
+    let unsupported_dialects = TestedDialects {
+        dialects: vec![Box::new(MsSqlDialect {})],
+        options: None,
+    };
+
     assert_eq!(
-        generic(None).parse_sql_statements(sql).unwrap_err(),
+        unsupported_dialects.parse_sql_statements(sql).unwrap_err(),
         ParserError::ParserError(
             "Expected an object type after CREATE, found: FUNCTION".to_string()
         )

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3257,7 +3257,7 @@ fn parse_similar_to() {
 fn parse_create_function() {
     let sql = "CREATE FUNCTION add(INTEGER, INTEGER) RETURNS INTEGER LANGUAGE SQL IMMUTABLE AS 'select $1 + $2;'";
     assert_eq!(
-        pg().verified_stmt(sql),
+        pg_and_generic().verified_stmt(sql),
         Statement::CreateFunction {
             or_replace: false,
             temporary: false,


### PR DESCRIPTION
we found in https://github.com/apache/arrow-datafusion/pull/9333 that `GenericDialect` does not support `CREATE FUNCTION` which is used by default

Thus support parsing posgres style `CREATE FUNCTION` in `GenericDialect` as well