### PR TITLE
Support for Snowflake dynamic pivot

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -46,10 +46,11 @@ pub use self::query::{
     GroupByExpr, IdentWithAlias, IlikeSelectItem, Join, JoinConstraint, JoinOperator,
     JsonTableColumn, JsonTableColumnErrorHandling, LateralView, LockClause, LockType,
     MatchRecognizePattern, MatchRecognizeSymbol, Measure, NamedWindowDefinition, NamedWindowExpr,
-    NonBlock, Offset, OffsetRows, OrderByExpr, Query, RenameSelectItem, RepetitionQuantifier,
-    ReplaceSelectElement, ReplaceSelectItem, RowsPerMatch, Select, SelectInto, SelectItem, SetExpr,
-    SetOperator, SetQuantifier, SymbolDefinition, Table, TableAlias, TableFactor, TableVersion,
-    TableWithJoins, Top, TopQuantity, ValueTableMode, Values, WildcardAdditionalOptions, With,
+    NonBlock, Offset, OffsetRows, OrderByExpr, PivotValueSource, Query, RenameSelectItem,
+    RepetitionQuantifier, ReplaceSelectElement, ReplaceSelectItem, RowsPerMatch, Select,
+    SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, SymbolDefinition, Table,
+    TableAlias, TableFactor, TableVersion, TableWithJoins, Top, TopQuantity, ValueTableMode,
+    Values, WildcardAdditionalOptions, With,
 };
 pub use self::value::{
     escape_double_quote_string, escape_quoted_string, DateTimeField, DollarQuotedString,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -946,7 +946,8 @@ pub enum TableFactor {
         table: Box<TableFactor>,
         aggregate_functions: Vec<ExprWithAlias>, // Function expression
         value_column: Vec<Ident>,
-        pivot_values: Vec<ExprWithAlias>,
+        value_source: PivotValueSource,
+        default_on_null: Option<Expr>,
         alias: Option<TableAlias>,
     },
     /// An UNPIVOT operation on a table.
@@ -985,6 +986,41 @@ pub enum TableFactor {
         symbols: Vec<SymbolDefinition>,
         alias: Option<TableAlias>,
     },
+}
+
+/// The source of values in a `PIVOT` operation.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum PivotValueSource {
+    /// Pivot on a static list of values.
+    ///
+    /// See <https://docs.snowflake.com/en/sql-reference/constructs/pivot#pivot-on-a-specified-list-of-column-values-for-the-pivot-column>.
+    List(Vec<ExprWithAlias>),
+    /// Pivot on all distinct values of the pivot column.
+    ///
+    /// See <https://docs.snowflake.com/en/sql-reference/constructs/pivot#pivot-on-all-distinct-column-values-automatically-with-dynamic-pivot>.
+    Any(Vec<OrderByExpr>),
+    /// Pivot on all values returned by a subquery.
+    ///
+    /// See <https://docs.snowflake.com/en/sql-reference/constructs/pivot#pivot-on-column-values-using-a-subquery-with-dynamic-pivot>.
+    Subquery(Query),
+}
+
+impl fmt::Display for PivotValueSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PivotValueSource::List(values) => write!(f, "{}", display_comma_separated(values)),
+            PivotValueSource::Any(order_by) => {
+                write!(f, "ANY")?;
+                if !order_by.is_empty() {
+                    write!(f, " ORDER BY {}", display_comma_separated(order_by))?;
+                }
+                Ok(())
+            }
+            PivotValueSource::Subquery(query) => write!(f, "{query}"),
+        }
+    }
 }
 
 /// An item in the `MEASURES` subclause of a `MATCH_RECOGNIZE` operation.
@@ -1313,17 +1349,20 @@ impl fmt::Display for TableFactor {
                 table,
                 aggregate_functions,
                 value_column,
-                pivot_values,
+                value_source,
+                default_on_null,
                 alias,
             } => {
                 write!(
                     f,
-                    "{} PIVOT({} FOR {} IN ({}))",
-                    table,
+                    "{table} PIVOT({} FOR {} IN ({value_source})",
                     display_comma_separated(aggregate_functions),
                     Expr::CompoundIdentifier(value_column.to_vec()),
-                    display_comma_separated(pivot_values)
                 )?;
+                if let Some(expr) = default_on_null {
+                    write!(f, " DEFAULT ON NULL ({expr})")?;
+                }
+                write!(f, ")")?;
                 if alias.is_some() {
                     write!(f, " AS {}", alias.as_ref().unwrap())?;
                 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8612,7 +8612,7 @@ fn parse_pivot_table() {
                 expected_function("c", Some("u")),
             ],
             value_column: vec![Ident::new("a"), Ident::new("MONTH")],
-            pivot_values: vec![
+            value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
                     expr: Expr::Value(number("1")),
                     alias: Some(Ident::new("x"))
@@ -8625,7 +8625,8 @@ fn parse_pivot_table() {
                     expr: Expr::Identifier(Ident::new("three")),
                     alias: Some(Ident::new("y"))
                 },
-            ],
+            ]),
+            default_on_null: None,
             alias: Some(TableAlias {
                 name: Ident {
                     value: "p".to_string(),
@@ -8763,7 +8764,7 @@ fn parse_pivot_unpivot_table() {
                 alias: None
             }],
             value_column: vec![Ident::new("year")],
-            pivot_values: vec![
+            value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
                     expr: Expr::Value(Value::SingleQuotedString("population_2000".to_string())),
                     alias: None
@@ -8772,7 +8773,8 @@ fn parse_pivot_unpivot_table() {
                     expr: Expr::Value(Value::SingleQuotedString("population_2010".to_string())),
                     alias: None
                 },
-            ],
+            ]),
+            default_on_null: None,
             alias: Some(TableAlias {
                 name: Ident::new("p"),
                 columns: vec![]


### PR DESCRIPTION
Snowflake just gained a nifty new feature called [Dynamic Pivot](https://medium.com/snowflake/snowflake-supports-dynamic-pivot-e6cb58b71dd9). This adds parser support for it (+ another `PIVOT` option that I noticed we were missing support for in the process).