### PR TITLE
fix: have wildcard replace work in duckdb and snowflake syntax

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9059,7 +9059,7 @@ impl<'a> Parser<'a> {
             None
         };
 
-        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect | ClickHouseDialect)
+        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect | ClickHouseDialect |  DuckDbDialect | SnowflakeDialect)
         {
             self.parse_optional_select_item_replace()?
         } else {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1281,49 +1281,6 @@ fn test_select_wildcard_with_except() {
 }
 
 #[test]
-fn test_select_wildcard_with_replace() {
-    let select = bigquery_and_generic()
-        .verified_only_select(r#"SELECT * REPLACE ('widget' AS item_name) FROM orders"#);
-    let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
-        opt_replace: Some(ReplaceSelectItem {
-            items: vec![Box::new(ReplaceSelectElement {
-                expr: Expr::Value(Value::SingleQuotedString("widget".to_owned())),
-                column_name: Ident::new("item_name"),
-                as_keyword: true,
-            })],
-        }),
-        ..Default::default()
-    });
-    assert_eq!(expected, select.projection[0]);
-
-    let select = bigquery_and_generic().verified_only_select(
-        r#"SELECT * REPLACE (quantity / 2 AS quantity, 3 AS order_id) FROM orders"#,
-    );
-    let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
-        opt_replace: Some(ReplaceSelectItem {
-            items: vec![
-                Box::new(ReplaceSelectElement {
-                    expr: Expr::BinaryOp {
-                        left: Box::new(Expr::Identifier(Ident::new("quantity"))),
-                        op: BinaryOperator::Divide,
-                        right: Box::new(Expr::Value(number("2"))),
-                    },
-                    column_name: Ident::new("quantity"),
-                    as_keyword: true,
-                }),
-                Box::new(ReplaceSelectElement {
-                    expr: Expr::Value(number("3")),
-                    column_name: Ident::new("order_id"),
-                    as_keyword: true,
-                }),
-            ],
-        }),
-        ..Default::default()
-    });
-    assert_eq!(expected, select.projection[0]);
-}
-
-#[test]
 fn parse_big_query_declare() {
     for (sql, expected_names, expected_data_type, expected_assigned_expr) in [
         (

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -382,11 +382,6 @@ fn parse_select_star_except_no_parens() {
     );
 }
 
-#[test]
-fn parse_select_star_replace() {
-    clickhouse().verified_stmt("SELECT * REPLACE (i + 1 AS i) FROM columns_transformers");
-}
-
 fn clickhouse() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(ClickHouseDialect {})],


### PR DESCRIPTION
Snowflake and DuckDB also support `SELECT * REPLACE() from table`, so enabling the functionality for both dialects. 
I added test cases so that the examples given in the respective documentation passed:
duck db: https://duckdb.org/docs/sql/query_syntax/select.html
snowflake: https://docs.snowflake.com/en/sql-reference/sql/select