### PR TITLE
Return errors, not panic, when integers fail to parse in `AUTO_INCREMENT` and `TOP`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9292,7 +9292,7 @@ impl<'a> Parser<'a> {
                                 return self.expected("literal number", next_token);
                             };
                             self.expect_token(&Token::RBrace)?;
-                            RepetitionQuantifier::AtMost(n.parse().expect("literal int"))
+                            RepetitionQuantifier::AtMost(Self::parse(n, token.location)?)
                         }
                         Token::Number(n, _) if self.consume_token(&Token::Comma) => {
                             let next_token = self.next_token();
@@ -9300,12 +9300,12 @@ impl<'a> Parser<'a> {
                                 Token::Number(m, _) => {
                                     self.expect_token(&Token::RBrace)?;
                                     RepetitionQuantifier::Range(
-                                        n.parse().expect("literal int"),
-                                        m.parse().expect("literal int"),
+                                        Self::parse(n, token.location)?,
+                                        Self::parse(m, token.location)?,
                                     )
                                 }
                                 Token::RBrace => {
-                                    RepetitionQuantifier::AtLeast(n.parse().expect("literal int"))
+                                    RepetitionQuantifier::AtLeast(Self::parse(n, token.location)?)
                                 }
                                 _ => {
                                     return self.expected("} or upper bound", next_token);
@@ -9314,7 +9314,7 @@ impl<'a> Parser<'a> {
                         }
                         Token::Number(n, _) => {
                             self.expect_token(&Token::RBrace)?;
-                            RepetitionQuantifier::Exactly(n.parse().expect("literal int"))
+                            RepetitionQuantifier::Exactly(Self::parse(n, token.location)?)
                         }
                         _ => return self.expected("quantifier range", token),
                     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3270,7 +3270,7 @@ impl<'a> Parser<'a> {
         s.parse::<T>().map_err(|e| {
             ParserError::ParserError(format!(
                 "Could not parse '{s}' as {}: {e}{loc}",
-                std::any::type_name::<T>()
+                core::any::type_name::<T>()
             ))
         })
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5281,7 +5281,12 @@ impl<'a> Parser<'a> {
             let _ = self.consume_token(&Token::Eq);
             let next_token = self.next_token();
             match next_token.token {
-                Token::Number(s, _) => Some(s.parse::<u32>().expect("literal int")),
+                Token::Number(s, _) => Some(s.parse::<u32>().map_err(|e| {
+                    ParserError::ParserError(format!(
+                        "Could not parse '{s}' as u32: {e}{}",
+                        next_token.location
+                    ))
+                })?),
                 _ => self.expected("literal int", next_token)?,
             }
         } else {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -9991,3 +9991,18 @@ fn parse_select_wildcard_with_except() {
         "sql parser error: Expected identifier, found: )"
     );
 }
+
+#[test]
+fn parse_auto_increment_too_large() {
+    let dialect = GenericDialect {};
+    let u64_max = u64::MAX;
+    let sql =
+        format!("CREATE TABLE foo (bar INT NOT NULL AUTO_INCREMENT) AUTO_INCREMENT=1{u64_max}");
+
+    let res = Parser::new(&dialect)
+        .try_with_sql(&sql)
+        .expect("tokenize to work")
+        .parse_statements();
+
+    assert!(res.is_err(), "{res:?}");
+}


### PR DESCRIPTION
This fixes several places where the code currently panic when parsing an integer value. This change makes us return the error instead.

This replaces #1304 by also handling one more cases and introducing a helper method that can be used in all places when an integer value needs to be parsed.

Closes #1303 