### PR TITLE
Add identifier quote style to `Dialect` trait

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -108,6 +108,10 @@ pub trait Dialect: Debug + Any {
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
         ch == '"' || ch == '`'
     }
+    /// Return the character used to quote identifiers.
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        None
+    }
     /// Determine if quoted characters are proper for identifier
     fn is_proper_identifier_inside_quotes(&self, mut _chars: Peekable<Chars<'_>>) -> bool {
         true

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -267,6 +267,21 @@ mod tests {
     }
 
     #[test]
+    fn identifier_quote_style() {
+        let tests: Vec<(&dyn Dialect, &str, Option<char>)> = vec![
+            (&GenericDialect {}, "id", None),
+            (&SQLiteDialect {}, "id", Some('`')),
+            (&PostgreSqlDialect {}, "id", Some('"')),
+        ];
+
+        for (dialect, ident, expected) in tests {
+            let actual = dialect.identifier_quote_style(ident);
+
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
     fn parse_with_wrapped_dialect() {
         /// Wrapper for a dialect. In a real-world example, this wrapper
         /// would tweak the behavior of the dialect. For the test case,
@@ -285,6 +300,10 @@ mod tests {
 
             fn is_delimited_identifier_start(&self, ch: char) -> bool {
                 self.0.is_delimited_identifier_start(ch)
+            }
+
+            fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
+                self.0.identifier_quote_style(identifier)
             }
 
             fn is_proper_identifier_inside_quotes(

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -44,6 +44,10 @@ impl Dialect for MySqlDialect {
         ch == '`'
     }
 
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('`')
+    }
+
     fn parse_infix(
         &self,
         parser: &mut crate::parser::Parser,

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -21,6 +21,10 @@ use crate::tokenizer::Token;
 pub struct PostgreSqlDialect {}
 
 impl Dialect for PostgreSqlDialect {
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('"')
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         // See https://www.postgresql.org/docs/11/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
         // We don't yet support identifiers beginning with "letters with

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -32,6 +32,10 @@ impl Dialect for SQLiteDialect {
         ch == '`' || ch == '"' || ch == '['
     }
 
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('`')
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         // See https://www.sqlite.org/draft/tokenreq.html
         ch.is_ascii_lowercase()


### PR DESCRIPTION
This relates to apache/arrow-datafusion#9517 where we're adding an SQL `unparser` to turn DataFusion Expr/Plans back into SQL.

I extended the method to allow passing the identifier value. This may be helpful in case we want to add heuristics to only add quotes if truly needed by the dialect.