### PR TITLE
feat: support tailing commas on snowflake dialect.

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2953,7 +2953,8 @@ impl<'a> Parser<'a> {
         // This pattern could be captured better with RAII type semantics, but it's quite a bit of
         // code to add for just one case, so we'll just do it manually here.
         let old_value = self.options.trailing_commas;
-        self.options.trailing_commas |= dialect_of!(self is BigQueryDialect);
+        self.options.trailing_commas |=
+            dialect_of!(self is BigQueryDialect) || dialect_of!(self is SnowflakeDialect);
 
         let ret = self.parse_comma_separated(|p| p.parse_select_item());
         self.options.trailing_commas = old_value;


### PR DESCRIPTION
See https://docs.snowflake.com/en/release-notes/2024/8_11#select-supports-trailing-commas