### PR TITLE
Support for Postgres array slice syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -820,18 +820,19 @@ pub enum Subscript {
     /// {2,3,4,5}
     /// ```
     ///
-    /// Stride notation is also supported
+    /// The lower and/or upper bound can be omitted to slice from the start or
+    /// end of the array respectively.
+    ///
+    /// See <https://www.postgresql.org/docs/current/arrays.html#ARRAYS-ACCESSING>.
+    ///
+    /// Also supports an optional "stride" as the last element (this is not
+    /// supported by postgres), e.g.
     ///
     /// ```plaintext
     /// => select (array[1,2,3,4,5,6])[1:6:2];
     /// -----------
     /// {1,3,5}
     /// ```
-    ///
-    /// The lower and/or upper bound can be omitted to slice from the start or
-    /// end of the array respectively.
-    ///
-    /// See <https://www.postgresql.org/docs/current/arrays.html#ARRAYS-ACCESSING>.
     Slice {
         lower_bound: Option<Expr>,
         upper_bound: Option<Expr>,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -820,6 +820,14 @@ pub enum Subscript {
     /// {2,3,4,5}
     /// ```
     ///
+    /// Stride notation is also supported
+    ///
+    /// ```plaintext
+    /// => select (array[1,2,3,4,5,6])[1:6:2];
+    /// -----------
+    /// {1,3,5}
+    /// ```
+    ///
     /// The lower and/or upper bound can be omitted to slice from the start or
     /// end of the array respectively.
     ///
@@ -827,6 +835,7 @@ pub enum Subscript {
     Slice {
         lower_bound: Option<Expr>,
         upper_bound: Option<Expr>,
+        stride: Option<Expr>,
     },
 }
 
@@ -837,6 +846,7 @@ impl fmt::Display for Subscript {
             Subscript::Slice {
                 lower_bound,
                 upper_bound,
+                stride,
             } => {
                 if let Some(lower) = lower_bound {
                     write!(f, "{lower}")?;
@@ -844,6 +854,10 @@ impl fmt::Display for Subscript {
                 write!(f, ":")?;
                 if let Some(upper) = upper_bound {
                     write!(f, "{upper}")?;
+                }
+                if let Some(stride) = stride {
+                    write!(f, ":")?;
+                    write!(f, "{stride}")?;
                 }
                 Ok(())
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -678,7 +678,7 @@ pub enum Expr {
     },
     /// Access a map-like object by field (e.g. `column['field']` or `column[4]`
     /// Note that depending on the dialect, struct like accesses may be
-    /// parsed as [`ArrayIndex`](Self::ArrayIndex) or [`MapAccess`](Self::MapAccess)
+    /// parsed as [`Subscript`](Self::Subscript) or [`MapAccess`](Self::MapAccess)
     /// <https://clickhouse.com/docs/en/sql-reference/data-types/map/>
     MapAccess {
         column: Box<Expr>,

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -528,8 +528,8 @@ fn test_array_index() {
         _ => panic!("Expected an expression with alias"),
     };
     assert_eq!(
-        &Expr::ArrayIndex {
-            obj: Box::new(Expr::Array(Array {
+        &Expr::Subscript {
+            expr: Box::new(Expr::Array(Array {
                 elem: vec![
                     Expr::Value(Value::SingleQuotedString("a".to_owned())),
                     Expr::Value(Value::SingleQuotedString("b".to_owned())),
@@ -537,7 +537,9 @@ fn test_array_index() {
                 ],
                 named: false
             })),
-            indexes: vec![Expr::Value(number("3"))]
+            subscript: Box::new(Subscript::Index {
+                index: Expr::Value(number("3"))
+            })
         },
         expr
     );

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2038,7 +2038,7 @@ fn parse_array_subscript() {
         assert_eq!(expect, *subscript);
     }
 
-    // pg_and_generic().verified_expr("schedule[:2][2:]");
+    pg_and_generic().verified_expr("schedule[:2][2:]");
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2055,6 +2055,34 @@ fn parse_array_subscript() {
 }
 
 #[test]
+fn parse_array_multi_subscript() {
+    let expr = pg_and_generic().verified_expr("make_array(1, 2, 3)[1:2][2]");
+    assert_eq!(
+        Expr::Subscript {
+            expr: Box::new(Expr::Subscript {
+                expr: Box::new(call(
+                    "make_array",
+                    vec![
+                        Expr::Value(number("1")),
+                        Expr::Value(number("2")),
+                        Expr::Value(number("3"))
+                    ]
+                )),
+                subscript: Box::new(Subscript::Slice {
+                    lower_bound: Some(Expr::Value(number("1"))),
+                    upper_bound: Some(Expr::Value(number("2"))),
+                    stride: None,
+                }),
+            }),
+            subscript: Box::new(Subscript::Index {
+                index: Expr::Value(number("2")),
+            }),
+        },
+        expr,
+    );
+}
+
+#[test]
 fn parse_create_index() {
     let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2)";
     match pg().verified_stmt(sql) {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1992,6 +1992,15 @@ fn parse_array_subscript() {
             Subscript::Slice {
                 lower_bound: Some(Expr::Value(number("2"))),
                 upper_bound: Some(Expr::Value(number("5"))),
+                stride: None,
+            },
+        ),
+        (
+            "(ARRAY[1, 2, 3, 4, 5, 6])[2:5:3]",
+            Subscript::Slice {
+                lower_bound: Some(Expr::Value(number("2"))),
+                upper_bound: Some(Expr::Value(number("5"))),
+                stride: Some(Expr::Value(number("3"))),
             },
         ),
         (
@@ -2007,6 +2016,7 @@ fn parse_array_subscript() {
                     op: BinaryOperator::Minus,
                     right: Box::new(Expr::Value(number("1"))),
                 }),
+                stride: None,
             },
         ),
         (
@@ -2014,6 +2024,7 @@ fn parse_array_subscript() {
             Subscript::Slice {
                 lower_bound: None,
                 upper_bound: Some(Expr::Value(number("5"))),
+                stride: None,
             },
         ),
         (
@@ -2021,6 +2032,7 @@ fn parse_array_subscript() {
             Subscript::Slice {
                 lower_bound: Some(Expr::Value(number("2"))),
                 upper_bound: None,
+                stride: None,
             },
         ),
         (
@@ -2028,6 +2040,7 @@ fn parse_array_subscript() {
             Subscript::Slice {
                 lower_bound: None,
                 upper_bound: None,
+                stride: None,
             },
         ),
     ];

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -344,6 +344,36 @@ fn parse_semi_structured_data_traversal() {
         })],
         select.projection
     );
+
+    // a json access used as a key to another json access
+    assert_eq!(
+        snowflake().verified_expr("a[b:c]"),
+        Expr::JsonAccess {
+            value: Box::new(Expr::Identifier(Ident::new("a"))),
+            path: JsonPath {
+                path: vec![JsonPathElem::Bracket {
+                    key: Expr::JsonAccess {
+                        value: Box::new(Expr::Identifier(Ident::new("b"))),
+                        path: JsonPath {
+                            path: vec![JsonPathElem::Dot {
+                                key: "c".to_owned(),
+                                quoted: false
+                            }]
+                        }
+                    }
+                }]
+            }
+        }
+    );
+
+    // unquoted object keys cannot start with a digit
+    assert_eq!(
+        snowflake()
+            .parse_sql_statements("SELECT a:42")
+            .unwrap_err()
+            .to_string(),
+        "sql parser error: Expected variant object key name, found: 42"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This is related to #1283, though I don't know what SQL dialect DataFusion uses so I'm not sure whether this alone resolves it. cc @alamb @tisonkun 

Prior to 0.46, we were able to parse an expression such as `select make_array(1, 2, 3)[1:2]`, but this was only because we were incorrectly interpreting the `1:2` as a JSON access (Snowflake syntax) of a property `2` on the value `1`. (Snowflake doesn't actually allow the field name to start with a number.)

On PostgreSQL, this syntax represents an array slice access. An important detail here is that these two syntaxes are mutually exclusive, since the array slice syntax can accept arbitrary expressions for either bound. For example, `array[foo:bar]` on Snowflake means: "access the property of `array` whose name is the value of the `bar` field in `foo`", while on Postgres it means "return the subarray starting at the index from column `foo` until the index from the column `bar`".

As part of this change, I also renamed `ArrayIndex` to `Subscript`. My intention is to remove the `MapAccess` variant and subsume that functionality into `Subscript` and `CompositeAccess` in a follow-up, as it's entirely redundant.