### PR TITLE
Allow keyword as field names in BigQuery struct syntax

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2155,13 +2155,12 @@ impl<'a> Parser<'a> {
     fn parse_big_query_struct_field_def(
         &mut self,
     ) -> Result<(StructField, MatchedTrailingBracket), ParserError> {
-        let is_anonymous_field = if let Token::Word(w) = self.peek_token().token {
-            ALL_KEYWORDS
-                .binary_search(&w.value.to_uppercase().as_str())
-                .is_ok()
-        } else {
-            false
-        };
+        // Look beyond the next item to infer whether both field name
+        // and type are specified.
+        let is_anonymous_field = !matches!(
+            (self.peek_nth_token(0).token, self.peek_nth_token(1).token),
+            (Token::Word(_), Token::Word(_))
+        );
 
         let field_name = if is_anonymous_field {
             None

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -792,6 +792,27 @@ fn parse_typed_struct_syntax_bigquery() {
         },
         expr_from_projection(&select.projection[1])
     );
+
+    // Keywords in the parser may be used as field names.
+    let sql = r#"SELECT STRUCT<key INT64, value INT64>(1, 2)"#;
+    let select = bigquery().verified_only_select(sql);
+    assert_eq!(1, select.projection.len());
+    assert_eq!(
+        &Expr::Struct {
+            values: vec![Expr::Value(number("1")), Expr::Value(number("2")),],
+            fields: vec![
+                StructField {
+                    field_name: Some("key".into()),
+                    field_type: DataType::Int64,
+                },
+                StructField {
+                    field_name: Some("value".into()),
+                    field_type: DataType::Int64,
+                },
+            ]
+        },
+        expr_from_projection(&select.projection[0])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Updates the logic for inferring named vs anonymouse field syntax in a BigQuery struct. The previous logic incorrectly assumed that seeing a keyword meant no field name was specified.
Updates the logic to instead look further ahead at both tokens in order to correctly infer if both name and type are present.