### PR TITLE
CreateIndex: Move Display fmt to struct

### DIFF
--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -47,6 +47,49 @@ pub struct CreateIndex {
     pub nulls_distinct: Option<bool>,
     pub predicate: Option<Expr>,
 }
+
+impl Display for CreateIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "CREATE {unique}INDEX {concurrently}{if_not_exists}",
+            unique = if self.unique { "UNIQUE " } else { "" },
+            concurrently = if self.concurrently {
+                "CONCURRENTLY "
+            } else {
+                ""
+            },
+            if_not_exists = if self.if_not_exists {
+                "IF NOT EXISTS "
+            } else {
+                ""
+            },
+        )?;
+        if let Some(value) = &self.name {
+            write!(f, "{value} ")?;
+        }
+        write!(f, "ON {}", self.table_name)?;
+        if let Some(value) = &self.using {
+            write!(f, " USING {value} ")?;
+        }
+        write!(f, "({})", display_separated(&self.columns, ","))?;
+        if !self.include.is_empty() {
+            write!(f, " INCLUDE ({})", display_separated(&self.include, ","))?;
+        }
+        if let Some(value) = self.nulls_distinct {
+            if value {
+                write!(f, " NULLS DISTINCT")?;
+            } else {
+                write!(f, " NULLS NOT DISTINCT")?;
+            }
+        }
+        if let Some(predicate) = &self.predicate {
+            write!(f, " WHERE {predicate}")?;
+        }
+        Ok(())
+    }
+}
+
 /// CREATE TABLE statement.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3383,48 +3383,7 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::CreateIndex(CreateIndex {
-                name,
-                table_name,
-                using,
-                columns,
-                unique,
-                concurrently,
-                if_not_exists,
-                include,
-                nulls_distinct,
-                predicate,
-            }) => {
-                write!(
-                    f,
-                    "CREATE {unique}INDEX {concurrently}{if_not_exists}",
-                    unique = if *unique { "UNIQUE " } else { "" },
-                    concurrently = if *concurrently { "CONCURRENTLY " } else { "" },
-                    if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
-                )?;
-                if let Some(value) = name {
-                    write!(f, "{value} ")?;
-                }
-                write!(f, "ON {table_name}")?;
-                if let Some(value) = using {
-                    write!(f, " USING {value} ")?;
-                }
-                write!(f, "({})", display_separated(columns, ","))?;
-                if !include.is_empty() {
-                    write!(f, " INCLUDE ({})", display_separated(include, ","))?;
-                }
-                if let Some(value) = nulls_distinct {
-                    if *value {
-                        write!(f, " NULLS DISTINCT")?;
-                    } else {
-                        write!(f, " NULLS NOT DISTINCT")?;
-                    }
-                }
-                if let Some(predicate) = predicate {
-                    write!(f, " WHERE {predicate}")?;
-                }
-                Ok(())
-            }
+            Statement::CreateIndex(create_index) => create_index.fmt(f),
             Statement::CreateExtension {
                 name,
                 if_not_exists,


### PR DESCRIPTION
Move the Display trait `fmt` implementation to the CreateIndex struct to to allow for display!

The struct was created in a0f511cb21efd9e992fb4c6ef273ef41802d308c with the CreateTable `fmt` being moved, but the CreateIndex was not.

Follows up from #1291