### PR TITLE
Support multiple `SET` variables

### DIFF
--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -44,4 +44,9 @@ impl Dialect for BigQueryDialect {
     fn supports_window_clause_named_window_reference(&self) -> bool {
         true
     }
+
+    /// See [doc](https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#set)
+    fn supports_parenthesized_set_variables(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -62,4 +62,8 @@ impl Dialect for GenericDialect {
     fn supports_window_clause_named_window_reference(&self) -> bool {
         true
     }
+
+    fn supports_parenthesized_set_variables(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -217,6 +217,15 @@ pub trait Dialect: Debug + Any {
     fn supports_lambda_functions(&self) -> bool {
         false
     }
+    /// Returns true if the dialect supports multiple variable assignment
+    /// using parentheses in a `SET` variable declaration.
+    ///
+    /// ```sql
+    /// SET (variable[, ...]) = (expression[, ...]);
+    /// ```
+    fn supports_parenthesized_set_variables(&self) -> bool {
+        false
+    }
     /// Returns true if the dialect has a CONVERT function which accepts a type first
     /// and an expression second, e.g. `CONVERT(varchar, 1)`
     fn convert_type_before_value(&self) -> bool {

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -71,6 +71,11 @@ impl Dialect for SnowflakeDialect {
         true
     }
 
+    /// See [doc](https://docs.snowflake.com/en/sql-reference/sql/set#syntax)
+    fn supports_parenthesized_set_variables(&self) -> bool {
+        true
+    }
+
     fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
         if parser.parse_keyword(Keyword::CREATE) {
             // possibly CREATE STAGE

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6958,18 +6958,65 @@ fn parse_set_variable() {
         Statement::SetVariable {
             local,
             hivevar,
-            variable,
+            variables,
             value,
         } => {
             assert!(!local);
             assert!(!hivevar);
-            assert_eq!(variable, ObjectName(vec!["SOMETHING".into()]));
+            assert_eq!(
+                variables,
+                OneOrManyWithParens::One(ObjectName(vec!["SOMETHING".into()]))
+            );
             assert_eq!(
                 value,
                 vec![Expr::Value(Value::SingleQuotedString("1".into()))]
             );
         }
         _ => unreachable!(),
+    }
+
+    let multi_variable_dialects = all_dialects_where(|d| d.supports_parenthesized_set_variables());
+    let sql = r#"SET (a, b, c) = (1, 2, 3)"#;
+    match multi_variable_dialects.verified_stmt(sql) {
+        Statement::SetVariable {
+            local,
+            hivevar,
+            variables,
+            value,
+        } => {
+            assert!(!local);
+            assert!(!hivevar);
+            assert_eq!(
+                variables,
+                OneOrManyWithParens::Many(vec![
+                    ObjectName(vec!["a".into()]),
+                    ObjectName(vec!["b".into()]),
+                    ObjectName(vec!["c".into()]),
+                ])
+            );
+            assert_eq!(
+                value,
+                vec![
+                    Expr::Value(number("1")),
+                    Expr::Value(number("2")),
+                    Expr::Value(number("3")),
+                ]
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    let error_sqls = [
+        ("SET (a, b, c) = (1, 2, 3", "Expected ), found: EOF"),
+        ("SET (a, b, c) = 1, 2, 3", "Expected (, found: 1"),
+    ];
+    for (sql, error) in error_sqls {
+        assert_eq!(
+            ParserError::ParserError(error.to_string()),
+            multi_variable_dialects
+                .parse_sql_statements(sql)
+                .unwrap_err()
+        );
     }
 
     one_statement_parses_to("SET SOMETHING TO '1'", "SET SOMETHING = '1'");
@@ -6981,12 +7028,15 @@ fn parse_set_time_zone() {
         Statement::SetVariable {
             local,
             hivevar,
-            variable,
+            variables: variable,
             value,
         } => {
             assert!(!local);
             assert!(!hivevar);
-            assert_eq!(variable, ObjectName(vec!["TIMEZONE".into()]));
+            assert_eq!(
+                variable,
+                OneOrManyWithParens::One(ObjectName(vec!["TIMEZONE".into()]))
+            );
             assert_eq!(
                 value,
                 vec![Expr::Value(Value::SingleQuotedString("UTC".into()))]

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -17,8 +17,8 @@
 
 use sqlparser::ast::{
     CreateFunctionBody, CreateFunctionUsing, Expr, Function, FunctionArgumentList,
-    FunctionArguments, FunctionDefinition, Ident, ObjectName, SelectItem, Statement, TableFactor,
-    UnaryOperator,
+    FunctionArguments, FunctionDefinition, Ident, ObjectName, OneOrManyWithParens, SelectItem,
+    Statement, TableFactor, UnaryOperator,
 };
 use sqlparser::dialect::{GenericDialect, HiveDialect, MsSqlDialect};
 use sqlparser::parser::{ParserError, ParserOptions};
@@ -268,12 +268,12 @@ fn set_statement_with_minus() {
         Statement::SetVariable {
             local: false,
             hivevar: false,
-            variable: ObjectName(vec![
+            variables: OneOrManyWithParens::One(ObjectName(vec![
                 Ident::new("hive"),
                 Ident::new("tez"),
                 Ident::new("java"),
                 Ident::new("opts")
-            ]),
+            ])),
             value: vec![Expr::UnaryOp {
                 op: UnaryOperator::Minus,
                 expr: Box::new(Expr::Identifier(Ident::new("Xmx4g")))

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -460,7 +460,7 @@ fn parse_set_variables() {
         Statement::SetVariable {
             local: true,
             hivevar: false,
-            variable: ObjectName(vec!["autocommit".into()]),
+            variables: OneOrManyWithParens::One(ObjectName(vec!["autocommit".into()])),
             value: vec![Expr::Value(number("1"))],
         }
     );

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1201,7 +1201,7 @@ fn parse_set() {
         Statement::SetVariable {
             local: false,
             hivevar: false,
-            variable: ObjectName(vec![Ident::new("a")]),
+            variables: OneOrManyWithParens::One(ObjectName(vec![Ident::new("a")])),
             value: vec![Expr::Identifier(Ident {
                 value: "b".into(),
                 quote_style: None
@@ -1215,7 +1215,7 @@ fn parse_set() {
         Statement::SetVariable {
             local: false,
             hivevar: false,
-            variable: ObjectName(vec![Ident::new("a")]),
+            variables: OneOrManyWithParens::One(ObjectName(vec![Ident::new("a")])),
             value: vec![Expr::Value(Value::SingleQuotedString("b".into()))],
         }
     );
@@ -1226,7 +1226,7 @@ fn parse_set() {
         Statement::SetVariable {
             local: false,
             hivevar: false,
-            variable: ObjectName(vec![Ident::new("a")]),
+            variables: OneOrManyWithParens::One(ObjectName(vec![Ident::new("a")])),
             value: vec![Expr::Value(number("0"))],
         }
     );
@@ -1237,7 +1237,7 @@ fn parse_set() {
         Statement::SetVariable {
             local: false,
             hivevar: false,
-            variable: ObjectName(vec![Ident::new("a")]),
+            variables: OneOrManyWithParens::One(ObjectName(vec![Ident::new("a")])),
             value: vec![Expr::Identifier(Ident {
                 value: "DEFAULT".into(),
                 quote_style: None
@@ -1251,7 +1251,7 @@ fn parse_set() {
         Statement::SetVariable {
             local: true,
             hivevar: false,
-            variable: ObjectName(vec![Ident::new("a")]),
+            variables: OneOrManyWithParens::One(ObjectName(vec![Ident::new("a")])),
             value: vec![Expr::Identifier("b".into())],
         }
     );
@@ -1262,7 +1262,11 @@ fn parse_set() {
         Statement::SetVariable {
             local: false,
             hivevar: false,
-            variable: ObjectName(vec![Ident::new("a"), Ident::new("b"), Ident::new("c")]),
+            variables: OneOrManyWithParens::One(ObjectName(vec![
+                Ident::new("a"),
+                Ident::new("b"),
+                Ident::new("c")
+            ])),
             value: vec![Expr::Identifier(Ident {
                 value: "b".into(),
                 quote_style: None
@@ -1279,13 +1283,13 @@ fn parse_set() {
         Statement::SetVariable {
             local: false,
             hivevar: false,
-            variable: ObjectName(vec![
+            variables: OneOrManyWithParens::One(ObjectName(vec![
                 Ident::new("hive"),
                 Ident::new("tez"),
                 Ident::new("auto"),
                 Ident::new("reducer"),
                 Ident::new("parallelism")
-            ]),
+            ])),
             value: vec![Expr::Value(Value::Boolean(false))],
         }
     );


### PR DESCRIPTION
Both BigQuery and Snowflake support assigning multiple variables via `SET`

```
SET (a, b) = (1, 2)
```
This adds support for such syntax

https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#set 

https://docs.snowflake.com/en/sql-reference/sql/set#syntax