### PR TITLE
feat/adding scalar-variable expression

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -798,6 +798,16 @@ pub enum Expr {
     ///
     /// See <https://docs.snowflake.com/en/sql-reference/constructs/where#joins-in-the-where-clause>.
     OuterJoin(Box<Expr>),
+<<<<<<< Updated upstream
+=======
+    /// A reference to the prior level in a CONNECT BY clause.
+    Prior(Box<Expr>),
+    /// Scalar variable creation e.g. `[@]foo INT`
+    ScalarVariable {
+        data_type: DataType,
+        name: String,
+    },
+>>>>>>> Stashed changes
 }
 
 impl fmt::Display for CastFormat {
@@ -1255,6 +1265,13 @@ impl fmt::Display for Expr {
             Expr::OuterJoin(expr) => {
                 write!(f, "{expr} (+)")
             }
+<<<<<<< Updated upstream
+=======
+            Expr::Prior(expr) => write!(f, "PRIOR {expr}"),
+            Expr::ScalarVariable { data_type, name } => {
+                write!(f, "{name} {data_type}")
+            }
+>>>>>>> Stashed changes
         }
     }
 }
@@ -6287,6 +6304,24 @@ mod tests {
             vec![Expr::Identifier(Ident::new("d"))],
         ]);
         assert_eq!("CUBE (a, (b, c), d)", format!("{cube}"));
+    }
+
+    #[test]
+    fn test_scalar_variable_display() {
+        let scalar_variable = Expr::ScalarVariable {
+            data_type: DataType::Boolean,
+            name: "foo".to_string(),
+        };
+        assert_eq!("foo BOOLEAN", format!("{scalar_variable}"));
+    }
+
+    #[test]
+    fn test_scalar_variable_display_int() {
+        let scalar_variable = Expr::ScalarVariable {
+            data_type: DataType::Int(None),
+            name: "foo".to_string(),
+        };
+        assert_eq!("foo INT", format!("{scalar_variable}"));
     }
 
     #[test]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -798,8 +798,6 @@ pub enum Expr {
     ///
     /// See <https://docs.snowflake.com/en/sql-reference/constructs/where#joins-in-the-where-clause>.
     OuterJoin(Box<Expr>),
-<<<<<<< Updated upstream
-=======
     /// A reference to the prior level in a CONNECT BY clause.
     Prior(Box<Expr>),
     /// Scalar variable creation e.g. `[@]foo INT`
@@ -807,7 +805,6 @@ pub enum Expr {
         data_type: DataType,
         name: String,
     },
->>>>>>> Stashed changes
 }
 
 impl fmt::Display for CastFormat {
@@ -1265,13 +1262,10 @@ impl fmt::Display for Expr {
             Expr::OuterJoin(expr) => {
                 write!(f, "{expr} (+)")
             }
-<<<<<<< Updated upstream
-=======
             Expr::Prior(expr) => write!(f, "PRIOR {expr}"),
             Expr::ScalarVariable { data_type, name } => {
                 write!(f, "{name} {data_type}")
             }
->>>>>>> Stashed changes
         }
     }
 }


### PR DESCRIPTION
- Adds `ScalarVariable` expression type
- `ScalarVariable` has two fields one for the corresponding SQL datatype and one of the name of the variable
- Adds test for fmt::Display 
- Requirement for https://github.com/apache/datafusion/issues/9726