### PR TITLE
Fix parsing of equality binop in function argument

### DIFF
--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -33,4 +33,8 @@ impl Dialect for DuckDbDialect {
     fn supports_group_by_expr(&self) -> bool {
         true
     }
+
+    fn supports_named_fn_args_with_eq_operator(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -143,6 +143,10 @@ pub trait Dialect: Debug + Any {
     fn supports_start_transaction_modifier(&self) -> bool {
         false
     }
+    /// Returns true if the dialect supports named arguments of the form FUN(a = '1', b = '2').
+    fn supports_named_fn_args_with_eq_operator(&self) -> bool {
+        false
+    }
     /// Returns true if the dialect has a CONVERT function which accepts a type first
     /// and an expression second, e.g. `CONVERT(varchar, 1)`
     fn convert_type_before_value(&self) -> bool {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8547,7 +8547,9 @@ impl<'a> Parser<'a> {
                 arg,
                 operator: FunctionArgOperator::RightArrow,
             })
-        } else if self.peek_nth_token(1) == Token::Eq {
+        } else if self.dialect.supports_named_fn_args_with_eq_operator()
+            && self.peek_nth_token(1) == Token::Eq
+        {
             let name = self.parse_identifier(false)?;
 
             self.expect_token(&Token::Eq)?;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -68,7 +68,7 @@ impl TestedDialects {
                 }
                 Some((dialect, parsed))
             })
-            .unwrap()
+            .expect("tested dialects cannot be empty")
             .1
     }
 
@@ -195,15 +195,6 @@ impl TestedDialects {
 
 /// Returns all available dialects.
 pub fn all_dialects() -> TestedDialects {
-    all_dialects_except(|_| false)
-}
-
-/// Returns available dialects. The `except` predicate is used
-/// to filter out specific dialects.
-pub fn all_dialects_except<F>(except: F) -> TestedDialects
-where
-    F: Fn(&dyn Dialect) -> bool,
-{
     let all_dialects = vec![
         Box::new(GenericDialect {}) as Box<dyn Dialect>,
         Box::new(PostgreSqlDialect {}) as Box<dyn Dialect>,
@@ -218,12 +209,28 @@ where
         Box::new(DuckDbDialect {}) as Box<dyn Dialect>,
     ];
     TestedDialects {
-        dialects: all_dialects
-            .into_iter()
-            .filter(|d| !except(d.as_ref()))
-            .collect(),
+        dialects: all_dialects,
         options: None,
     }
+}
+
+/// Returns all dialects matching the given predicate.
+pub fn all_dialects_where<F>(predicate: F) -> TestedDialects
+where
+    F: Fn(&dyn Dialect) -> bool,
+{
+    let mut dialects = all_dialects();
+    dialects.dialects.retain(|d| predicate(&**d));
+    dialects
+}
+
+/// Returns available dialects. The `except` predicate is used
+/// to filter out specific dialects.
+pub fn all_dialects_except<F>(except: F) -> TestedDialects
+where
+    F: Fn(&dyn Dialect) -> bool,
+{
+    all_dialects_where(|d| !except(d))
 }
 
 pub fn assert_eq_vec<T: ToString>(expected: &[&str], actual: &[T]) {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -33,8 +33,8 @@ use sqlparser::keywords::ALL_KEYWORDS;
 use sqlparser::parser::{Parser, ParserError, ParserOptions};
 use sqlparser::tokenizer::Tokenizer;
 use test_utils::{
-    all_dialects, alter_table_op, assert_eq_vec, expr_from_projection, join, number, only, table,
-    table_alias, TestedDialects,
+    all_dialects, all_dialects_where, alter_table_op, assert_eq_vec, expr_from_projection, join,
+    number, only, table, table_alias, TestedDialects,
 };
 
 #[macro_use]
@@ -4045,7 +4045,9 @@ fn parse_named_argument_function() {
 #[test]
 fn parse_named_argument_function_with_eq_operator() {
     let sql = "SELECT FUN(a = '1', b = '2') FROM foo";
-    let select = verified_only_select(sql);
+
+    let select = all_dialects_where(|d| d.supports_named_fn_args_with_eq_operator())
+        .verified_only_select(sql);
     assert_eq!(
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("FUN")]),
@@ -4074,6 +4076,33 @@ fn parse_named_argument_function_with_eq_operator() {
         }),
         expr_from_projection(only(&select.projection))
     );
+
+    // Ensure that bar = 42 in a function argument parses as an equality binop
+    // rather than a named function argument.
+    assert_eq!(
+        all_dialects_except(|d| d.supports_named_fn_args_with_eq_operator())
+            .verified_expr("foo(bar = 42)"),
+        Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("foo")]),
+            args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
+                Expr::BinaryOp {
+                    left: Box::new(Expr::Identifier(Ident::new("bar"))),
+                    op: BinaryOperator::Eq,
+                    right: Box::new(Expr::Value(number("42"))),
+                },
+            ))],
+            filter: None,
+            null_treatment: None,
+            over: None,
+            distinct: false,
+            special: false,
+            order_by: vec![],
+        })
+    );
+
+    // TODO: should this parse for all dialects?
+    all_dialects_except(|d| d.supports_named_fn_args_with_eq_operator())
+        .verified_expr("iff(1 = 1, 1, 0)");
 }
 
 #[test]


### PR DESCRIPTION
https://github.com/sqlparser-rs/sqlparser-rs/issues/1057 added support for using the `=` operator for named function arguments. This syntax conflicts with passing an `=` binop expr as a function argument, and so this caused a regression on dialects that don't support this style of named argument. There were two problems in particular:

1. `foo(a = b)` would parse as a named argument rather than a comparison of `a` and `b`.
2. `foo(1=1)` resulted in a parsing failure, which is problematic as many people have the habit of writing `1=1` instead of `TRUE`.

So rather than accepting this everywhere, we should only accept it on dialects that have this form of named argument. The original PR only mentions DuckDB so that's the only dialect I enabled it for. If there are any others, please let me know and I'll add them.