### PR TITLE
Snowflake: support IGNORE/RESPECT NULLS inside function argument list

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -71,6 +71,12 @@ impl Dialect for SnowflakeDialect {
         true
     }
 
+    // Snowflake doesn't document this but `FIRST_VALUE(arg, { IGNORE | RESPECT } NULLS)`
+    // works (i.e. inside the argument list instead of after).
+    fn supports_window_function_null_treatment_arg(&self) -> bool {
+        true
+    }
+
     fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
         if parser.parse_keyword(Keyword::CREATE) {
             // possibly CREATE STAGE

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1576,3 +1576,12 @@ fn test_select_wildcard_with_ilike_replace() {
         "sql parser error: Expected end of statement, found: EXCLUDE"
     );
 }
+
+#[test]
+fn first_value_ignore_nulls() {
+    snowflake().verified_only_select(concat!(
+        "SELECT FIRST_VALUE(column2 IGNORE NULLS) ",
+        "OVER (PARTITION BY column1 ORDER BY column2) ",
+        "FROM some_table"
+    ));
+}


### PR DESCRIPTION
Just a tiny fix for a parsing failure I hit.