### PR TITLE
Encapsulate `CreateTable`, `CreateIndex` into specific structs

### DIFF
--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -13,6 +13,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, string::String, vec::Vec};
 
+use core::fmt::{self, Display};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "visitor")]
@@ -21,9 +22,10 @@ use sqlparser_derive::{Visit, VisitMut};
 pub use super::ddl::{ColumnDef, TableConstraint};
 
 use super::{
-    Expr, FileFormat, FromTable, HiveDistributionStyle, HiveFormat, Ident, InsertAliases,
-    MysqlInsertPriority, ObjectName, OnCommit, OnInsert, OrderByExpr, Query, SelectItem, SqlOption,
-    SqliteOnConflict, TableWithJoins,
+    display_comma_separated, display_separated, Expr, FileFormat, FromTable, HiveDistributionStyle,
+    HiveFormat, HiveIOFormat, HiveRowFormat, Ident, InsertAliases, MysqlInsertPriority, ObjectName,
+    OnCommit, OnInsert, OrderByExpr, Query, SelectItem, SqlOption, SqliteOnConflict,
+    TableWithJoins,
 };
 
 /// CREATE INDEX statement.
@@ -97,6 +99,214 @@ pub struct CreateTable {
     /// if the "STRICT" table-option keyword is added to the end, after the closing ")",
     /// then strict typing rules apply to that table.
     pub strict: bool,
+}
+
+impl Display for CreateTable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // We want to allow the following options
+        // Empty column list, allowed by PostgreSQL:
+        //   `CREATE TABLE t ()`
+        // No columns provided for CREATE TABLE AS:
+        //   `CREATE TABLE t AS SELECT a from t2`
+        // Columns provided for CREATE TABLE AS:
+        //   `CREATE TABLE t (a INT) AS SELECT a from t2`
+        write!(
+            f,
+            "CREATE {or_replace}{external}{global}{temporary}{transient}TABLE {if_not_exists}{name}",
+            or_replace = if self.or_replace { "OR REPLACE " } else { "" },
+            external = if self.external { "EXTERNAL " } else { "" },
+            global = self.global
+                .map(|global| {
+                    if global {
+                        "GLOBAL "
+                    } else {
+                        "LOCAL "
+                    }
+                })
+                .unwrap_or(""),
+            if_not_exists = if self.if_not_exists { "IF NOT EXISTS " } else { "" },
+            temporary = if self.temporary { "TEMPORARY " } else { "" },
+            transient = if self.transient { "TRANSIENT " } else { "" },
+            name = self.name,
+        )?;
+        if let Some(on_cluster) = &self.on_cluster {
+            write!(
+                f,
+                " ON CLUSTER {}",
+                on_cluster.replace('{', "'{").replace('}', "}'")
+            )?;
+        }
+        if !self.columns.is_empty() || !self.constraints.is_empty() {
+            write!(f, " ({}", display_comma_separated(&self.columns))?;
+            if !self.columns.is_empty() && !self.constraints.is_empty() {
+                write!(f, ", ")?;
+            }
+            write!(f, "{})", display_comma_separated(&self.constraints))?;
+        } else if self.query.is_none() && self.like.is_none() && self.clone.is_none() {
+            // PostgreSQL allows `CREATE TABLE t ();`, but requires empty parens
+            write!(f, " ()")?;
+        }
+        // Only for SQLite
+        if self.without_rowid {
+            write!(f, " WITHOUT ROWID")?;
+        }
+
+        // Only for Hive
+        if let Some(l) = &self.like {
+            write!(f, " LIKE {l}")?;
+        }
+
+        if let Some(c) = &self.clone {
+            write!(f, " CLONE {c}")?;
+        }
+
+        match &self.hive_distribution {
+            HiveDistributionStyle::PARTITIONED { columns } => {
+                write!(f, " PARTITIONED BY ({})", display_comma_separated(columns))?;
+            }
+            HiveDistributionStyle::CLUSTERED {
+                columns,
+                sorted_by,
+                num_buckets,
+            } => {
+                write!(f, " CLUSTERED BY ({})", display_comma_separated(columns))?;
+                if !sorted_by.is_empty() {
+                    write!(f, " SORTED BY ({})", display_comma_separated(sorted_by))?;
+                }
+                if *num_buckets > 0 {
+                    write!(f, " INTO {num_buckets} BUCKETS")?;
+                }
+            }
+            HiveDistributionStyle::SKEWED {
+                columns,
+                on,
+                stored_as_directories,
+            } => {
+                write!(
+                    f,
+                    " SKEWED BY ({})) ON ({})",
+                    display_comma_separated(columns),
+                    display_comma_separated(on)
+                )?;
+                if *stored_as_directories {
+                    write!(f, " STORED AS DIRECTORIES")?;
+                }
+            }
+            _ => (),
+        }
+
+        if let Some(HiveFormat {
+            row_format,
+            serde_properties,
+            storage,
+            location,
+        }) = &self.hive_formats
+        {
+            match row_format {
+                Some(HiveRowFormat::SERDE { class }) => write!(f, " ROW FORMAT SERDE '{class}'")?,
+                Some(HiveRowFormat::DELIMITED { delimiters }) => {
+                    write!(f, " ROW FORMAT DELIMITED")?;
+                    if !delimiters.is_empty() {
+                        write!(f, " {}", display_separated(delimiters, " "))?;
+                    }
+                }
+                None => (),
+            }
+            match storage {
+                Some(HiveIOFormat::IOF {
+                    input_format,
+                    output_format,
+                }) => write!(
+                    f,
+                    " STORED AS INPUTFORMAT {input_format} OUTPUTFORMAT {output_format}"
+                )?,
+                Some(HiveIOFormat::FileFormat { format }) if !self.external => {
+                    write!(f, " STORED AS {format}")?
+                }
+                _ => (),
+            }
+            if let Some(serde_properties) = serde_properties.as_ref() {
+                write!(
+                    f,
+                    " WITH SERDEPROPERTIES ({})",
+                    display_comma_separated(serde_properties)
+                )?;
+            }
+            if !self.external {
+                if let Some(loc) = location {
+                    write!(f, " LOCATION '{loc}'")?;
+                }
+            }
+        }
+        if self.external {
+            if let Some(file_format) = self.file_format {
+                write!(f, " STORED AS {file_format}")?;
+            }
+            write!(f, " LOCATION '{}'", self.location.as_ref().unwrap())?;
+        }
+        if !self.table_properties.is_empty() {
+            write!(
+                f,
+                " TBLPROPERTIES ({})",
+                display_comma_separated(&self.table_properties)
+            )?;
+        }
+        if !self.with_options.is_empty() {
+            write!(f, " WITH ({})", display_comma_separated(&self.with_options))?;
+        }
+        if let Some(engine) = &self.engine {
+            write!(f, " ENGINE={engine}")?;
+        }
+        if let Some(comment) = &self.comment {
+            write!(f, " COMMENT '{comment}'")?;
+        }
+        if let Some(auto_increment_offset) = self.auto_increment_offset {
+            write!(f, " AUTO_INCREMENT {auto_increment_offset}")?;
+        }
+        if let Some(order_by) = &self.order_by {
+            write!(f, " ORDER BY ({})", display_comma_separated(order_by))?;
+        }
+        if let Some(partition_by) = self.partition_by.as_ref() {
+            write!(f, " PARTITION BY {partition_by}")?;
+        }
+        if let Some(cluster_by) = self.cluster_by.as_ref() {
+            write!(
+                f,
+                " CLUSTER BY {}",
+                display_comma_separated(cluster_by.as_slice())
+            )?;
+        }
+        if let Some(options) = self.options.as_ref() {
+            write!(
+                f,
+                " OPTIONS({})",
+                display_comma_separated(options.as_slice())
+            )?;
+        }
+        if let Some(query) = &self.query {
+            write!(f, " AS {query}")?;
+        }
+        if let Some(default_charset) = &self.default_charset {
+            write!(f, " DEFAULT CHARSET={default_charset}")?;
+        }
+        if let Some(collation) = &self.collation {
+            write!(f, " COLLATE={collation}")?;
+        }
+
+        if self.on_commit.is_some() {
+            let on_commit = match self.on_commit {
+                Some(OnCommit::DeleteRows) => "ON COMMIT DELETE ROWS",
+                Some(OnCommit::PreserveRows) => "ON COMMIT PRESERVE ROWS",
+                Some(OnCommit::Drop) => "ON COMMIT DROP",
+                None => "",
+            };
+            write!(f, " {on_commit}")?;
+        }
+        if self.strict {
+            write!(f, " STRICT")?;
+        }
+        Ok(())
+    }
 }
 
 /// INSERT statement.

--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -26,6 +26,24 @@ use super::{
     SqliteOnConflict, TableWithJoins,
 };
 
+/// CREATE INDEX statement.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct CreateIndex {
+    /// index name
+    pub name: Option<ObjectName>,
+    #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
+    pub table_name: ObjectName,
+    pub using: Option<Ident>,
+    pub columns: Vec<OrderByExpr>,
+    pub unique: bool,
+    pub concurrently: bool,
+    pub if_not_exists: bool,
+    pub include: Vec<Ident>,
+    pub nulls_distinct: Option<bool>,
+    pub predicate: Option<Expr>,
+}
 /// CREATE TABLE statement.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "visitor")]
 use sqlparser_derive::{Visit, VisitMut};
 
+use super::super::dml::CreateTable;
 use crate::ast::{
     ColumnDef, Expr, FileFormat, HiveDistributionStyle, HiveFormat, Ident, ObjectName, OnCommit,
     Query, SqlOption, Statement, TableConstraint,
@@ -263,7 +264,7 @@ impl CreateTableBuilder {
     }
 
     pub fn build(self) -> Statement {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             or_replace: self.or_replace,
             temporary: self.temporary,
             external: self.external,
@@ -295,7 +296,7 @@ impl CreateTableBuilder {
             cluster_by: self.cluster_by,
             options: self.options,
             strict: self.strict,
-        }
+        })
     }
 }
 
@@ -306,7 +307,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
     // ownership.
     fn try_from(stmt: Statement) -> Result<Self, Self::Error> {
         match stmt {
-            Statement::CreateTable {
+            Statement::CreateTable(CreateTable {
                 or_replace,
                 temporary,
                 external,
@@ -338,7 +339,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 cluster_by,
                 options,
                 strict,
-            } => Ok(Self {
+            }) => Ok(Self {
                 or_replace,
                 temporary,
                 external,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -38,7 +38,7 @@ pub use self::ddl::{
     ReferentialAction, TableConstraint, UserDefinedTypeCompositeAttributeDef,
     UserDefinedTypeRepresentation, ViewColumnDef,
 };
-pub use self::dml::{CreateTable, Delete, Insert};
+pub use self::dml::{CreateIndex, CreateTable, Delete, Insert};
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     AfterMatchSkip, ConnectBy, Cte, CteAsMaterialized, Distinct, EmptyMatchesMode,
@@ -1987,20 +1987,7 @@ pub enum Statement {
     /// ```sql
     /// `CREATE INDEX`
     /// ```
-    CreateIndex {
-        /// index name
-        name: Option<ObjectName>,
-        #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
-        table_name: ObjectName,
-        using: Option<Ident>,
-        columns: Vec<OrderByExpr>,
-        unique: bool,
-        concurrently: bool,
-        if_not_exists: bool,
-        include: Vec<Ident>,
-        nulls_distinct: Option<bool>,
-        predicate: Option<Expr>,
-    },
+    CreateIndex(CreateIndex),
     /// ```sql
     /// CREATE ROLE
     /// ```
@@ -3574,7 +3561,7 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::CreateIndex {
+            Statement::CreateIndex(CreateIndex {
                 name,
                 table_name,
                 using,
@@ -3585,7 +3572,7 @@ impl fmt::Display for Statement {
                 include,
                 nulls_distinct,
                 predicate,
-            } => {
+            }) => {
                 write!(
                     f,
                     "CREATE {unique}INDEX {concurrently}{if_not_exists}",

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -38,7 +38,7 @@ pub use self::ddl::{
     ReferentialAction, TableConstraint, UserDefinedTypeCompositeAttributeDef,
     UserDefinedTypeRepresentation, ViewColumnDef,
 };
-pub use self::dml::{Delete, Insert};
+pub use self::dml::{CreateTable, Delete, Insert};
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     AfterMatchSkip, ConnectBy, Cte, CteAsMaterialized, Distinct, EmptyMatchesMode,
@@ -1972,56 +1972,7 @@ pub enum Statement {
     /// ```sql
     /// CREATE TABLE
     /// ```
-    CreateTable {
-        or_replace: bool,
-        temporary: bool,
-        external: bool,
-        global: Option<bool>,
-        if_not_exists: bool,
-        transient: bool,
-        /// Table name
-        #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
-        name: ObjectName,
-        /// Optional schema
-        columns: Vec<ColumnDef>,
-        constraints: Vec<TableConstraint>,
-        hive_distribution: HiveDistributionStyle,
-        hive_formats: Option<HiveFormat>,
-        table_properties: Vec<SqlOption>,
-        with_options: Vec<SqlOption>,
-        file_format: Option<FileFormat>,
-        location: Option<String>,
-        query: Option<Box<Query>>,
-        without_rowid: bool,
-        like: Option<ObjectName>,
-        clone: Option<ObjectName>,
-        engine: Option<String>,
-        comment: Option<String>,
-        auto_increment_offset: Option<u32>,
-        default_charset: Option<String>,
-        collation: Option<String>,
-        on_commit: Option<OnCommit>,
-        /// ClickHouse "ON CLUSTER" clause:
-        /// <https://clickhouse.com/docs/en/sql-reference/distributed-ddl/>
-        on_cluster: Option<String>,
-        /// ClickHouse "ORDER BY " clause. Note that omitted ORDER BY is different
-        /// than empty (represented as ()), the latter meaning "no sorting".
-        /// <https://clickhouse.com/docs/en/sql-reference/statements/create/table/>
-        order_by: Option<Vec<Ident>>,
-        /// BigQuery: A partition expression for the table.
-        /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#partition_expression>
-        partition_by: Option<Box<Expr>>,
-        /// BigQuery: Table clustering column list.
-        /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#table_option_list>
-        cluster_by: Option<Vec<Ident>>,
-        /// BigQuery: Table options list.
-        /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#table_option_list>
-        options: Option<Vec<SqlOption>>,
-        /// SQLite "STRICT" clause.
-        /// if the "STRICT" table-option keyword is added to the end, after the closing ")",
-        /// then strict typing rules apply to that table.
-        strict: bool,
-    },
+    CreateTable(CreateTable),
     /// ```sql
     /// CREATE VIRTUAL TABLE .. USING <module_name> (<module_args>)`
     /// ```
@@ -3365,39 +3316,40 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::CreateTable {
-                name,
-                columns,
-                constraints,
-                table_properties,
-                with_options,
-                or_replace,
-                if_not_exists,
-                transient,
-                hive_distribution,
-                hive_formats,
-                external,
-                global,
-                temporary,
-                file_format,
-                location,
-                query,
-                without_rowid,
-                like,
-                clone,
-                default_charset,
-                engine,
-                comment,
-                auto_increment_offset,
-                collation,
-                on_commit,
-                on_cluster,
-                order_by,
-                partition_by,
-                cluster_by,
-                options,
-                strict,
-            } => {
+            Statement::CreateTable(create_table) => {
+                let CreateTable {
+                    name,
+                    columns,
+                    constraints,
+                    table_properties,
+                    with_options,
+                    or_replace,
+                    if_not_exists,
+                    transient,
+                    hive_distribution,
+                    hive_formats,
+                    external,
+                    global,
+                    temporary,
+                    file_format,
+                    location,
+                    query,
+                    without_rowid,
+                    like,
+                    clone,
+                    default_charset,
+                    engine,
+                    comment,
+                    auto_increment_offset,
+                    collation,
+                    on_commit,
+                    on_cluster,
+                    order_by,
+                    partition_by,
+                    cluster_by,
+                    options,
+                    strict,
+                } = create_table;
                 // We want to allow the following options
                 // Empty column list, allowed by PostgreSQL:
                 //   `CREATE TABLE t ()`

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -75,7 +75,7 @@ mod value;
 #[cfg(feature = "visitor")]
 mod visitor;
 
-struct DisplaySeparated<'a, T>
+pub struct DisplaySeparated<'a, T>
 where
     T: fmt::Display,
 {
@@ -98,14 +98,14 @@ where
     }
 }
 
-fn display_separated<'a, T>(slice: &'a [T], sep: &'static str) -> DisplaySeparated<'a, T>
+pub fn display_separated<'a, T>(slice: &'a [T], sep: &'static str) -> DisplaySeparated<'a, T>
 where
     T: fmt::Display,
 {
     DisplaySeparated { slice, sep }
 }
 
-fn display_comma_separated<T>(slice: &[T]) -> DisplaySeparated<'_, T>
+pub fn display_comma_separated<T>(slice: &[T]) -> DisplaySeparated<'_, T>
 where
     T: fmt::Display,
 {
@@ -3303,246 +3303,7 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::CreateTable(create_table) => {
-                let CreateTable {
-                    name,
-                    columns,
-                    constraints,
-                    table_properties,
-                    with_options,
-                    or_replace,
-                    if_not_exists,
-                    transient,
-                    hive_distribution,
-                    hive_formats,
-                    external,
-                    global,
-                    temporary,
-                    file_format,
-                    location,
-                    query,
-                    without_rowid,
-                    like,
-                    clone,
-                    default_charset,
-                    engine,
-                    comment,
-                    auto_increment_offset,
-                    collation,
-                    on_commit,
-                    on_cluster,
-                    order_by,
-                    partition_by,
-                    cluster_by,
-                    options,
-                    strict,
-                } = create_table;
-                // We want to allow the following options
-                // Empty column list, allowed by PostgreSQL:
-                //   `CREATE TABLE t ()`
-                // No columns provided for CREATE TABLE AS:
-                //   `CREATE TABLE t AS SELECT a from t2`
-                // Columns provided for CREATE TABLE AS:
-                //   `CREATE TABLE t (a INT) AS SELECT a from t2`
-                write!(
-                    f,
-                    "CREATE {or_replace}{external}{global}{temporary}{transient}TABLE {if_not_exists}{name}",
-                    or_replace = if *or_replace { "OR REPLACE " } else { "" },
-                    external = if *external { "EXTERNAL " } else { "" },
-                    global = global
-                        .map(|global| {
-                            if global {
-                                "GLOBAL "
-                            } else {
-                                "LOCAL "
-                            }
-                        })
-                        .unwrap_or(""),
-                    if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
-                    temporary = if *temporary { "TEMPORARY " } else { "" },
-                    transient = if *transient { "TRANSIENT " } else { "" },
-                    name = name,
-                )?;
-                if let Some(on_cluster) = on_cluster {
-                    write!(
-                        f,
-                        " ON CLUSTER {}",
-                        on_cluster.replace('{', "'{").replace('}', "}'")
-                    )?;
-                }
-                if !columns.is_empty() || !constraints.is_empty() {
-                    write!(f, " ({}", display_comma_separated(columns))?;
-                    if !columns.is_empty() && !constraints.is_empty() {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{})", display_comma_separated(constraints))?;
-                } else if query.is_none() && like.is_none() && clone.is_none() {
-                    // PostgreSQL allows `CREATE TABLE t ();`, but requires empty parens
-                    write!(f, " ()")?;
-                }
-                // Only for SQLite
-                if *without_rowid {
-                    write!(f, " WITHOUT ROWID")?;
-                }
-
-                // Only for Hive
-                if let Some(l) = like {
-                    write!(f, " LIKE {l}")?;
-                }
-
-                if let Some(c) = clone {
-                    write!(f, " CLONE {c}")?;
-                }
-
-                match hive_distribution {
-                    HiveDistributionStyle::PARTITIONED { columns } => {
-                        write!(f, " PARTITIONED BY ({})", display_comma_separated(columns))?;
-                    }
-                    HiveDistributionStyle::CLUSTERED {
-                        columns,
-                        sorted_by,
-                        num_buckets,
-                    } => {
-                        write!(f, " CLUSTERED BY ({})", display_comma_separated(columns))?;
-                        if !sorted_by.is_empty() {
-                            write!(f, " SORTED BY ({})", display_comma_separated(sorted_by))?;
-                        }
-                        if *num_buckets > 0 {
-                            write!(f, " INTO {num_buckets} BUCKETS")?;
-                        }
-                    }
-                    HiveDistributionStyle::SKEWED {
-                        columns,
-                        on,
-                        stored_as_directories,
-                    } => {
-                        write!(
-                            f,
-                            " SKEWED BY ({})) ON ({})",
-                            display_comma_separated(columns),
-                            display_comma_separated(on)
-                        )?;
-                        if *stored_as_directories {
-                            write!(f, " STORED AS DIRECTORIES")?;
-                        }
-                    }
-                    _ => (),
-                }
-
-                if let Some(HiveFormat {
-                    row_format,
-                    serde_properties,
-                    storage,
-                    location,
-                }) = hive_formats
-                {
-                    match row_format {
-                        Some(HiveRowFormat::SERDE { class }) => {
-                            write!(f, " ROW FORMAT SERDE '{class}'")?
-                        }
-                        Some(HiveRowFormat::DELIMITED { delimiters }) => {
-                            write!(f, " ROW FORMAT DELIMITED")?;
-                            if !delimiters.is_empty() {
-                                write!(f, " {}", display_separated(delimiters, " "))?;
-                            }
-                        }
-                        None => (),
-                    }
-                    match storage {
-                        Some(HiveIOFormat::IOF {
-                            input_format,
-                            output_format,
-                        }) => write!(
-                            f,
-                            " STORED AS INPUTFORMAT {input_format} OUTPUTFORMAT {output_format}"
-                        )?,
-                        Some(HiveIOFormat::FileFormat { format }) if !*external => {
-                            write!(f, " STORED AS {format}")?
-                        }
-                        _ => (),
-                    }
-                    if let Some(serde_properties) = serde_properties.as_ref() {
-                        write!(
-                            f,
-                            " WITH SERDEPROPERTIES ({})",
-                            display_comma_separated(serde_properties)
-                        )?;
-                    }
-                    if !*external {
-                        if let Some(loc) = location {
-                            write!(f, " LOCATION '{loc}'")?;
-                        }
-                    }
-                }
-                if *external {
-                    if let Some(file_format) = &file_format {
-                        write!(f, " STORED AS {file_format}")?;
-                    }
-                    write!(f, " LOCATION '{}'", location.as_ref().unwrap())?;
-                }
-                if !table_properties.is_empty() {
-                    write!(
-                        f,
-                        " TBLPROPERTIES ({})",
-                        display_comma_separated(table_properties)
-                    )?;
-                }
-                if !with_options.is_empty() {
-                    write!(f, " WITH ({})", display_comma_separated(with_options))?;
-                }
-                if let Some(engine) = engine {
-                    write!(f, " ENGINE={engine}")?;
-                }
-                if let Some(comment) = comment {
-                    write!(f, " COMMENT '{comment}'")?;
-                }
-                if let Some(auto_increment_offset) = auto_increment_offset {
-                    write!(f, " AUTO_INCREMENT {auto_increment_offset}")?;
-                }
-                if let Some(order_by) = order_by {
-                    write!(f, " ORDER BY ({})", display_comma_separated(order_by))?;
-                }
-                if let Some(partition_by) = partition_by.as_ref() {
-                    write!(f, " PARTITION BY {partition_by}")?;
-                }
-                if let Some(cluster_by) = cluster_by.as_ref() {
-                    write!(
-                        f,
-                        " CLUSTER BY {}",
-                        display_comma_separated(cluster_by.as_slice())
-                    )?;
-                }
-                if let Some(options) = options.as_ref() {
-                    write!(
-                        f,
-                        " OPTIONS({})",
-                        display_comma_separated(options.as_slice())
-                    )?;
-                }
-                if let Some(query) = query {
-                    write!(f, " AS {query}")?;
-                }
-                if let Some(default_charset) = default_charset {
-                    write!(f, " DEFAULT CHARSET={default_charset}")?;
-                }
-                if let Some(collation) = collation {
-                    write!(f, " COLLATE={collation}")?;
-                }
-
-                if on_commit.is_some() {
-                    let on_commit = match on_commit {
-                        Some(OnCommit::DeleteRows) => "ON COMMIT DELETE ROWS",
-                        Some(OnCommit::PreserveRows) => "ON COMMIT PRESERVE ROWS",
-                        Some(OnCommit::Drop) => "ON COMMIT DROP",
-                        None => "",
-                    };
-                    write!(f, " {on_commit}")?;
-                }
-                if *strict {
-                    write!(f, " STRICT")?;
-                }
-                Ok(())
-            }
+            Statement::CreateTable(create_table) => create_table.fmt(f),
             Statement::CreateVirtualTable {
                 name,
                 if_not_exists,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4895,7 +4895,7 @@ impl<'a> Parser<'a> {
             None
         };
 
-        Ok(Statement::CreateIndex {
+        Ok(Statement::CreateIndex(CreateIndex {
             name: index_name,
             table_name,
             using,
@@ -4906,7 +4906,7 @@ impl<'a> Parser<'a> {
             include,
             nulls_distinct,
             predicate,
-        })
+        }))
     }
 
     pub fn parse_create_extension(&mut self) -> Result<Statement, ParserError> {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -354,7 +354,7 @@ fn parse_create_view_with_unquoted_hyphen() {
 fn parse_create_table_with_unquoted_hyphen() {
     let sql = "CREATE TABLE my-pro-ject.mydataset.mytable (x INT64)";
     match bigquery().verified_stmt(sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(
                 name,
                 ObjectName(vec![
@@ -388,14 +388,14 @@ fn parse_create_table_with_options() {
         r#"OPTIONS(partition_expiration_days = 1, description = "table option description")"#
     );
     match bigquery().verified_stmt(sql) {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             name,
             columns,
             partition_by,
             cluster_by,
             options,
             ..
-        } => {
+        }) => {
             assert_eq!(
                 name,
                 ObjectName(vec!["mydataset".into(), "newtable".into()])
@@ -477,7 +477,7 @@ fn parse_create_table_with_options() {
 fn parse_nested_data_types() {
     let sql = "CREATE TABLE table (x STRUCT<a ARRAY<INT64>, b BYTES(42)>, y ARRAY<STRUCT<INT64>>)";
     match bigquery_and_generic().one_statement_parses_to(sql, sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name, ObjectName(vec!["table".into()]));
             assert_eq!(
                 columns,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7210,14 +7210,14 @@ fn parse_create_index() {
         },
     ];
     match verified_stmt(sql) {
-        Statement::CreateIndex {
+        Statement::CreateIndex(CreateIndex {
             name: Some(name),
             table_name,
             columns,
             unique,
             if_not_exists,
             ..
-        } => {
+        }) => {
             assert_eq!("idx_name", name.to_string());
             assert_eq!("test", table_name.to_string());
             assert_eq!(indexed_columns, columns);
@@ -7244,7 +7244,7 @@ fn test_create_index_with_using_function() {
         },
     ];
     match verified_stmt(sql) {
-        Statement::CreateIndex {
+        Statement::CreateIndex(CreateIndex {
             name: Some(name),
             table_name,
             using,
@@ -7255,7 +7255,7 @@ fn test_create_index_with_using_function() {
             include,
             nulls_distinct: None,
             predicate: None,
-        } => {
+        }) => {
             assert_eq!("idx_name", name.to_string());
             assert_eq!("test", table_name.to_string());
             assert_eq!("btree", using.unwrap().to_string());

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -470,7 +470,7 @@ fn parse_set_variables() {
 fn parse_create_table_auto_increment() {
     let sql = "CREATE TABLE foo (bar INT PRIMARY KEY AUTO_INCREMENT)";
     match mysql().verified_stmt(sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
                 vec![ColumnDef {
@@ -541,12 +541,12 @@ fn parse_create_table_primary_and_unique_key() {
 
     for (sql, index_type_display) in sqls.iter().zip(index_type_display) {
         match mysql().one_statement_parses_to(sql, "") {
-            Statement::CreateTable {
+            Statement::CreateTable(CreateTable {
                 name,
                 columns,
                 constraints,
                 ..
-            } => {
+            }) => {
                 assert_eq!(name.to_string(), "foo");
 
                 let expected_constraint = table_constraint_unique_primary_ctor(
@@ -609,9 +609,9 @@ fn parse_create_table_primary_and_unique_key_with_index_options() {
 
     for (sql, index_type_display) in sqls.iter().zip(index_type_display) {
         match mysql_and_generic().one_statement_parses_to(sql, "") {
-            Statement::CreateTable {
+            Statement::CreateTable(CreateTable {
                 name, constraints, ..
-            } => {
+            }) => {
                 assert_eq!(name.to_string(), "foo");
 
                 let expected_constraint = table_constraint_unique_primary_ctor(
@@ -647,9 +647,9 @@ fn parse_create_table_primary_and_unique_key_with_index_type() {
 
     for (sql, index_type_display) in sqls.iter().zip(index_type_display) {
         match mysql_and_generic().one_statement_parses_to(sql, "") {
-            Statement::CreateTable {
+            Statement::CreateTable(CreateTable {
                 name, constraints, ..
-            } => {
+            }) => {
                 assert_eq!(name.to_string(), "foo");
 
                 let expected_constraint = table_constraint_unique_primary_ctor(
@@ -690,7 +690,7 @@ fn parse_create_table_comment() {
 
     for sql in [canonical, with_equal] {
         match mysql().one_statement_parses_to(sql, canonical) {
-            Statement::CreateTable { name, comment, .. } => {
+            Statement::CreateTable(CreateTable { name, comment, .. }) => {
                 assert_eq!(name.to_string(), "foo");
                 assert_eq!(comment.expect("Should exist").to_string(), "baz");
             }
@@ -708,11 +708,11 @@ fn parse_create_table_auto_increment_offset() {
 
     for sql in [canonical, with_equal] {
         match mysql().one_statement_parses_to(sql, canonical) {
-            Statement::CreateTable {
+            Statement::CreateTable(CreateTable {
                 name,
                 auto_increment_offset,
                 ..
-            } => {
+            }) => {
                 assert_eq!(name.to_string(), "foo");
                 assert_eq!(
                     auto_increment_offset.expect("Should exist").to_string(),
@@ -728,7 +728,7 @@ fn parse_create_table_auto_increment_offset() {
 fn parse_create_table_set_enum() {
     let sql = "CREATE TABLE foo (bar SET('a', 'b'), baz ENUM('a', 'b'))";
     match mysql().verified_stmt(sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
                 vec![
@@ -756,13 +756,13 @@ fn parse_create_table_set_enum() {
 fn parse_create_table_engine_default_charset() {
     let sql = "CREATE TABLE foo (id INT(11)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3";
     match mysql().verified_stmt(sql) {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             name,
             columns,
             engine,
             default_charset,
             ..
-        } => {
+        }) => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
                 vec![ColumnDef {
@@ -784,12 +784,12 @@ fn parse_create_table_engine_default_charset() {
 fn parse_create_table_collate() {
     let sql = "CREATE TABLE foo (id INT(11)) COLLATE=utf8mb4_0900_ai_ci";
     match mysql().verified_stmt(sql) {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             name,
             columns,
             collation,
             ..
-        } => {
+        }) => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
                 vec![ColumnDef {
@@ -810,7 +810,7 @@ fn parse_create_table_collate() {
 fn parse_create_table_comment_character_set() {
     let sql = "CREATE TABLE foo (s TEXT CHARACTER SET utf8mb4 COMMENT 'comment')";
     match mysql().verified_stmt(sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
                 vec![ColumnDef {
@@ -857,7 +857,7 @@ fn parse_create_table_gencol() {
 fn parse_quote_identifiers() {
     let sql = "CREATE TABLE `PRIMARY` (`BEGIN` INT PRIMARY KEY)";
     match mysql().verified_stmt(sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "`PRIMARY`");
             assert_eq!(
                 vec![ColumnDef {
@@ -1126,7 +1126,7 @@ fn check_roundtrip_of_escaped_string() {
 fn parse_create_table_with_minimum_display_width() {
     let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3), bar_smallint SMALLINT(5), bar_mediumint MEDIUMINT(6), bar_int INT(11), bar_bigint BIGINT(20))";
     match mysql().verified_stmt(sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
                 vec![
@@ -1172,7 +1172,7 @@ fn parse_create_table_with_minimum_display_width() {
 fn parse_create_table_unsigned() {
     let sql = "CREATE TABLE foo (bar_tinyint TINYINT(3) UNSIGNED, bar_smallint SMALLINT(5) UNSIGNED, bar_mediumint MEDIUMINT(13) UNSIGNED, bar_int INT(11) UNSIGNED, bar_bigint BIGINT(20) UNSIGNED)";
     match mysql().verified_stmt(sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
                 vec![
@@ -2321,7 +2321,7 @@ fn parse_kill() {
 fn parse_table_colum_option_on_update() {
     let sql1 = "CREATE TABLE foo (`modification_time` DATETIME ON UPDATE CURRENT_TIMESTAMP())";
     match mysql().verified_stmt(sql1) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
                 vec![ColumnDef {
@@ -2622,7 +2622,7 @@ fn parse_create_table_with_column_collate() {
     let sql = "CREATE TABLE tb (id TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci)";
     let canonical = "CREATE TABLE tb (id TEXT COLLATE utf8mb4_0900_ai_ci CHARACTER SET utf8mb4)";
     match mysql().one_statement_parses_to(sql, canonical) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "tb");
             assert_eq!(
                 vec![ColumnDef {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -317,7 +317,7 @@ fn parse_create_table_with_defaults() {
             active int NOT NULL
     ) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)";
     match pg_and_generic().one_statement_parses_to(sql, "") {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             name,
             columns,
             constraints,
@@ -327,7 +327,7 @@ fn parse_create_table_with_defaults() {
             file_format: None,
             location: None,
             ..
-        } => {
+        }) => {
             use pretty_assertions::assert_eq;
             assert_eq!("public.customer", name.to_string());
             assert_eq!(
@@ -537,12 +537,12 @@ fn parse_create_table_constraints_only() {
     let sql = "CREATE TABLE t (CONSTRAINT positive CHECK (2 > 1))";
     let ast = pg_and_generic().verified_stmt(sql);
     match ast {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             name,
             columns,
             constraints,
             ..
-        } => {
+        }) => {
             assert_eq!("t", name.to_string());
             assert!(columns.is_empty());
             assert_eq!(
@@ -718,11 +718,11 @@ fn parse_create_table_if_not_exists() {
     let sql = "CREATE TABLE IF NOT EXISTS uk_cities ()";
     let ast = pg_and_generic().verified_stmt(sql);
     match ast {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             name,
             if_not_exists: true,
             ..
-        } => {
+        }) => {
             assert_eq!("uk_cities", name.to_string());
         }
         _ => unreachable!(),
@@ -3570,7 +3570,7 @@ fn parse_create_table_with_alias() {
       bool_col BOOL,
     );";
     match pg_and_generic().one_statement_parses_to(sql, "") {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             name,
             columns,
             constraints,
@@ -3580,7 +3580,7 @@ fn parse_create_table_with_alias() {
             file_format: None,
             location: None,
             ..
-        } => {
+        }) => {
             assert_eq!("public.datatype_aliases", name.to_string());
             assert_eq!(
                 columns,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1952,7 +1952,7 @@ fn parse_array_index_expr() {
 fn parse_create_index() {
     let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2)";
     match pg().verified_stmt(sql) {
-        Statement::CreateIndex {
+        Statement::CreateIndex(CreateIndex {
             name: Some(ObjectName(name)),
             table_name: ObjectName(table_name),
             using,
@@ -1963,7 +1963,7 @@ fn parse_create_index() {
             nulls_distinct: None,
             include,
             predicate: None,
-        } => {
+        }) => {
             assert_eq_vec(&["my_index"], &name);
             assert_eq_vec(&["my_table"], &table_name);
             assert_eq!(None, using);
@@ -1981,7 +1981,7 @@ fn parse_create_index() {
 fn parse_create_anonymous_index() {
     let sql = "CREATE INDEX ON my_table(col1,col2)";
     match pg().verified_stmt(sql) {
-        Statement::CreateIndex {
+        Statement::CreateIndex(CreateIndex {
             name,
             table_name: ObjectName(table_name),
             using,
@@ -1992,7 +1992,7 @@ fn parse_create_anonymous_index() {
             include,
             nulls_distinct: None,
             predicate: None,
-        } => {
+        }) => {
             assert_eq!(None, name);
             assert_eq_vec(&["my_table"], &table_name);
             assert_eq!(None, using);
@@ -2010,7 +2010,7 @@ fn parse_create_anonymous_index() {
 fn parse_create_index_concurrently() {
     let sql = "CREATE INDEX CONCURRENTLY IF NOT EXISTS my_index ON my_table(col1,col2)";
     match pg().verified_stmt(sql) {
-        Statement::CreateIndex {
+        Statement::CreateIndex(CreateIndex {
             name: Some(ObjectName(name)),
             table_name: ObjectName(table_name),
             using,
@@ -2021,7 +2021,7 @@ fn parse_create_index_concurrently() {
             include,
             nulls_distinct: None,
             predicate: None,
-        } => {
+        }) => {
             assert_eq_vec(&["my_index"], &name);
             assert_eq_vec(&["my_table"], &table_name);
             assert_eq!(None, using);
@@ -2039,7 +2039,7 @@ fn parse_create_index_concurrently() {
 fn parse_create_index_with_predicate() {
     let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2) WHERE col3 IS NULL";
     match pg().verified_stmt(sql) {
-        Statement::CreateIndex {
+        Statement::CreateIndex(CreateIndex {
             name: Some(ObjectName(name)),
             table_name: ObjectName(table_name),
             using,
@@ -2050,7 +2050,7 @@ fn parse_create_index_with_predicate() {
             include,
             nulls_distinct: None,
             predicate: Some(_),
-        } => {
+        }) => {
             assert_eq_vec(&["my_index"], &name);
             assert_eq_vec(&["my_table"], &table_name);
             assert_eq!(None, using);
@@ -2068,7 +2068,7 @@ fn parse_create_index_with_predicate() {
 fn parse_create_index_with_include() {
     let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2) INCLUDE (col3)";
     match pg().verified_stmt(sql) {
-        Statement::CreateIndex {
+        Statement::CreateIndex(CreateIndex {
             name: Some(ObjectName(name)),
             table_name: ObjectName(table_name),
             using,
@@ -2079,7 +2079,7 @@ fn parse_create_index_with_include() {
             include,
             nulls_distinct: None,
             predicate: None,
-        } => {
+        }) => {
             assert_eq_vec(&["my_index"], &name);
             assert_eq_vec(&["my_table"], &table_name);
             assert_eq!(None, using);
@@ -2097,7 +2097,7 @@ fn parse_create_index_with_include() {
 fn parse_create_index_with_nulls_distinct() {
     let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2) NULLS NOT DISTINCT";
     match pg().verified_stmt(sql) {
-        Statement::CreateIndex {
+        Statement::CreateIndex(CreateIndex {
             name: Some(ObjectName(name)),
             table_name: ObjectName(table_name),
             using,
@@ -2108,7 +2108,7 @@ fn parse_create_index_with_nulls_distinct() {
             include,
             nulls_distinct: Some(nulls_distinct),
             predicate: None,
-        } => {
+        }) => {
             assert_eq_vec(&["my_index"], &name);
             assert_eq_vec(&["my_table"], &table_name);
             assert_eq!(None, using);
@@ -2124,7 +2124,7 @@ fn parse_create_index_with_nulls_distinct() {
 
     let sql = "CREATE INDEX IF NOT EXISTS my_index ON my_table(col1,col2) NULLS DISTINCT";
     match pg().verified_stmt(sql) {
-        Statement::CreateIndex {
+        Statement::CreateIndex(CreateIndex {
             name: Some(ObjectName(name)),
             table_name: ObjectName(table_name),
             using,
@@ -2135,7 +2135,7 @@ fn parse_create_index_with_nulls_distinct() {
             include,
             nulls_distinct: Some(nulls_distinct),
             predicate: None,
-        } => {
+        }) => {
             assert_eq_vec(&["my_index"], &name);
             assert_eq_vec(&["my_table"], &table_name);
             assert_eq!(None, using);

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -33,7 +33,7 @@ use pretty_assertions::assert_eq;
 fn test_snowflake_create_table() {
     let sql = "CREATE TABLE _my_$table (am00unt number)";
     match snowflake_and_generic().verified_stmt(sql) {
-        Statement::CreateTable { name, .. } => {
+        Statement::CreateTable(CreateTable { name, .. }) => {
             assert_eq!("_my_$table", name.to_string());
         }
         _ => unreachable!(),
@@ -44,9 +44,9 @@ fn test_snowflake_create_table() {
 fn test_snowflake_create_transient_table() {
     let sql = "CREATE TRANSIENT TABLE CUSTOMER (id INT, name VARCHAR(255))";
     match snowflake_and_generic().verified_stmt(sql) {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             name, transient, ..
-        } => {
+        }) => {
             assert_eq!("CUSTOMER", name.to_string());
             assert!(transient)
         }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -122,11 +122,11 @@ fn pragma_eq_placeholder_style() {
 fn parse_create_table_without_rowid() {
     let sql = "CREATE TABLE t (a INT) WITHOUT ROWID";
     match sqlite_and_generic().verified_stmt(sql) {
-        Statement::CreateTable {
+        Statement::CreateTable(CreateTable {
             name,
             without_rowid: true,
             ..
-        } => {
+        }) => {
             assert_eq!("t", name.to_string());
         }
         _ => unreachable!(),
@@ -200,7 +200,7 @@ fn double_equality_operator() {
 fn parse_create_table_auto_increment() {
     let sql = "CREATE TABLE foo (bar INT PRIMARY KEY AUTOINCREMENT)";
     match sqlite_and_generic().verified_stmt(sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "foo");
             assert_eq!(
                 vec![ColumnDef {
@@ -234,7 +234,7 @@ fn parse_create_table_auto_increment() {
 fn parse_create_sqlite_quote() {
     let sql = "CREATE TABLE `PRIMARY` (\"KEY\" INT, [INDEX] INT)";
     match sqlite().verified_stmt(sql) {
-        Statement::CreateTable { name, columns, .. } => {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "`PRIMARY`");
             assert_eq!(
                 vec![
@@ -295,7 +295,7 @@ fn test_placeholder() {
 #[test]
 fn parse_create_table_with_strict() {
     let sql = "CREATE TABLE Fruits (id TEXT NOT NULL PRIMARY KEY) STRICT";
-    if let Statement::CreateTable { name, strict, .. } = sqlite().verified_stmt(sql) {
+    if let Statement::CreateTable(CreateTable { name, strict, .. }) = sqlite().verified_stmt(sql) {
         assert_eq!(name.to_string(), "Fruits");
         assert!(strict);
     }


### PR DESCRIPTION
cc @alamb, @tisonkun 

Continue moving structs as part of #1204 

The `CreateTableBuilder` could maybe be combined into the `CreateTable`. For the purposes of minimizing breaking changes I did not attempt to merge them. 