### PR TITLE
Add support for DuckDB functions named arguments with assignment operator

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4556,6 +4556,8 @@ pub enum FunctionArgOperator {
     Equals,
     /// function(arg1 => value1)
     RightArrow,
+    /// function(arg1 := value1)
+    Assignment,
 }
 
 impl fmt::Display for FunctionArgOperator {
@@ -4563,6 +4565,7 @@ impl fmt::Display for FunctionArgOperator {
         match self {
             FunctionArgOperator::Equals => f.write_str("="),
             FunctionArgOperator::RightArrow => f.write_str("=>"),
+            FunctionArgOperator::Assignment => f.write_str(":="),
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4557,7 +4557,7 @@ pub enum FunctionArgOperator {
     /// function(arg1 => value1)
     RightArrow,
     /// function(arg1 := value1)
-    Assignment,
+    DuckAssignment,
 }
 
 impl fmt::Display for FunctionArgOperator {
@@ -4565,7 +4565,7 @@ impl fmt::Display for FunctionArgOperator {
         match self {
             FunctionArgOperator::Equals => f.write_str("="),
             FunctionArgOperator::RightArrow => f.write_str("=>"),
-            FunctionArgOperator::Assignment => f.write_str(":="),
+            FunctionArgOperator::DuckAssignment => f.write_str(":="),
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4557,7 +4557,7 @@ pub enum FunctionArgOperator {
     /// function(arg1 => value1)
     RightArrow,
     /// function(arg1 := value1)
-    DuckAssignment,
+    Assignment,
 }
 
 impl fmt::Display for FunctionArgOperator {
@@ -4565,7 +4565,7 @@ impl fmt::Display for FunctionArgOperator {
         match self {
             FunctionArgOperator::Equals => f.write_str("="),
             FunctionArgOperator::RightArrow => f.write_str("=>"),
-            FunctionArgOperator::DuckAssignment => f.write_str(":="),
+            FunctionArgOperator::Assignment => f.write_str(":="),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8602,7 +8602,8 @@ impl<'a> Parser<'a> {
                 arg,
                 operator: FunctionArgOperator::Equals,
             })
-        } else if dialect_of!(self is DuckDbDialect) && self.peek_nth_token(1) == Token::Assignment
+        } else if dialect_of!(self is DuckDbDialect | GenericDialect)
+            && self.peek_nth_token(1) == Token::Assignment
         {
             let name = self.parse_identifier(false)?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8559,6 +8559,17 @@ impl<'a> Parser<'a> {
                 arg,
                 operator: FunctionArgOperator::Equals,
             })
+        } else if self.peek_nth_token(1) == Token::DuckAssignment {
+            let name = self.parse_identifier(false)?;
+
+            self.expect_token(&Token::DuckAssignment)?;
+            let arg = self.parse_wildcard_expr()?.into();
+
+            Ok(FunctionArg::Named {
+                name,
+                arg,
+                operator: FunctionArgOperator::Assignment,
+            })
         } else {
             Ok(FunctionArg::Unnamed(self.parse_wildcard_expr()?.into()))
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8559,7 +8559,8 @@ impl<'a> Parser<'a> {
                 arg,
                 operator: FunctionArgOperator::Equals,
             })
-        } else if self.peek_nth_token(1) == Token::Assignment {
+        } else if dialect_of!(self is DuckDbDialect) && self.peek_nth_token(1) == Token::Assignment
+        {
             let name = self.parse_identifier(false)?;
 
             self.expect_token(&Token::Assignment)?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8607,7 +8607,7 @@ impl<'a> Parser<'a> {
             let name = self.parse_identifier(false)?;
 
             self.expect_token(&Token::Assignment)?;
-            let arg = self.parse_wildcard_expr()?.into();
+            let arg = self.parse_expr()?.into();
 
             Ok(FunctionArg::Named {
                 name,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3442,7 +3442,7 @@ impl<'a> Parser<'a> {
         let name = self.parse_identifier(false)?;
 
         let default_expr =
-            if self.consume_token(&Token::DuckAssignment) || self.consume_token(&Token::RArrow) {
+            if self.consume_token(&Token::Assignment) || self.consume_token(&Token::RArrow) {
                 Some(self.parse_expr()?)
             } else {
                 None
@@ -4140,7 +4140,7 @@ impl<'a> Parser<'a> {
                 self.next_token(); // Skip `DEFAULT`
                 Some(DeclareAssignment::Default(Box::new(self.parse_expr()?)))
             }
-            Token::DuckAssignment => {
+            Token::Assignment => {
                 self.next_token(); // Skip `:=`
                 Some(DeclareAssignment::DuckAssignment(Box::new(
                     self.parse_expr()?,
@@ -8559,16 +8559,16 @@ impl<'a> Parser<'a> {
                 arg,
                 operator: FunctionArgOperator::Equals,
             })
-        } else if self.peek_nth_token(1) == Token::DuckAssignment {
+        } else if self.peek_nth_token(1) == Token::Assignment {
             let name = self.parse_identifier(false)?;
 
-            self.expect_token(&Token::DuckAssignment)?;
+            self.expect_token(&Token::Assignment)?;
             let arg = self.parse_wildcard_expr()?.into();
 
             Ok(FunctionArg::Named {
                 name,
                 arg,
-                operator: FunctionArgOperator::DuckAssignment,
+                operator: FunctionArgOperator::Assignment,
             })
         } else {
             Ok(FunctionArg::Unnamed(self.parse_wildcard_expr()?.into()))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8568,7 +8568,7 @@ impl<'a> Parser<'a> {
             Ok(FunctionArg::Named {
                 name,
                 arg,
-                operator: FunctionArgOperator::Assignment,
+                operator: FunctionArgOperator::DuckAssignment,
             })
         } else {
             Ok(FunctionArg::Unnamed(self.parse_wildcard_expr()?.into()))

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -117,7 +117,7 @@ pub enum Token {
     Colon,
     /// DoubleColon `::` (used for casting in PostgreSQL)
     DoubleColon,
-    /// Assignment `:=` (used for keyword argument in DuckDB macros)
+    /// Assignment `:=` (used for keyword argument in DuckDB macros and some functions)
     DuckAssignment,
     /// SemiColon `;` used as separator for COPY and payload
     SemiColon,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -117,8 +117,8 @@ pub enum Token {
     Colon,
     /// DoubleColon `::` (used for casting in PostgreSQL)
     DoubleColon,
-    /// Assignment `:=` (used for keyword argument in DuckDB macros and some functions)
-    DuckAssignment,
+    /// Assignment `:=` (used for keyword argument in DuckDB macros and some functions, and for variable declarations in DuckDB and Snowflake)
+    Assignment,
     /// SemiColon `;` used as separator for COPY and payload
     SemiColon,
     /// Backslash `\` used in terminating the COPY payload with `\.`
@@ -239,7 +239,7 @@ impl fmt::Display for Token {
             Token::Period => f.write_str("."),
             Token::Colon => f.write_str(":"),
             Token::DoubleColon => f.write_str("::"),
-            Token::DuckAssignment => f.write_str(":="),
+            Token::Assignment => f.write_str(":="),
             Token::SemiColon => f.write_str(";"),
             Token::Backslash => f.write_str("\\"),
             Token::LBracket => f.write_str("["),
@@ -959,7 +959,7 @@ impl<'a> Tokenizer<'a> {
                     chars.next();
                     match chars.peek() {
                         Some(':') => self.consume_and_return(chars, Token::DoubleColon),
-                        Some('=') => self.consume_and_return(chars, Token::DuckAssignment),
+                        Some('=') => self.consume_and_return(chars, Token::Assignment),
                         _ => Ok(Some(Token::Colon)),
                     }
                 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4089,14 +4089,14 @@ fn parse_named_argument_function_with_duckdb_assignment_operator() {
                     arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
                         "1".to_owned()
                     ))),
-                    operator: FunctionArgOperator::DuckAssignment
+                    operator: FunctionArgOperator::Assignment
                 },
                 FunctionArg::Named {
                     name: Ident::new("b"),
                     arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
                         "2".to_owned()
                     ))),
-                    operator: FunctionArgOperator::DuckAssignment
+                    operator: FunctionArgOperator::Assignment
                 },
             ],
             null_treatment: None,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4077,7 +4077,7 @@ fn parse_named_argument_function_with_eq_operator() {
 }
 
 #[test]
-fn parse_named_argument_function_with_assignment_operator() {
+fn parse_named_argument_function_with_duckdb_assignment_operator() {
     let sql = "SELECT FUN(a := '1', b := '2') FROM foo";
     let select = verified_only_select(sql);
     assert_eq!(
@@ -4089,14 +4089,14 @@ fn parse_named_argument_function_with_assignment_operator() {
                     arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
                         "1".to_owned()
                     ))),
-                    operator: FunctionArgOperator::Assignment
+                    operator: FunctionArgOperator::DuckAssignment
                 },
                 FunctionArg::Named {
                     name: Ident::new("b"),
                     arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
                         "2".to_owned()
                     ))),
-                    operator: FunctionArgOperator::Assignment
+                    operator: FunctionArgOperator::DuckAssignment
                 },
             ],
             null_treatment: None,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4077,40 +4077,6 @@ fn parse_named_argument_function_with_eq_operator() {
 }
 
 #[test]
-fn parse_named_argument_function_with_duckdb_assignment_operator() {
-    let sql = "SELECT FUN(a := '1', b := '2') FROM foo";
-    let select = verified_only_select(sql);
-    assert_eq!(
-        &Expr::Function(Function {
-            name: ObjectName(vec![Ident::new("FUN")]),
-            args: vec![
-                FunctionArg::Named {
-                    name: Ident::new("a"),
-                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
-                        "1".to_owned()
-                    ))),
-                    operator: FunctionArgOperator::Assignment
-                },
-                FunctionArg::Named {
-                    name: Ident::new("b"),
-                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
-                        "2".to_owned()
-                    ))),
-                    operator: FunctionArgOperator::Assignment
-                },
-            ],
-            null_treatment: None,
-            filter: None,
-            over: None,
-            distinct: false,
-            special: false,
-            order_by: vec![],
-        }),
-        expr_from_projection(only(&select.projection))
-    );
-}
-
-#[test]
 fn parse_window_functions() {
     let sql = "SELECT row_number() OVER (ORDER BY dt DESC), \
                sum(foo) OVER (PARTITION BY a, b ORDER BY c, d \

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4077,6 +4077,40 @@ fn parse_named_argument_function_with_eq_operator() {
 }
 
 #[test]
+fn parse_named_argument_function_with_assignment_operator() {
+    let sql = "SELECT FUN(a := '1', b := '2') FROM foo";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("FUN")]),
+            args: vec![
+                FunctionArg::Named {
+                    name: Ident::new("a"),
+                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        "1".to_owned()
+                    ))),
+                    operator: FunctionArgOperator::Assignment
+                },
+                FunctionArg::Named {
+                    name: Ident::new("b"),
+                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        "2".to_owned()
+                    ))),
+                    operator: FunctionArgOperator::Assignment
+                },
+            ],
+            null_treatment: None,
+            filter: None,
+            over: None,
+            distinct: false,
+            special: false,
+            order_by: vec![],
+        }),
+        expr_from_projection(only(&select.projection))
+    );
+}
+
+#[test]
 fn parse_window_functions() {
     let sql = "SELECT row_number() OVER (ORDER BY dt DESC), \
                sum(foo) OVER (PARTITION BY a, b ORDER BY c, d \

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -337,7 +337,7 @@ fn test_duckdb_struct_literal() {
 #[test]
 fn test_duckdb_named_argument_function_with_assignment_operator() {
     let sql = "SELECT FUN(a := '1', b := '2') FROM foo";
-    let select = duckdb().verified_only_select(sql);
+    let select = duckdb_and_generic().verified_only_select(sql);
     assert_eq!(
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("FUN")]),

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -246,3 +246,37 @@ fn test_duckdb_load_extension() {
         stmt
     );
 }
+
+#[test]
+fn parse_duckdb_named_argument_function_with_assignment_operator() {
+    let sql = "SELECT FUN(a := '1', b := '2') FROM foo";
+    let select = duckdb().verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("FUN")]),
+            args: vec![
+                FunctionArg::Named {
+                    name: Ident::new("a"),
+                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        "1".to_owned()
+                    ))),
+                    operator: FunctionArgOperator::Assignment
+                },
+                FunctionArg::Named {
+                    name: Ident::new("b"),
+                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        "2".to_owned()
+                    ))),
+                    operator: FunctionArgOperator::Assignment
+                },
+            ],
+            null_treatment: None,
+            filter: None,
+            over: None,
+            distinct: false,
+            special: false,
+            order_by: vec![],
+        }),
+        expr_from_projection(only(&select.projection))
+    );
+}


### PR DESCRIPTION
[Some nested DuckDB functions use assignment operator](https://duckdb.org/docs/sql/functions/nested.html)

```
struct_insert(struct, name := any, ...)
struct_pack(name := any, ...)
union_value(tag := any)
```