### PR TITLE
BigQuery support inline comment with hash syntax

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -984,7 +984,7 @@ impl<'a> Tokenizer<'a> {
                 }
                 '{' => self.consume_and_return(chars, Token::LBrace),
                 '}' => self.consume_and_return(chars, Token::RBrace),
-                '#' if dialect_of!(self is SnowflakeDialect) => {
+                '#' if dialect_of!(self is SnowflakeDialect | BigQueryDialect) => {
                     chars.next(); // consume the '#', starting a snowflake single-line comment
                     let comment = self.tokenize_single_line_comment(chars);
                     Ok(Some(Token::Whitespace(Whitespace::SingleLineComment {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8512,6 +8512,24 @@ fn test_release_savepoint() {
 }
 
 #[test]
+fn test_comment_hash_syntax() {
+    let dialects = TestedDialects {
+        dialects: vec![Box::new(BigQueryDialect {}), Box::new(SnowflakeDialect {})],
+        options: None,
+    };
+    let sql = r#"
+    # comment
+    SELECT a, b, c # , d, e
+    FROM T
+    ####### comment #################
+    WHERE true
+    # comment
+    "#;
+    let canonical = "SELECT a, b, c FROM T WHERE true";
+    dialects.verified_only_select_with_canonical(sql, canonical);
+}
+
+#[test]
 fn test_buffer_reuse() {
     let d = GenericDialect {};
     let q = "INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)";


### PR DESCRIPTION
Adds support for single line comments using `#` syntax. GenericDialect isn't included because the syntax conflicts with Postgres' JSON access syntax `#>`

https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#single_line_comments