### PR TITLE
Idea: add const generic peek_tokens method to parser

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2905,8 +2905,8 @@ impl<'a> Parser<'a> {
     /// let dialect = GenericDialect {};
     /// let mut parser = Parser::new(&dialect).try_with_sql("ORDER BY foo, bar").unwrap();
     ///
-    /// // Note that the Rust infers the number of tokens to peek based on the
-    /// // slice pattern!
+    /// // Note that Rust infers the number of tokens to peek based on the
+    /// // length of the slice pattern!
     /// assert!(matches!(
     ///     parser.peek_tokens(),
     ///     [
@@ -2920,6 +2920,10 @@ impl<'a> Parser<'a> {
             .map(|with_loc| with_loc.token)
     }
 
+    /// Returns the `N` next non-whitespace tokens with locations that have not
+    /// yet been processed.
+    ///
+    /// See [`Self::peek_token`] for an example.
     pub fn peek_tokens_with_location<const N: usize>(&self) -> [TokenWithLocation; N] {
         let mut index = self.index;
         core::array::from_fn(|_| loop {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2919,7 +2919,7 @@ impl<'a> Parser<'a> {
     /// ```
     pub fn peek_tokens<const N: usize>(&self) -> [TokenWithLocation; N] {
         let mut index = self.index;
-        std::array::from_fn(|_| loop {
+        core::array::from_fn(|_| loop {
             let token = self.tokens.get(index);
             index += 1;
             if let Some(TokenWithLocation {


### PR DESCRIPTION
This provides a nicer API for peeking multiple tokens ahead.

Also, while this is probably not super impactful in the grand scheme of things since you're generally not peeking more than a few tokens at a time, this technically decreases the complexity of doing so from O(n^2) to O(n).