### PR TITLE
fix: Add support for `MAX` for `NVARCHAR`

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -40,7 +40,7 @@ pub enum DataType {
     /// Variable-length character type e.g. VARCHAR(10)
     Varchar(Option<CharacterLength>),
     /// Variable-length character type e.g. NVARCHAR(10)
-    Nvarchar(Option<u64>),
+    Nvarchar(Option<CharacterLength>),
     /// Uuid type
     Uuid,
     /// Large character object with optional length e.g. CHARACTER LARGE OBJECT, CHARACTER LARGE OBJECT(1000), [standard]
@@ -238,9 +238,7 @@ impl fmt::Display for DataType {
 
             DataType::CharVarying(size) => format_character_string_type(f, "CHAR VARYING", size),
             DataType::Varchar(size) => format_character_string_type(f, "VARCHAR", size),
-            DataType::Nvarchar(size) => {
-                format_type_with_optional_length(f, "NVARCHAR", size, false)
-            }
+            DataType::Nvarchar(size) => format_character_string_type(f, "NVARCHAR", size),
             DataType::Uuid => write!(f, "UUID"),
             DataType::CharacterLargeObject(size) => {
                 format_type_with_optional_length(f, "CHARACTER LARGE OBJECT", size, false)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6451,7 +6451,9 @@ impl<'a> Parser<'a> {
                     }
                 }
                 Keyword::VARCHAR => Ok(DataType::Varchar(self.parse_optional_character_length()?)),
-                Keyword::NVARCHAR => Ok(DataType::Nvarchar(self.parse_optional_precision()?)),
+                Keyword::NVARCHAR => {
+                    Ok(DataType::Nvarchar(self.parse_optional_character_length()?))
+                }
                 Keyword::CHARACTER => {
                     if self.parse_keyword(Keyword::VARYING) {
                         Ok(DataType::CharacterVarying(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2258,7 +2258,10 @@ fn parse_cast() {
         &Expr::Cast {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
-            data_type: DataType::Nvarchar(Some(50)),
+            data_type: DataType::Nvarchar(Some(CharacterLength::IntegerLength {
+                length: 50,
+                unit: None,
+            })),
             format: None,
         },
         expr_from_projection(only(&select.projection))

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -431,6 +431,7 @@ fn parse_for_json_expect_ast() {
 #[test]
 fn parse_cast_varchar_max() {
     ms_and_generic().verified_expr("CAST('foo' AS VARCHAR(MAX))");
+    ms_and_generic().verified_expr("CAST('foo' AS NVARCHAR(MAX))");
 }
 
 #[test]


### PR DESCRIPTION
`NVARCHAR` works similar to `VARCHAR` except it uses unicode for the character set. This means that it supports the `MAX` keyword for some dialects just like `VARCHAR`.

This will change the wrapped type for `Nvarchar` to a `CharacterLength` instead of `u64`.

---
The support for this was already mentioned in a comment in the code but wasn't supported so I was hoping this would be a reasonable change.

https://github.com/sqlparser-rs/sqlparser-rs/blob/ce85084debefd69d2d43a1bdde73e25f2cb0c9d6/src/ast/data_type.rs#L537-L538