### PR TITLE
Fix typo in `sqlparser-derive` README

### DIFF
--- a/derive/README.md
+++ b/derive/README.md
@@ -97,7 +97,7 @@ impl Visit for TableFactor {
         match self {
             Self::Table { name, alias } => {
                 visitor.pre_visit_relation(name)?;
-                alias.visit(name)?;
+                name.visit(visitor)?;
                 visitor.post_visit_relation(name)?;
                 alias.visit(visitor)?;
             }


### PR DESCRIPTION
This is just from reading it, but I think that bit is wrong.