### PR TITLE
Snowflake: support for object constants

### DIFF
--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -37,4 +37,11 @@ impl Dialect for DuckDbDialect {
     fn supports_named_fn_args_with_eq_operator(&self) -> bool {
         true
     }
+
+    // DuckDB uses this syntax for `STRUCT`s.
+    //
+    // https://duckdb.org/docs/sql/data_types/struct.html#creating-structs
+    fn supports_dictionary_syntax(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -46,4 +46,8 @@ impl Dialect for GenericDialect {
     fn supports_start_transaction_modifier(&self) -> bool {
         true
     }
+
+    fn supports_dictionary_syntax(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -168,6 +168,11 @@ pub trait Dialect: Debug + Any {
     fn supports_named_fn_args_with_eq_operator(&self) -> bool {
         false
     }
+    /// Returns true if the dialect supports defining structs or objects using a
+    /// syntax like `{'x': 1, 'y': 2, 'z': 3}`.
+    fn supports_dictionary_syntax(&self) -> bool {
+        false
+    }
     /// Returns true if the dialect has a CONVERT function which accepts a type first
     /// and an expression second, e.g. `CONVERT(varchar, 1)`
     fn convert_type_before_value(&self) -> bool {

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -59,6 +59,14 @@ impl Dialect for SnowflakeDialect {
         true
     }
 
+    // Snowflake uses this syntax for "object constants" (the values of which
+    // are not actually required to be constants).
+    //
+    // https://docs.snowflake.com/en/sql-reference/data-types-semistructured#label-object-constant
+    fn supports_dictionary_syntax(&self) -> bool {
+        true
+    }
+
     fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
         if parser.parse_keyword(Keyword::CREATE) {
             // possibly CREATE STAGE

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1192,7 +1192,7 @@ impl<'a> Parser<'a> {
                 self.prev_token();
                 Ok(Expr::Value(self.parse_value()?))
             }
-            Token::LBrace if dialect_of!(self is DuckDbDialect | GenericDialect) => {
+            Token::LBrace if self.dialect.supports_dictionary_syntax() => {
                 self.prev_token();
                 self.parse_duckdb_struct_literal()
             }


### PR DESCRIPTION
The syntax of these is identical, as far as I can tell, to DuckDB's "array notation" for `STRUCT`s, so this reuses the parser's existing support.