### PR TITLE
Support expression in AT TIME ZONE and fix precedence

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -584,7 +584,7 @@ pub enum Expr {
     /// AT a timestamp to a different timezone e.g. `FROM_UNIXTIME(0) AT TIME ZONE 'UTC-06:00'`
     AtTimeZone {
         timestamp: Box<Expr>,
-        time_zone: String,
+        time_zone: Box<Expr>,
     },
     /// Extract a field from a timestamp e.g. `EXTRACT(MONTH FROM foo)`
     ///
@@ -1270,7 +1270,7 @@ impl fmt::Display for Expr {
                 timestamp,
                 time_zone,
             } => {
-                write!(f, "{timestamp} AT TIME ZONE '{time_zone}'")
+                write!(f, "{timestamp} AT TIME ZONE {time_zone}")
             }
             Expr::Interval(interval) => {
                 write!(f, "{interval}")

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4995,7 +4995,9 @@ fn parse_at_timezone() {
     assert_eq!(
         &Expr::AtTimeZone {
             timestamp: Box::new(call("FROM_UNIXTIME", [zero.clone()])),
-            time_zone: "UTC-06:00".to_string(),
+            time_zone: Box::new(Expr::Value(Value::SingleQuotedString(
+                "UTC-06:00".to_string()
+            ))),
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -5009,7 +5011,9 @@ fn parse_at_timezone() {
                 [
                     Expr::AtTimeZone {
                         timestamp: Box::new(call("FROM_UNIXTIME", [zero])),
-                        time_zone: "UTC-06:00".to_string(),
+                        time_zone: Box::new(Expr::Value(Value::SingleQuotedString(
+                            "UTC-06:00".to_string()
+                        ))),
                     },
                     Expr::Value(Value::SingleQuotedString("%Y-%m-%dT%H".to_string()),)
                 ]
@@ -7037,7 +7041,9 @@ fn parse_double_colon_cast_at_timezone() {
                 data_type: DataType::Timestamp(None, TimezoneInfo::None),
                 format: None
             }),
-            time_zone: "Europe/Brussels".to_string()
+            time_zone: Box::new(Expr::Value(Value::SingleQuotedString(
+                "Europe/Brussels".to_string()
+            ))),
         },
         expr_from_projection(only(&select.projection)),
     );


### PR DESCRIPTION
Postgres supports an expression for the timezone input to the `AT TIME ZONE` operator. Through some experimentation, I discovered that the precedence is actually not that of the "(any other operator)" entry in the [documentation](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE), so I corrected this as well. The latter makes the workaround from https://github.com/sqlparser-rs/sqlparser-rs/pull/1267/files no longer necessary - the test added in that PR passes without it.

Resolves #1270.