### PR TITLE
Add `supports_nulls_first_in_sort` to Dialect

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -271,6 +271,10 @@ pub trait Dialect: Debug + Any {
         // return None to fall back to the default behavior
         None
     }
+    /// Does the dialect support specifying `NULLS FIRST/LAST` in `ORDER BY` clauses?
+    fn supports_nulls_first_in_sort(&self) -> bool {
+        true
+    }
 }
 
 impl dyn Dialect {

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -84,6 +84,10 @@ impl Dialect for MySqlDialect {
             None
         }
     }
+
+    fn supports_nulls_first_in_sort(&self) -> bool {
+        false
+    }
 }
 
 /// `LOCK TABLES`


### PR DESCRIPTION
The MySQL dialect doesn't support parsing the `NULLS FIRST/LAST` clause in `ORDER BY` expressions. This PR adds a `supports_nulls_first_in_sort` function to the `Dialect` trait (which is also a requirement in DataFusion for unparsing using the MySQL dialect, see https://github.com/apache/datafusion/pull/10625). Using this, we now validate that SQL statements that were previously using `NULLS FIRST/LAST` will fail properly when parsed with the MySQL syntax.

This is the error I get from MySQL when trying to use `NULLS FIRST` in a query:

`Query 1 ERROR at Line 3: : You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'nulls first limit 10' at line 3`