### PR TITLE
Add support for view comments for Snowflake

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1958,6 +1958,9 @@ pub enum Statement {
         query: Box<Query>,
         options: CreateTableOptions,
         cluster_by: Vec<Ident>,
+        /// Snowflake: Views can have comments in Snowflake.
+        /// <https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax>
+        comment: Option<String>,
         /// if true, has RedShift [`WITH NO SCHEMA BINDING`] clause <https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_VIEW.html>
         with_no_schema_binding: bool,
         /// if true, has SQLite `IF NOT EXISTS` clause <https://www.sqlite.org/lang_createview.html>
@@ -3226,6 +3229,7 @@ impl fmt::Display for Statement {
                 materialized,
                 options,
                 cluster_by,
+                comment,
                 with_no_schema_binding,
                 if_not_exists,
                 temporary,
@@ -3239,6 +3243,9 @@ impl fmt::Display for Statement {
                     temporary = if *temporary { "TEMPORARY " } else { "" },
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" }
                 )?;
+                if let Some(comment) = comment {
+                    write!(f, " COMMENT = '{comment}'")?;
+                }
                 if matches!(options, CreateTableOptions::With(_)) {
                     write!(f, " {options}")?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3244,7 +3244,7 @@ impl fmt::Display for Statement {
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" }
                 )?;
                 if let Some(comment) = comment {
-                    write!(f, " COMMENT = '{comment}'")?;
+                    write!(f, " COMMENT = '{}'", value::escape_single_quote_string(comment))?;
                 }
                 if matches!(options, CreateTableOptions::With(_)) {
                     write!(f, " {options}")?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3244,7 +3244,11 @@ impl fmt::Display for Statement {
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" }
                 )?;
                 if let Some(comment) = comment {
-                    write!(f, " COMMENT = '{}'", value::escape_single_quote_string(comment))?;
+                    write!(
+                        f,
+                        " COMMENT = '{}'",
+                        value::escape_single_quote_string(comment)
+                    )?;
                 }
                 if matches!(options, CreateTableOptions::With(_)) {
                     write!(f, " {options}")?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3903,16 +3903,14 @@ impl<'a> Parser<'a> {
             };
         }
 
-        let comment = if dialect_of!(self is SnowflakeDialect) {
-            if self.parse_keyword(Keyword::COMMENT) {
-                let _ = self.consume_token(&Token::Eq);
-                let next_token = self.next_token();
-                match next_token.token {
-                    Token::SingleQuotedString(str) => Some(str),
-                    _ => self.expected("comment", next_token)?,
-                }
-            } else {
-                None
+        let comment = if dialect_of!(self is SnowflakeDialect | GenericDialect)
+            && self.parse_keyword(Keyword::COMMENT)
+        {
+            self.expect_token(&Token::Eq)?;
+            let next_token = self.next_token();
+            match next_token.token {
+                Token::SingleQuotedString(str) => Some(str),
+                _ => self.expected("string literal", next_token)?,
             }
         } else {
             None

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -309,6 +309,7 @@ fn parse_create_view_if_not_exists() {
             materialized,
             options,
             cluster_by,
+            comment,
             with_no_schema_binding: late_binding,
             if_not_exists,
             temporary,
@@ -320,6 +321,7 @@ fn parse_create_view_if_not_exists() {
             assert!(!or_replace);
             assert_eq!(options, CreateTableOptions::None);
             assert_eq!(cluster_by, vec![]);
+            assert!(comment.is_none());
             assert!(!late_binding);
             assert!(if_not_exists);
             assert!(!temporary);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6251,6 +6251,7 @@ fn parse_create_view() {
             materialized,
             options,
             cluster_by,
+            comment,
             with_no_schema_binding: late_binding,
             if_not_exists,
             temporary,
@@ -6262,6 +6263,7 @@ fn parse_create_view() {
             assert!(!or_replace);
             assert_eq!(options, CreateTableOptions::None);
             assert_eq!(cluster_by, vec![]);
+            assert!(comment.is_none());
             assert!(!late_binding);
             assert!(!if_not_exists);
             assert!(!temporary);
@@ -6305,6 +6307,7 @@ fn parse_create_view_with_columns() {
             query,
             materialized,
             cluster_by,
+            comment,
             with_no_schema_binding: late_binding,
             if_not_exists,
             temporary,
@@ -6325,6 +6328,7 @@ fn parse_create_view_with_columns() {
             assert!(!materialized);
             assert!(!or_replace);
             assert_eq!(cluster_by, vec![]);
+            assert!(comment.is_none());
             assert!(!late_binding);
             assert!(!if_not_exists);
             assert!(!temporary);
@@ -6345,6 +6349,7 @@ fn parse_create_view_temporary() {
             materialized,
             options,
             cluster_by,
+            comment,
             with_no_schema_binding: late_binding,
             if_not_exists,
             temporary,
@@ -6356,6 +6361,7 @@ fn parse_create_view_temporary() {
             assert!(!or_replace);
             assert_eq!(options, CreateTableOptions::None);
             assert_eq!(cluster_by, vec![]);
+            assert!(comment.is_none());
             assert!(!late_binding);
             assert!(!if_not_exists);
             assert!(temporary);
@@ -6376,6 +6382,7 @@ fn parse_create_or_replace_view() {
             query,
             materialized,
             cluster_by,
+            comment,
             with_no_schema_binding: late_binding,
             if_not_exists,
             temporary,
@@ -6387,6 +6394,46 @@ fn parse_create_or_replace_view() {
             assert!(!materialized);
             assert!(or_replace);
             assert_eq!(cluster_by, vec![]);
+            assert!(comment.is_none());
+            assert!(!late_binding);
+            assert!(!if_not_exists);
+            assert!(!temporary);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_or_replace_with_comment_for_snowflake() {
+    let sql = "CREATE OR REPLACE VIEW v COMMENT = 'hello, world' AS SELECT 1";
+    let dialect = test_utils::TestedDialects {
+        dialects: vec![Box::new(SnowflakeDialect {}) as Box<dyn Dialect>],
+        options: None,
+    };
+
+    match dialect.verified_stmt(sql) {
+        Statement::CreateView {
+            name,
+            columns,
+            or_replace,
+            options,
+            query,
+            materialized,
+            cluster_by,
+            comment,
+            with_no_schema_binding: late_binding,
+            if_not_exists,
+            temporary,
+        } => {
+            assert_eq!("v", name.to_string());
+            assert_eq!(columns, vec![]);
+            assert_eq!(options, CreateTableOptions::None);
+            assert_eq!("SELECT 1", query.to_string());
+            assert!(!materialized);
+            assert!(or_replace);
+            assert_eq!(cluster_by, vec![]);
+            assert!(comment.is_some());
+            assert_eq!(comment.expect("expected comment"), "hello, world");
             assert!(!late_binding);
             assert!(!if_not_exists);
             assert!(!temporary);
@@ -6411,6 +6458,7 @@ fn parse_create_or_replace_materialized_view() {
             query,
             materialized,
             cluster_by,
+            comment,
             with_no_schema_binding: late_binding,
             if_not_exists,
             temporary,
@@ -6422,6 +6470,7 @@ fn parse_create_or_replace_materialized_view() {
             assert!(materialized);
             assert!(or_replace);
             assert_eq!(cluster_by, vec![]);
+            assert!(comment.is_none());
             assert!(!late_binding);
             assert!(!if_not_exists);
             assert!(!temporary);
@@ -6442,6 +6491,7 @@ fn parse_create_materialized_view() {
             materialized,
             options,
             cluster_by,
+            comment,
             with_no_schema_binding: late_binding,
             if_not_exists,
             temporary,
@@ -6453,6 +6503,7 @@ fn parse_create_materialized_view() {
             assert_eq!(options, CreateTableOptions::None);
             assert!(!or_replace);
             assert_eq!(cluster_by, vec![]);
+            assert!(comment.is_none());
             assert!(!late_binding);
             assert!(!if_not_exists);
             assert!(!temporary);
@@ -6473,6 +6524,7 @@ fn parse_create_materialized_view_with_cluster_by() {
             materialized,
             options,
             cluster_by,
+            comment,
             with_no_schema_binding: late_binding,
             if_not_exists,
             temporary,
@@ -6484,6 +6536,7 @@ fn parse_create_materialized_view_with_cluster_by() {
             assert_eq!(options, CreateTableOptions::None);
             assert!(!or_replace);
             assert_eq!(cluster_by, vec![Ident::new("foo")]);
+            assert!(comment.is_none());
             assert!(!late_binding);
             assert!(!if_not_exists);
             assert!(!temporary);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6404,45 +6404,6 @@ fn parse_create_or_replace_view() {
 }
 
 #[test]
-fn parse_create_or_replace_with_comment_for_snowflake() {
-    let sql = "CREATE OR REPLACE VIEW v COMMENT = 'hello, world' AS SELECT 1";
-    let dialect = test_utils::TestedDialects {
-        dialects: vec![Box::new(SnowflakeDialect {}) as Box<dyn Dialect>],
-        options: None,
-    };
-
-    match dialect.verified_stmt(sql) {
-        Statement::CreateView {
-            name,
-            columns,
-            or_replace,
-            options,
-            query,
-            materialized,
-            cluster_by,
-            comment,
-            with_no_schema_binding: late_binding,
-            if_not_exists,
-            temporary,
-        } => {
-            assert_eq!("v", name.to_string());
-            assert_eq!(columns, vec![]);
-            assert_eq!(options, CreateTableOptions::None);
-            assert_eq!("SELECT 1", query.to_string());
-            assert!(!materialized);
-            assert!(or_replace);
-            assert_eq!(cluster_by, vec![]);
-            assert!(comment.is_some());
-            assert_eq!(comment.expect("expected comment"), "hello, world");
-            assert!(!late_binding);
-            assert!(!if_not_exists);
-            assert!(!temporary);
-        }
-        _ => unreachable!(),
-    }
-}
-
-#[test]
 fn parse_create_or_replace_materialized_view() {
     // Supported in BigQuery (Beta)
     // https://cloud.google.com/bigquery/docs/materialized-views-intro

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -167,6 +167,7 @@ fn parse_create_view_temporary_if_not_exists() {
             materialized,
             options,
             cluster_by,
+            comment,
             with_no_schema_binding: late_binding,
             if_not_exists,
             temporary,
@@ -178,6 +179,7 @@ fn parse_create_view_temporary_if_not_exists() {
             assert!(!or_replace);
             assert_eq!(options, CreateTableOptions::None);
             assert_eq!(cluster_by, vec![]);
+            assert!(comment.is_none());
             assert!(!late_binding);
             assert!(if_not_exists);
             assert!(temporary);


### PR DESCRIPTION
Snowflake supports adding a comment when creating a view, see https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax.