### PR TITLE
Add support for DuckDB struct literal syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -347,6 +347,23 @@ impl fmt::Display for StructField {
     }
 }
 
+/// A dictionary field within a dictionary.
+///
+/// [duckdb]: https://duckdb.org/docs/sql/data_types/struct#creating-structs
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct DictionaryField {
+    pub key: Ident,
+    pub value: Box<Expr>,
+}
+
+impl fmt::Display for DictionaryField {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.key, self.value)
+    }
+}
+
 /// Options for `CAST` / `TRY_CAST`
 /// BigQuery: <https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements#formatting_syntax>
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -669,21 +686,12 @@ pub enum Expr {
     /// ```sql
     /// STRUCT<[field_name] field_type, ...>( expr1 [, ... ])
     /// ```
-    /// `DuckDB` specific `Struct` literal expression [2]
-    /// Syntax:
-    /// ```sql
-    /// syntax: {'field_name': expr1[, ... ]}
-    /// ```
     /// [1]: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type
-    /// [2]: https://duckdb.org/docs/sql/data_types/struct#creating-structs
     Struct {
         /// Struct values.
         values: Vec<Expr>,
         /// Struct field definitions.
         fields: Vec<StructField>,
-        /// true if uses duckdb array notation syntax(no change in semantics)
-        /// this field is used for formatting
-        array_notation: bool,
     },
     /// `BigQuery` specific: An named expression in a typeless struct [1]
     ///
@@ -696,6 +704,13 @@ pub enum Expr {
         expr: Box<Expr>,
         name: Ident,
     },
+    /// `DuckDB` specific `Struct` literal expression [1]
+    /// Syntax:
+    /// ```sql
+    /// syntax: {'field_name': expr1[, ... ]}
+    /// ```
+    /// [1]: https://duckdb.org/docs/sql/data_types/struct#creating-structs
+    Dictionary(Vec<DictionaryField>),
     /// An array index expression e.g. `(ARRAY[1, 2])[1]` or `(current_schemas(FALSE))[1]`
     ArrayIndex {
         obj: Box<Expr>,
@@ -1140,23 +1155,8 @@ impl fmt::Display for Expr {
             Expr::Tuple(exprs) => {
                 write!(f, "({})", display_comma_separated(exprs))
             }
-            Expr::Struct {
-                values,
-                fields,
-                array_notation,
-            } => {
-                if *array_notation {
-                    let args = values
-                        .iter()
-                        .map(|value| match value {
-                            Expr::Named { expr, name } => {
-                                format!("'{}': {}", name.value, expr)
-                            }
-                            _ => unreachable!(),
-                        })
-                        .collect::<Vec<_>>();
-                    write!(f, "{{{}}}", display_comma_separated(&args))
-                } else if !fields.is_empty() {
+            Expr::Struct { values, fields } => {
+                if !fields.is_empty() {
                     write!(
                         f,
                         "STRUCT<{}>({})",
@@ -1169,6 +1169,9 @@ impl fmt::Display for Expr {
             }
             Expr::Named { expr, name } => {
                 write!(f, "{} AS {}", expr, name)
+            }
+            Expr::Dictionary(fields) => {
+                write!(f, "{{{}}}", display_comma_separated(fields))
             }
             Expr::ArrayIndex { obj, indexes } => {
                 write!(f, "{obj}")?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -705,6 +705,7 @@ pub enum Expr {
         name: Ident,
     },
     /// `DuckDB` specific `Struct` literal expression [1]
+    ///
     /// Syntax:
     /// ```sql
     /// syntax: {'field_name': expr1[, ... ]}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2012,11 +2012,7 @@ impl<'a> Parser<'a> {
             .parse_comma_separated(|parser| parser.parse_struct_field_expr(!fields.is_empty()))?;
         self.expect_token(&Token::RParen)?;
 
-        Ok(Expr::Struct {
-            values,
-            fields,
-            array_notation: false,
-        })
+        Ok(Expr::Struct { values, fields })
     }
 
     /// Parse an expression value for a bigquery struct [1]
@@ -2145,39 +2141,30 @@ impl<'a> Parser<'a> {
     fn parse_duckdb_struct_literal(&mut self) -> Result<Expr, ParserError> {
         self.expect_token(&Token::LBrace)?;
 
-        let values = self.parse_comma_separated(Self::parse_duckdb_struct_field)?;
+        let fields = self.parse_comma_separated(Self::parse_duckdb_dictionary_field)?;
 
         self.expect_token(&Token::RBrace)?;
 
-        Ok(Expr::Struct {
-            values,
-            fields: vec![],
-            array_notation: true,
-        })
+        Ok(Expr::Dictionary(fields))
     }
 
-    /// Parse an expression value for a duckdb struct [1]
+    /// Parse a field for a duckdb dictionary [1]
     /// Syntax
     /// ```sql
     /// 'name': expr
     /// ```
     ///
     /// [1]: https://duckdb.org/docs/sql/data_types/struct#creating-structs
-    fn parse_duckdb_struct_field(&mut self) -> Result<Expr, ParserError> {
-        let next_token = self.next_token();
-
-        let name = match next_token.token {
-            Token::SingleQuotedString(name) => name,
-            _ => return self.expected("single quoted string", next_token),
-        };
+    fn parse_duckdb_dictionary_field(&mut self) -> Result<DictionaryField, ParserError> {
+        let key = self.parse_identifier(false)?;
 
         self.expect_token(&Token::Colon)?;
 
         let expr = self.parse_expr()?;
 
-        Ok(Expr::Named {
-            expr: Box::new(expr),
-            name: Ident::with_quote('\'', name),
+        Ok(DictionaryField {
+            key,
+            value: Box::new(expr),
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2131,13 +2131,15 @@ impl<'a> Parser<'a> {
         ))
     }
 
-    /// DuckDB specific: Parse a struct literal [1]
-    /// Syntax
+    /// DuckDB specific: Parse a duckdb dictionary [1]
+    ///
+    /// Syntax:
+    ///
     /// ```sql
     /// {'field_name': expr1[, ... ]}
     /// ```
     ///
-    /// [1] https://duckdb.org/docs/sql/data_types/struct#creating-structs
+    /// [1]: https://duckdb.org/docs/sql/data_types/struct#creating-structs
     fn parse_duckdb_struct_literal(&mut self) -> Result<Expr, ParserError> {
         self.expect_token(&Token::LBrace)?;
 

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -409,7 +409,7 @@ fn parse_typeless_struct_syntax() {
                 Expr::Value(number("2")),
                 Expr::Value(number("3")),
             ],
-            fields: Default::default(),
+            fields: Default::default()
         },
         expr_from_projection(&select.projection[0])
     );
@@ -417,7 +417,7 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(Value::SingleQuotedString("abc".to_string())),],
-            fields: Default::default(),
+            fields: Default::default()
         },
         expr_from_projection(&select.projection[1])
     );
@@ -427,7 +427,7 @@ fn parse_typeless_struct_syntax() {
                 Expr::Value(number("1")),
                 Expr::CompoundIdentifier(vec![Ident::from("t"), Ident::from("str_col")]),
             ],
-            fields: Default::default(),
+            fields: Default::default()
         },
         expr_from_projection(&select.projection[2])
     );
@@ -443,7 +443,7 @@ fn parse_typeless_struct_syntax() {
                     name: Ident::from("b")
                 },
             ],
-            fields: Default::default(),
+            fields: Default::default()
         },
         expr_from_projection(&select.projection[3])
     );
@@ -453,7 +453,7 @@ fn parse_typeless_struct_syntax() {
                 expr: Expr::Identifier(Ident::from("str_col")).into(),
                 name: Ident::from("abc")
             }],
-            fields: Default::default(),
+            fields: Default::default()
         },
         expr_from_projection(&select.projection[4])
     );
@@ -473,7 +473,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
-            }],
+            }]
         },
         expr_from_projection(&select.projection[0])
     );
@@ -507,7 +507,7 @@ fn parse_typed_struct_syntax() {
                     }),
                     field_type: DataType::String(None)
                 },
-            ],
+            ]
         },
         expr_from_projection(&select.projection[1])
     );
@@ -531,7 +531,7 @@ fn parse_typed_struct_syntax() {
                         field_type: DataType::Bool
                     }])
                 },
-            ],
+            ]
         },
         expr_from_projection(&select.projection[2])
     );
@@ -556,7 +556,7 @@ fn parse_typed_struct_syntax() {
                         DataType::Struct(Default::default())
                     )))
                 },
-            ],
+            ]
         },
         expr_from_projection(&select.projection[0])
     );
@@ -570,7 +570,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bool
-            }],
+            }]
         },
         expr_from_projection(&select.projection[0])
     );
@@ -582,7 +582,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bytes(Some(42))
-            }],
+            }]
         },
         expr_from_projection(&select.projection[1])
     );
@@ -598,7 +598,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Date
-            }],
+            }]
         },
         expr_from_projection(&select.projection[0])
     );
@@ -611,7 +611,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Datetime(None)
-            }],
+            }]
         },
         expr_from_projection(&select.projection[1])
     );
@@ -621,7 +621,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
-            }],
+            }]
         },
         expr_from_projection(&select.projection[2])
     );
@@ -631,7 +631,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
-            }],
+            }]
         },
         expr_from_projection(&select.projection[3])
     );
@@ -653,7 +653,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Interval
-            }],
+            }]
         },
         expr_from_projection(&select.projection[0])
     );
@@ -666,7 +666,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::JSON
-            }],
+            }]
         },
         expr_from_projection(&select.projection[1])
     );
@@ -680,7 +680,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::String(Some(42))
-            }],
+            }]
         },
         expr_from_projection(&select.projection[0])
     );
@@ -693,7 +693,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Timestamp(None, TimezoneInfo::None)
-            }],
+            }]
         },
         expr_from_projection(&select.projection[1])
     );
@@ -707,7 +707,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Time(None, TimezoneInfo::None)
-            }],
+            }]
         },
         expr_from_projection(&select.projection[2])
     );
@@ -724,7 +724,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Numeric(ExactNumberInfo::None)
-            }],
+            }]
         },
         expr_from_projection(&select.projection[0])
     );
@@ -737,7 +737,7 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::BigNumeric(ExactNumberInfo::None)
-            }],
+            }]
         },
         expr_from_projection(&select.projection[1])
     );
@@ -754,7 +754,7 @@ fn parse_typed_struct_with_field_name() {
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
-            }],
+            }]
         },
         expr_from_projection(&select.projection[0])
     );
@@ -764,7 +764,7 @@ fn parse_typed_struct_with_field_name() {
             fields: vec![StructField {
                 field_name: Some(Ident::from("y")),
                 field_type: DataType::String(None)
-            }],
+            }]
         },
         expr_from_projection(&select.projection[1])
     );
@@ -784,7 +784,7 @@ fn parse_typed_struct_with_field_name() {
                     field_name: Some(Ident::from("y")),
                     field_type: DataType::Int64
                 }
-            ],
+            ]
         },
         expr_from_projection(&select.projection[0])
     );

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -409,7 +409,8 @@ fn parse_typeless_struct_syntax() {
                 Expr::Value(number("2")),
                 Expr::Value(number("3")),
             ],
-            fields: Default::default()
+            fields: Default::default(),
+            array_notation: false,
         },
         expr_from_projection(&select.projection[0])
     );
@@ -417,7 +418,8 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(Value::SingleQuotedString("abc".to_string())),],
-            fields: Default::default()
+            fields: Default::default(),
+            array_notation: false,
         },
         expr_from_projection(&select.projection[1])
     );
@@ -427,7 +429,8 @@ fn parse_typeless_struct_syntax() {
                 Expr::Value(number("1")),
                 Expr::CompoundIdentifier(vec![Ident::from("t"), Ident::from("str_col")]),
             ],
-            fields: Default::default()
+            fields: Default::default(),
+            array_notation: false,
         },
         expr_from_projection(&select.projection[2])
     );
@@ -443,7 +446,8 @@ fn parse_typeless_struct_syntax() {
                     name: Ident::from("b")
                 },
             ],
-            fields: Default::default()
+            fields: Default::default(),
+            array_notation: false
         },
         expr_from_projection(&select.projection[3])
     );
@@ -453,7 +457,8 @@ fn parse_typeless_struct_syntax() {
                 expr: Expr::Identifier(Ident::from("str_col")).into(),
                 name: Ident::from("abc")
             }],
-            fields: Default::default()
+            fields: Default::default(),
+            array_notation: false
         },
         expr_from_projection(&select.projection[4])
     );
@@ -473,7 +478,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -507,7 +513,8 @@ fn parse_typed_struct_syntax() {
                     }),
                     field_type: DataType::String(None)
                 },
-            ]
+            ],
+            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -531,7 +538,8 @@ fn parse_typed_struct_syntax() {
                         field_type: DataType::Bool
                     }])
                 },
-            ]
+            ],
+            array_notation: false
         },
         expr_from_projection(&select.projection[2])
     );
@@ -556,7 +564,8 @@ fn parse_typed_struct_syntax() {
                         DataType::Struct(Default::default())
                     )))
                 },
-            ]
+            ],
+            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -570,7 +579,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bool
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -582,7 +592,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bytes(Some(42))
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -598,7 +609,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Date
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -611,7 +623,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Datetime(None)
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -621,7 +634,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[2])
     );
@@ -631,7 +645,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[3])
     );
@@ -653,7 +668,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Interval
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -666,7 +682,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::JSON
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -680,7 +697,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::String(Some(42))
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -693,7 +711,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Timestamp(None, TimezoneInfo::None)
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -707,7 +726,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Time(None, TimezoneInfo::None)
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[2])
     );
@@ -724,7 +744,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Numeric(ExactNumberInfo::None)
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -737,7 +758,8 @@ fn parse_typed_struct_syntax() {
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::BigNumeric(ExactNumberInfo::None)
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -754,7 +776,8 @@ fn parse_typed_struct_with_field_name() {
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -764,7 +787,8 @@ fn parse_typed_struct_with_field_name() {
             fields: vec![StructField {
                 field_name: Some(Ident::from("y")),
                 field_type: DataType::String(None)
-            }]
+            }],
+            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -784,7 +808,8 @@ fn parse_typed_struct_with_field_name() {
                     field_name: Some(Ident::from("y")),
                     field_type: DataType::Int64
                 }
-            ]
+            ],
+            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -410,7 +410,6 @@ fn parse_typeless_struct_syntax() {
                 Expr::Value(number("3")),
             ],
             fields: Default::default(),
-            array_notation: false,
         },
         expr_from_projection(&select.projection[0])
     );
@@ -419,7 +418,6 @@ fn parse_typeless_struct_syntax() {
         &Expr::Struct {
             values: vec![Expr::Value(Value::SingleQuotedString("abc".to_string())),],
             fields: Default::default(),
-            array_notation: false,
         },
         expr_from_projection(&select.projection[1])
     );
@@ -430,7 +428,6 @@ fn parse_typeless_struct_syntax() {
                 Expr::CompoundIdentifier(vec![Ident::from("t"), Ident::from("str_col")]),
             ],
             fields: Default::default(),
-            array_notation: false,
         },
         expr_from_projection(&select.projection[2])
     );
@@ -447,7 +444,6 @@ fn parse_typeless_struct_syntax() {
                 },
             ],
             fields: Default::default(),
-            array_notation: false
         },
         expr_from_projection(&select.projection[3])
     );
@@ -458,7 +454,6 @@ fn parse_typeless_struct_syntax() {
                 name: Ident::from("abc")
             }],
             fields: Default::default(),
-            array_notation: false
         },
         expr_from_projection(&select.projection[4])
     );
@@ -479,7 +474,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Int64,
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -514,7 +508,6 @@ fn parse_typed_struct_syntax() {
                     field_type: DataType::String(None)
                 },
             ],
-            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -539,7 +532,6 @@ fn parse_typed_struct_syntax() {
                     }])
                 },
             ],
-            array_notation: false
         },
         expr_from_projection(&select.projection[2])
     );
@@ -565,7 +557,6 @@ fn parse_typed_struct_syntax() {
                     )))
                 },
             ],
-            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -580,7 +571,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Bool
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -593,7 +583,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Bytes(Some(42))
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -610,7 +599,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Date
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -624,7 +612,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Datetime(None)
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -635,7 +622,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Float64
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[2])
     );
@@ -646,7 +632,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Int64
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[3])
     );
@@ -669,7 +654,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Interval
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -683,7 +667,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::JSON
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -698,7 +681,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::String(Some(42))
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -712,7 +694,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Timestamp(None, TimezoneInfo::None)
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -727,7 +708,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Time(None, TimezoneInfo::None)
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[2])
     );
@@ -745,7 +725,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::Numeric(ExactNumberInfo::None)
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -759,7 +738,6 @@ fn parse_typed_struct_syntax() {
                 field_name: None,
                 field_type: DataType::BigNumeric(ExactNumberInfo::None)
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -777,7 +755,6 @@ fn parse_typed_struct_with_field_name() {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );
@@ -788,7 +765,6 @@ fn parse_typed_struct_with_field_name() {
                 field_name: Some(Ident::from("y")),
                 field_type: DataType::String(None)
             }],
-            array_notation: false
         },
         expr_from_projection(&select.projection[1])
     );
@@ -809,7 +785,6 @@ fn parse_typed_struct_with_field_name() {
                     field_type: DataType::Int64
                 }
             ],
-            array_notation: false
         },
         expr_from_projection(&select.projection[0])
     );

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -246,3 +246,114 @@ fn test_duckdb_load_extension() {
         stmt
     );
 }
+
+#[test]
+fn test_duckdb_struct_literal() {
+    //array notation struct syntax https://duckdb.org/docs/sql/data_types/struct#creating-structs
+    //syntax: {'field_name': expr1[, ... ]}
+    let sql = "SELECT {'a': 1, 'b': 2, 'c': 3}, {'a': 'abc'}, {'a': 1, 'b': t.str_col}, {'a': 1, 'b': 'abc'}, {'abc': str_col}, {'a': {'aa': 1}}";
+    let select = duckdb_and_generic().verified_only_select(sql);
+    assert_eq!(6, select.projection.len());
+    assert_eq!(
+        &Expr::Struct {
+            values: vec![
+                Expr::Named {
+                    expr: Box::new(Expr::Value(number("1"))),
+                    name: Ident::with_quote('\'', "a")
+                },
+                Expr::Named {
+                    expr: Box::new(Expr::Value(number("2"))),
+                    name: Ident::with_quote('\'', "b")
+                },
+                Expr::Named {
+                    expr: Box::new(Expr::Value(number("3"))),
+                    name: Ident::with_quote('\'', "c")
+                },
+            ],
+            fields: Default::default(),
+            array_notation: true
+        },
+        expr_from_projection(&select.projection[0])
+    );
+
+    assert_eq!(
+        &Expr::Struct {
+            values: vec![Expr::Named {
+                expr: Box::new(Expr::Value(Value::SingleQuotedString("abc".to_string()))),
+                name: Ident::with_quote('\'', "a")
+            },],
+            fields: Default::default(),
+            array_notation: true
+        },
+        expr_from_projection(&select.projection[1])
+    );
+    assert_eq!(
+        &Expr::Struct {
+            values: vec![
+                Expr::Named {
+                    expr: Box::new(Expr::Value(number("1"))),
+                    name: Ident::with_quote('\'', "a")
+                },
+                Expr::Named {
+                    expr: Box::new(Expr::CompoundIdentifier(vec![
+                        Ident::from("t"),
+                        Ident::from("str_col")
+                    ])),
+                    name: Ident::with_quote('\'', "b")
+                },
+            ],
+            fields: Default::default(),
+            array_notation: true
+        },
+        expr_from_projection(&select.projection[2])
+    );
+    assert_eq!(
+        &Expr::Struct {
+            values: vec![
+                Expr::Named {
+                    expr: Expr::Value(number("1")).into(),
+                    name: Ident::with_quote('\'', "a")
+                },
+                Expr::Named {
+                    expr: Expr::Value(Value::SingleQuotedString("abc".to_string())).into(),
+                    name: Ident::with_quote('\'', "b")
+                },
+            ],
+            fields: Default::default(),
+            array_notation: true
+        },
+        expr_from_projection(&select.projection[3])
+    );
+    assert_eq!(
+        &Expr::Struct {
+            values: vec![Expr::Named {
+                expr: Expr::Identifier(Ident::from("str_col")).into(),
+                name: Ident::with_quote('\'', "abc")
+            }],
+            fields: Default::default(),
+            array_notation: true
+        },
+        expr_from_projection(&select.projection[4])
+    );
+    assert_eq!(
+        &Expr::Struct {
+            values: vec![Expr::Named {
+                expr: Expr::Struct {
+                    values: vec![
+                        Expr::Named {
+                            expr: Expr::Value(number("1")).into(),
+                            name: Ident::with_quote('\'', "aa")
+                        }
+                    ],
+                    fields: vec![],
+                    array_notation: true
+                }
+                .into(),
+                name: Ident::with_quote('\'', "a")
+            }],
+            fields: Default::default(),
+            array_notation: true
+        },
+        expr_from_projection(&select.projection[5])
+    );
+}


### PR DESCRIPTION
Fixes #1129

Existing Struct expression supports the BigQuery semantics, which allow for optionally typed fields, that if typed, also have an optional name.
DuckDB has incompatible semantics: only named fields without any type specification.

Should I create a separate expression, perharps `NamedFieldsStruct`, or change the `Struct` to have an inner enum `Struct(enum { MaybeTyped(...), Named(...) })` ?

Thanks!
