### PR TITLE
Support `[FIRST | AFTER column_name]` support in `ALTER TABLE` for MySQL 

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -26,7 +26,7 @@ use sqlparser_derive::{Visit, VisitMut};
 use crate::ast::value::escape_single_quote_string;
 use crate::ast::{
     display_comma_separated, display_separated, DataType, Expr, Ident, ObjectName, SequenceOptions,
-    SqlOption,
+    SqlOption, MySQLColumnPosition
 };
 use crate::tokenizer::Token;
 
@@ -45,6 +45,8 @@ pub enum AlterTableOperation {
         if_not_exists: bool,
         /// <column_def>.
         column_def: ColumnDef,
+        /// MySQL `ALTER TABLE` only  [FIRST | AFTER column_name]
+        column_position: Option<MySQLColumnPosition>,
     },
     /// `DISABLE ROW LEVEL SECURITY`
     ///
@@ -129,6 +131,8 @@ pub enum AlterTableOperation {
         new_name: Ident,
         data_type: DataType,
         options: Vec<ColumnOption>,
+        /// MySQL `ALTER TABLE` only  [FIRST | AFTER column_name]
+        column_position: Option<MySQLColumnPosition>,
     },
     /// `RENAME CONSTRAINT <old_constraint_name> TO <new_constraint_name>`
     ///
@@ -171,6 +175,7 @@ impl fmt::Display for AlterTableOperation {
                 column_keyword,
                 if_not_exists,
                 column_def,
+                column_position,
             } => {
                 write!(f, "ADD")?;
                 if *column_keyword {
@@ -180,6 +185,10 @@ impl fmt::Display for AlterTableOperation {
                     write!(f, " IF NOT EXISTS")?;
                 }
                 write!(f, " {column_def}")?;
+
+                if let Some(position) = column_position {
+                    write!(f, " {position}")?;
+                }
 
                 Ok(())
             }
@@ -271,13 +280,17 @@ impl fmt::Display for AlterTableOperation {
                 new_name,
                 data_type,
                 options,
+                column_position,
             } => {
                 write!(f, "CHANGE COLUMN {old_name} {new_name} {data_type}")?;
-                if options.is_empty() {
-                    Ok(())
-                } else {
-                    write!(f, " {}", display_separated(options, " "))
+                if !options.is_empty() {
+                    write!(f, " {}", display_separated(options, " "))?;
                 }
+                if let Some(position) = column_position {
+                    write!(f, " {position}")?;
+                }
+
+                Ok(())
             }
             AlterTableOperation::RenameConstraint { old_name, new_name } => {
                 write!(f, "RENAME CONSTRAINT {old_name} TO {new_name}")

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -25,8 +25,8 @@ use sqlparser_derive::{Visit, VisitMut};
 
 use crate::ast::value::escape_single_quote_string;
 use crate::ast::{
-    display_comma_separated, display_separated, DataType, Expr, Ident, ObjectName, SequenceOptions,
-    SqlOption, MySQLColumnPosition
+    display_comma_separated, display_separated, DataType, Expr, Ident, MySQLColumnPosition,
+    ObjectName, SequenceOptions, SqlOption,
 };
 use crate::tokenizer::Token;
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -5928,14 +5928,10 @@ impl fmt::Display for HiveSetLocation {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-feature = "visitor",
-derive(Visit, VisitMut),
-visit(with = "visit_statement")
-)]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum MySQLColumnPosition {
     First,
-    After(Ident)
+    After(Ident),
 }
 
 impl Display for MySQLColumnPosition {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -5924,6 +5924,32 @@ impl fmt::Display for HiveSetLocation {
     }
 }
 
+/// MySQL `ALTER TABLE` only  [FIRST | AFTER column_name]
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+feature = "visitor",
+derive(Visit, VisitMut),
+visit(with = "visit_statement")
+)]
+pub enum MySQLColumnPosition {
+    First,
+    After(Ident)
+}
+
+impl Display for MySQLColumnPosition {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MySQLColumnPosition::First => Ok(write!(f, "FIRST")?),
+            MySQLColumnPosition::After(ident) => {
+                let column_name = &ident.value;
+                Ok(write!(f, "AFTER {column_name}")?)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -73,6 +73,7 @@ define_keywords!(
     ACTION,
     ADD,
     ADMIN,
+    AFTER,
     AGAINST,
     ALL,
     ALLOCATE,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3511,11 +3511,13 @@ fn parse_alter_table() {
             column_keyword,
             if_not_exists,
             column_def,
+            column_position,
         } => {
             assert!(column_keyword);
             assert!(!if_not_exists);
             assert_eq!("foo", column_def.name.to_string());
             assert_eq!("TEXT", column_def.data_type.to_string());
+            assert_eq!(None, column_position);
         }
         _ => unreachable!(),
     };

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1876,6 +1876,120 @@ fn parse_delete_with_limit() {
 }
 
 #[test]
+fn parse_alter_table_add_column() {
+    match mysql().verified_stmt("ALTER TABLE tab ADD COLUMN b INT FIRST") {
+        Statement::AlterTable {
+            name,
+            if_exists,
+            only,
+            operations,
+            location: _,
+        } => {
+            assert_eq!(name.to_string(), "tab");
+            assert_eq!(if_exists, false);
+            assert_eq!(only, false);
+            assert_eq!(
+                operations,
+                vec![
+                    AlterTableOperation::AddColumn {
+                        column_keyword: true,
+                        if_not_exists: false,
+                        column_def: ColumnDef {
+                            name: "b".into(),
+                            data_type: DataType::Int(None),
+                            collation: None,
+                            options: vec![],
+                        },
+                        column_position: Some(MySQLColumnPosition::First),
+                    },
+                ]
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    match mysql().verified_stmt("ALTER TABLE tab ADD COLUMN b INT AFTER foo") {
+        Statement::AlterTable {
+            name,
+            if_exists,
+            only,
+            operations,
+            location: _,
+        } => {
+            assert_eq!(name.to_string(), "tab");
+            assert_eq!(if_exists, false);
+            assert_eq!(only, false);
+            assert_eq!(
+                operations,
+                vec![
+                    AlterTableOperation::AddColumn {
+                        column_keyword: true,
+                        if_not_exists: false,
+                        column_def: ColumnDef {
+                            name: "b".into(),
+                            data_type: DataType::Int(None),
+                            collation: None,
+                            options: vec![],
+                        },
+                        column_position: Some(MySQLColumnPosition::After(
+                            Ident {value: String::from("foo"), quote_style :None}
+                        )),
+                    },
+                ]
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_alter_table_add_columns() {
+    match mysql().verified_stmt("ALTER TABLE tab ADD COLUMN a TEXT FIRST, ADD COLUMN b INT AFTER foo") {
+        Statement::AlterTable {
+            name,
+            if_exists,
+            only,
+            operations,
+            location: _,
+        } => {
+            assert_eq!(name.to_string(), "tab");
+            assert_eq!(if_exists, false);
+            assert_eq!(only, false);
+            assert_eq!(
+                operations,
+                vec![
+                    AlterTableOperation::AddColumn {
+                        column_keyword: true,
+                        if_not_exists: false,
+                        column_def: ColumnDef {
+                            name: "a".into(),
+                            data_type: DataType::Text,
+                            collation: None,
+                            options: vec![],
+                        },
+                        column_position: Some(MySQLColumnPosition::First),
+                    },
+                    AlterTableOperation::AddColumn {
+                        column_keyword: true,
+                        if_not_exists: false,
+                        column_def: ColumnDef {
+                            name: "b".into(),
+                            data_type: DataType::Int(None),
+                            collation: None,
+                            options: vec![],
+                        },
+                        column_position: Some(MySQLColumnPosition::After(
+                            Ident {value: String::from("foo"), quote_style :None}
+                        )),
+                    },
+                ]
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_alter_table_drop_primary_key() {
     assert_matches!(
         alter_table_op(mysql_and_generic().verified_stmt("ALTER TABLE tab DROP PRIMARY KEY")),
@@ -1891,6 +2005,7 @@ fn parse_alter_table_change_column() {
         new_name: Ident::new("desc"),
         data_type: DataType::Text,
         options: vec![ColumnOption::NotNull],
+        column_position: None,
     };
 
     let sql1 = "ALTER TABLE orders CHANGE COLUMN description desc TEXT NOT NULL";
@@ -1904,6 +2019,82 @@ fn parse_alter_table_change_column() {
         &expected_name.to_string(),
     );
     assert_eq!(expected_operation, operation);
+
+    let expected_operation = AlterTableOperation::ChangeColumn {
+        old_name: Ident::new("description"),
+        new_name: Ident::new("desc"),
+        data_type: DataType::Text,
+        options: vec![ColumnOption::NotNull],
+        column_position: Some(MySQLColumnPosition::First),
+    };
+    let sql3 = "ALTER TABLE orders CHANGE COLUMN description desc TEXT NOT NULL FIRST";
+    let operation =
+        alter_table_op_with_name(mysql().verified_stmt(sql3), &expected_name.to_string());
+    assert_eq!(expected_operation, operation);
+
+    let expected_operation = AlterTableOperation::ChangeColumn {
+        old_name: Ident::new("description"),
+        new_name: Ident::new("desc"),
+        data_type: DataType::Text,
+        options: vec![ColumnOption::NotNull],
+        column_position: Some(MySQLColumnPosition::After(
+            Ident{ value: String::from("foo"), quote_style: None}
+        )),
+    };
+    let sql4 = "ALTER TABLE orders CHANGE COLUMN description desc TEXT NOT NULL AFTER foo";
+    let operation =
+        alter_table_op_with_name(mysql().verified_stmt(sql4), &expected_name.to_string());
+    assert_eq!(expected_operation, operation);
+
+
+}
+
+#[test]
+fn parse_alter_table_change_column_with_column_position() {
+    let expected_name = ObjectName(vec![Ident::new("orders")]);
+    let expected_operation_first = AlterTableOperation::ChangeColumn {
+        old_name: Ident::new("description"),
+        new_name: Ident::new("desc"),
+        data_type: DataType::Text,
+        options: vec![ColumnOption::NotNull],
+        column_position: Some(MySQLColumnPosition::First),
+    };
+
+    let sql1 = "ALTER TABLE orders CHANGE COLUMN description desc TEXT NOT NULL FIRST";
+    let operation =
+        alter_table_op_with_name(mysql().verified_stmt(sql1), &expected_name.to_string());
+    assert_eq!(expected_operation_first, operation);
+
+    let sql2 = "ALTER TABLE orders CHANGE description desc TEXT NOT NULL FIRST";
+    let operation = alter_table_op_with_name(
+        mysql().one_statement_parses_to(sql2, sql1),
+        &expected_name.to_string(),
+    );
+    assert_eq!(expected_operation_first, operation);
+
+    let expected_operation_after = AlterTableOperation::ChangeColumn {
+        old_name: Ident::new("description"),
+        new_name: Ident::new("desc"),
+        data_type: DataType::Text,
+        options: vec![ColumnOption::NotNull],
+        column_position: Some(MySQLColumnPosition::After(
+            Ident{value: String::from("total_count"), quote_style: None}
+        )),
+    };
+
+    let sql1 = "ALTER TABLE orders CHANGE COLUMN description desc TEXT NOT NULL AFTER total_count";
+    let operation =
+        alter_table_op_with_name(mysql().verified_stmt(sql1), &expected_name.to_string());
+    assert_eq!(expected_operation_after, operation);
+
+    let sql2 = "ALTER TABLE orders CHANGE description desc TEXT NOT NULL AFTER total_count";
+    let operation = alter_table_op_with_name(
+        mysql().one_statement_parses_to(sql2, sql1),
+        &expected_name.to_string(),
+    );
+    assert_eq!(expected_operation_after, operation);
+
+
 }
 
 #[test]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1886,23 +1886,21 @@ fn parse_alter_table_add_column() {
             location: _,
         } => {
             assert_eq!(name.to_string(), "tab");
-            assert_eq!(if_exists, false);
-            assert_eq!(only, false);
+            assert!(!if_exists);
+            assert!(!only);
             assert_eq!(
                 operations,
-                vec![
-                    AlterTableOperation::AddColumn {
-                        column_keyword: true,
-                        if_not_exists: false,
-                        column_def: ColumnDef {
-                            name: "b".into(),
-                            data_type: DataType::Int(None),
-                            collation: None,
-                            options: vec![],
-                        },
-                        column_position: Some(MySQLColumnPosition::First),
+                vec![AlterTableOperation::AddColumn {
+                    column_keyword: true,
+                    if_not_exists: false,
+                    column_def: ColumnDef {
+                        name: "b".into(),
+                        data_type: DataType::Int(None),
+                        collation: None,
+                        options: vec![],
                     },
-                ]
+                    column_position: Some(MySQLColumnPosition::First),
+                },]
             );
         }
         _ => unreachable!(),
@@ -1917,25 +1915,24 @@ fn parse_alter_table_add_column() {
             location: _,
         } => {
             assert_eq!(name.to_string(), "tab");
-            assert_eq!(if_exists, false);
-            assert_eq!(only, false);
+            assert!(!if_exists);
+            assert!(!only);
             assert_eq!(
                 operations,
-                vec![
-                    AlterTableOperation::AddColumn {
-                        column_keyword: true,
-                        if_not_exists: false,
-                        column_def: ColumnDef {
-                            name: "b".into(),
-                            data_type: DataType::Int(None),
-                            collation: None,
-                            options: vec![],
-                        },
-                        column_position: Some(MySQLColumnPosition::After(
-                            Ident {value: String::from("foo"), quote_style :None}
-                        )),
+                vec![AlterTableOperation::AddColumn {
+                    column_keyword: true,
+                    if_not_exists: false,
+                    column_def: ColumnDef {
+                        name: "b".into(),
+                        data_type: DataType::Int(None),
+                        collation: None,
+                        options: vec![],
                     },
-                ]
+                    column_position: Some(MySQLColumnPosition::After(Ident {
+                        value: String::from("foo"),
+                        quote_style: None
+                    })),
+                },]
             );
         }
         _ => unreachable!(),
@@ -1944,7 +1941,9 @@ fn parse_alter_table_add_column() {
 
 #[test]
 fn parse_alter_table_add_columns() {
-    match mysql().verified_stmt("ALTER TABLE tab ADD COLUMN a TEXT FIRST, ADD COLUMN b INT AFTER foo") {
+    match mysql()
+        .verified_stmt("ALTER TABLE tab ADD COLUMN a TEXT FIRST, ADD COLUMN b INT AFTER foo")
+    {
         Statement::AlterTable {
             name,
             if_exists,
@@ -1953,8 +1952,8 @@ fn parse_alter_table_add_columns() {
             location: _,
         } => {
             assert_eq!(name.to_string(), "tab");
-            assert_eq!(if_exists, false);
-            assert_eq!(only, false);
+            assert!(!if_exists);
+            assert!(!only);
             assert_eq!(
                 operations,
                 vec![
@@ -1978,9 +1977,10 @@ fn parse_alter_table_add_columns() {
                             collation: None,
                             options: vec![],
                         },
-                        column_position: Some(MySQLColumnPosition::After(
-                            Ident {value: String::from("foo"), quote_style :None}
-                        )),
+                        column_position: Some(MySQLColumnPosition::After(Ident {
+                            value: String::from("foo"),
+                            quote_style: None,
+                        })),
                     },
                 ]
             );
@@ -2037,16 +2037,15 @@ fn parse_alter_table_change_column() {
         new_name: Ident::new("desc"),
         data_type: DataType::Text,
         options: vec![ColumnOption::NotNull],
-        column_position: Some(MySQLColumnPosition::After(
-            Ident{ value: String::from("foo"), quote_style: None}
-        )),
+        column_position: Some(MySQLColumnPosition::After(Ident {
+            value: String::from("foo"),
+            quote_style: None,
+        })),
     };
     let sql4 = "ALTER TABLE orders CHANGE COLUMN description desc TEXT NOT NULL AFTER foo";
     let operation =
         alter_table_op_with_name(mysql().verified_stmt(sql4), &expected_name.to_string());
     assert_eq!(expected_operation, operation);
-
-
 }
 
 #[test]
@@ -2077,9 +2076,10 @@ fn parse_alter_table_change_column_with_column_position() {
         new_name: Ident::new("desc"),
         data_type: DataType::Text,
         options: vec![ColumnOption::NotNull],
-        column_position: Some(MySQLColumnPosition::After(
-            Ident{value: String::from("total_count"), quote_style: None}
-        )),
+        column_position: Some(MySQLColumnPosition::After(Ident {
+            value: String::from("total_count"),
+            quote_style: None,
+        })),
     };
 
     let sql1 = "ALTER TABLE orders CHANGE COLUMN description desc TEXT NOT NULL AFTER total_count";
@@ -2093,8 +2093,6 @@ fn parse_alter_table_change_column_with_column_position() {
         &expected_name.to_string(),
     );
     assert_eq!(expected_operation_after, operation);
-
-
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -694,6 +694,7 @@ fn parse_alter_table_add_columns() {
                             collation: None,
                             options: vec![],
                         },
+                        column_position: None,
                     },
                     AlterTableOperation::AddColumn {
                         column_keyword: true,
@@ -704,6 +705,7 @@ fn parse_alter_table_add_columns() {
                             collation: None,
                             options: vec![],
                         },
+                        column_position: None,
                     },
                 ]
             );


### PR DESCRIPTION
As per [MySQL doc](https://dev.mysql.com/doc/refman/8.0/en/alter-table.html), the `ALTER TABLE Statement` has the definition:
```sql
ALTER TABLE tbl_name
    [alter_option [, alter_option] ...]
    [partition_options]

alter_option: {
    table_options
  | ADD [COLUMN] col_name column_definition
        [FIRST | AFTER col_name]
  | ADD [COLUMN] (col_name column_definition,...)
  | ADD {INDEX | KEY} [index_name]
        [index_type] (key_part,...) [index_option] ...
  | ADD {FULLTEXT | SPATIAL} [INDEX | KEY] [index_name]
        (key_part,...) [index_option] ...
  | ADD [CONSTRAINT [symbol]] PRIMARY KEY
        [index_type] (key_part,...)
        [index_option] ...
  | ADD [CONSTRAINT [symbol]] UNIQUE [INDEX | KEY]
        [index_name] [index_type] (key_part,...)
        [index_option] ...
  | ADD [CONSTRAINT [symbol]] FOREIGN KEY
        [index_name] (col_name,...)
        reference_definition
  | ADD [CONSTRAINT [symbol]] CHECK (expr) [[NOT] ENFORCED]
  | DROP {CHECK | CONSTRAINT} symbol
  | ALTER {CHECK | CONSTRAINT} symbol [NOT] ENFORCED
  | ALGORITHM [=] {DEFAULT | INSTANT | INPLACE | COPY}
  | ALTER [COLUMN] col_name {
        SET DEFAULT {literal | (expr)}
      | SET {VISIBLE | INVISIBLE}
      | DROP DEFAULT
    }
  | ALTER INDEX index_name {VISIBLE | INVISIBLE}
  | CHANGE [COLUMN] old_col_name new_col_name column_definition
        [FIRST | AFTER col_name]
  | [DEFAULT] CHARACTER SET [=] charset_name [COLLATE [=] collation_name]
  | CONVERT TO CHARACTER SET charset_name [COLLATE collation_name]
  | {DISABLE | ENABLE} KEYS
  | {DISCARD | IMPORT} TABLESPACE
  | DROP [COLUMN] col_name
  | DROP {INDEX | KEY} index_name
  | DROP PRIMARY KEY
  | DROP FOREIGN KEY fk_symbol
  | FORCE
  | LOCK [=] {DEFAULT | NONE | SHARED | EXCLUSIVE}
  | MODIFY [COLUMN] col_name column_definition
        [FIRST | AFTER col_name]
  | ORDER BY col_name [, col_name] ...
  | RENAME COLUMN old_col_name TO new_col_name
  | RENAME {INDEX | KEY} old_index_name TO new_index_name
  | RENAME [TO | AS] new_tbl_name
  | {WITHOUT | WITH} VALIDATION
}

partition_options:
    partition_option [partition_option] ...

partition_option: {
    ADD PARTITION (partition_definition)
  | DROP PARTITION partition_names
  | DISCARD PARTITION {partition_names | ALL} TABLESPACE
  | IMPORT PARTITION {partition_names | ALL} TABLESPACE
  | TRUNCATE PARTITION {partition_names | ALL}
  | COALESCE PARTITION number
  | REORGANIZE PARTITION partition_names INTO (partition_definitions)
  | EXCHANGE PARTITION partition_name WITH TABLE tbl_name [{WITH | WITHOUT} VALIDATION]
  | ANALYZE PARTITION {partition_names | ALL}
  | CHECK PARTITION {partition_names | ALL}
  | OPTIMIZE PARTITION {partition_names | ALL}
  | REBUILD PARTITION {partition_names | ALL}
  | REPAIR PARTITION {partition_names | ALL}
  | REMOVE PARTITIONING
}

key_part: {col_name [(length)] | (expr)} [ASC | DESC]

index_type:
    USING {BTREE | HASH}

index_option: {
    KEY_BLOCK_SIZE [=] value
  | index_type
  | WITH PARSER parser_name
  | COMMENT 'string'
  | {VISIBLE | INVISIBLE}
}

table_options:
    table_option [[,] table_option] ...

table_option: {
    AUTOEXTEND_SIZE [=] value
  | AUTO_INCREMENT [=] value
  | AVG_ROW_LENGTH [=] value
  | [DEFAULT] CHARACTER SET [=] charset_name
  | CHECKSUM [=] {0 | 1}
  | [DEFAULT] COLLATE [=] collation_name
  | COMMENT [=] 'string'
  | COMPRESSION [=] {'ZLIB' | 'LZ4' | 'NONE'}
  | CONNECTION [=] 'connect_string'
  | {DATA | INDEX} DIRECTORY [=] 'absolute path to directory'
  | DELAY_KEY_WRITE [=] {0 | 1}
  | ENCRYPTION [=] {'Y' | 'N'}
  | ENGINE [=] engine_name
  | ENGINE_ATTRIBUTE [=] 'string'
  | INSERT_METHOD [=] { NO | FIRST | LAST }
  | KEY_BLOCK_SIZE [=] value
  | MAX_ROWS [=] value
  | MIN_ROWS [=] value
  | PACK_KEYS [=] {0 | 1 | DEFAULT}
  | PASSWORD [=] 'string'
  | ROW_FORMAT [=] {DEFAULT | DYNAMIC | FIXED | COMPRESSED | REDUNDANT | COMPACT}
  | SECONDARY_ENGINE_ATTRIBUTE [=] 'string'
  | STATS_AUTO_RECALC [=] {DEFAULT | 0 | 1}
  | STATS_PERSISTENT [=] {DEFAULT | 0 | 1}
  | STATS_SAMPLE_PAGES [=] value
  | TABLESPACE tablespace_name [STORAGE {DISK | MEMORY}]
  | UNION [=] (tbl_name[,tbl_name]...)
}

partition_options:
    (see CREATE TABLE options)
```

issue reported in #1172 , this PR  add `[FIRST | AFTER column_name]` support in MySQL alter table