### PR TITLE
Support CREATE FUNCTION for BigQuery

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -572,6 +572,7 @@ define_keywords!(
     RELATIVE,
     RELAY,
     RELEASE,
+    REMOTE,
     RENAME,
     REORG,
     REPAIR,

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -17,8 +17,8 @@
 
 use sqlparser::ast::{
     CreateFunctionBody, CreateFunctionUsing, Expr, Function, FunctionArgumentList,
-    FunctionArguments, FunctionDefinition, Ident, ObjectName, OneOrManyWithParens, SelectItem,
-    Statement, TableFactor, UnaryOperator,
+    FunctionArguments, Ident, ObjectName, OneOrManyWithParens, SelectItem, Statement, TableFactor,
+    UnaryOperator, Value,
 };
 use sqlparser::dialect::{GenericDialect, HiveDialect, MsSqlDialect};
 use sqlparser::parser::{ParserError, ParserOptions};
@@ -296,22 +296,23 @@ fn parse_create_function() {
         Statement::CreateFunction {
             temporary,
             name,
-            params,
+            function_body,
+            using,
             ..
         } => {
             assert!(temporary);
             assert_eq!(name.to_string(), "mydb.myfunc");
             assert_eq!(
-                params,
-                CreateFunctionBody {
-                    as_: Some(FunctionDefinition::SingleQuotedDef(
-                        "org.random.class.Name".to_string()
-                    )),
-                    using: Some(CreateFunctionUsing::Jar(
-                        "hdfs://somewhere.com:8020/very/far".to_string()
-                    )),
-                    ..Default::default()
-                }
+                function_body,
+                Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+                    Value::SingleQuotedString("org.random.class.Name".to_string())
+                )))
+            );
+            assert_eq!(
+                using,
+                Some(CreateFunctionUsing::Jar(
+                    "hdfs://somewhere.com:8020/very/far".to_string()
+                )),
             )
         }
         _ => unreachable!(),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3285,16 +3285,18 @@ fn parse_create_function() {
                 OperateFunctionArg::unnamed(DataType::Integer(None)),
             ]),
             return_type: Some(DataType::Integer(None)),
-            params: CreateFunctionBody {
-                language: Some("SQL".into()),
-                behavior: Some(FunctionBehavior::Immutable),
-                called_on_null: Some(FunctionCalledOnNull::Strict),
-                parallel: Some(FunctionParallel::Safe),
-                as_: Some(FunctionDefinition::SingleQuotedDef(
-                    "select $1 + $2;".into()
-                )),
-                ..Default::default()
-            },
+            language: Some("SQL".into()),
+            behavior: Some(FunctionBehavior::Immutable),
+            called_on_null: Some(FunctionCalledOnNull::Strict),
+            parallel: Some(FunctionParallel::Safe),
+            function_body: Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+                Value::SingleQuotedString("select $1 + $2;".into())
+            ))),
+            if_not_exists: false,
+            using: None,
+            determinism_specifier: None,
+            options: None,
+            remote_connection: None,
         }
     );
 }


### PR DESCRIPTION
Adds support for the `CREATE FUNCTION` statement in BigQuery. Merges with the representation used in the hive/postgres dialects.

https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_function_statement