### PR TITLE
Return error when AUTO_INCREMENT offset is too large

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5281,7 +5281,12 @@ impl<'a> Parser<'a> {
             let _ = self.consume_token(&Token::Eq);
             let next_token = self.next_token();
             match next_token.token {
-                Token::Number(s, _) => Some(s.parse::<u32>().expect("literal int")),
+                Token::Number(s, _) => Some(s.parse::<u32>().map_err(|e| {
+                    ParserError::ParserError(format!(
+                        "Could not parse '{s}' as u32: {e}{}",
+                        next_token.location
+                    ))
+                })?),
                 _ => self.expected("literal int", next_token)?,
             }
         } else {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -9991,3 +9991,17 @@ fn parse_select_wildcard_with_except() {
         "sql parser error: Expected identifier, found: )"
     );
 }
+
+#[test]
+fn parse_auto_increment_too_large() {
+    let dialect = GenericDialect {};
+    let u64_max = u64::MAX;
+    let sql = format!("CREATE TABLE foo (bar INT NOT NULL AUTO_INCREMENT) AUTO_INCREMENT=1{u64_max}");
+
+    let res = Parser::new(&dialect)
+        .try_with_sql(&sql)
+        .expect("tokenize to work")
+        .parse_statements();
+
+    assert!(res.is_err(), "{res:?}");
+}


### PR DESCRIPTION
Before this change the added test case would fail with a panic
```
panicked at src/parser/mod.rs:5284:62:
literal int: ParseIntError { kind: PosOverflow }
```

Closes #1303