### PR TITLE
ClickHouse: create view with fields and data types

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -815,7 +815,7 @@ impl fmt::Display for ColumnDef {
 ///
 /// Syntax
 /// ```markdown
-/// <name> [OPTIONS(option, ...)]
+/// <name> [data_type][OPTIONS(option, ...)]
 ///
 /// option: <name> = <value>
 /// ```
@@ -824,18 +824,23 @@ impl fmt::Display for ColumnDef {
 /// ```sql
 /// name
 /// age OPTIONS(description = "age column", tag = "prod")
+/// created_at DateTime64
 /// ```
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct ViewColumnDef {
     pub name: Ident,
+    pub data_type: Option<DataType>,
     pub options: Option<Vec<SqlOption>>,
 }
 
 impl fmt::Display for ViewColumnDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.name)?;
+        if let Some(data_type) = self.data_type.as_ref() {
+            write!(f, " {}", data_type)?;
+        }
         if let Some(options) = self.options.as_ref() {
             write!(
                 f,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7122,7 +7122,17 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
-        Ok(ViewColumnDef { name, options })
+        let data_type = if dialect_of!(self is ClickHouseDialect) {
+            let (data_type, _) = self.parse_data_type_helper()?;
+            Some(data_type)
+        } else {
+            None
+        };
+        Ok(ViewColumnDef {
+            name,
+            data_type,
+            options,
+        })
     }
 
     /// Parse a parenthesized comma-separated list of unqualified, possibly quoted identifiers

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7123,8 +7123,7 @@ impl<'a> Parser<'a> {
             None
         };
         let data_type = if dialect_of!(self is ClickHouseDialect) {
-            let (data_type, _) = self.parse_data_type_helper()?;
-            Some(data_type)
+            Some(self.parse_data_type()?)
         } else {
             None
         };

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -261,10 +261,12 @@ fn parse_create_view_with_options() {
                 vec![
                     ViewColumnDef {
                         name: Ident::new("name"),
+                        data_type: None,
                         options: None,
                     },
                     ViewColumnDef {
                         name: Ident::new("age"),
+                        data_type: None,
                         options: Some(vec![SqlOption {
                             name: Ident::new("description"),
                             value: Expr::Value(Value::DoubleQuotedString("field age".to_string())),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6316,6 +6316,7 @@ fn parse_create_view_with_columns() {
                     .into_iter()
                     .map(|name| ViewColumnDef {
                         name,
+                        data_type: None,
                         options: None
                     })
                     .collect::<Vec<_>>()


### PR DESCRIPTION
The CREATE VIEW syntax for ClickHouse is a bit different from many warehouses in the sense that you can specify the type of the columns when creating the view instead of them being deferred.

This PR extends parsing `CREATE VIEW` with this way of declaring view in ClickHouse.

Related issue: https://github.com/sqlparser-rs/sqlparser-rs/issues/1277