### PR TITLE
Re-enable trailing commas in DCL

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -886,34 +886,3 @@ pub const RESERVED_FOR_COLUMN_ALIAS: &[Keyword] = &[
     Keyword::INTO,
     Keyword::END,
 ];
-
-/// Can't be used as a column alias, so that `SELECT <expr> alias`
-/// can be parsed unambiguously without looking ahead.
-pub const RESERVED_FOR_GRANT_PERMISSIONS: &[Keyword] = &[
-    // Reserved as both a table and a column alias:
-    Keyword::ON,
-    Keyword::WITH,
-    Keyword::EXPLAIN,
-    Keyword::ANALYZE,
-    Keyword::WHERE,
-    Keyword::GROUP,
-    Keyword::SORT,
-    Keyword::HAVING,
-    Keyword::ORDER,
-    Keyword::TOP,
-    Keyword::LATERAL,
-    Keyword::VIEW,
-    Keyword::LIMIT,
-    Keyword::OFFSET,
-    Keyword::FETCH,
-    Keyword::UNION,
-    Keyword::EXCEPT,
-    Keyword::INTERSECT,
-    Keyword::CLUSTER,
-    Keyword::DISTRIBUTE,
-    Keyword::RETURNING,
-    // Reserved only as a column alias in the `SELECT` clause
-    Keyword::FROM,
-    Keyword::INTO,
-    Keyword::END,
-];

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -886,3 +886,34 @@ pub const RESERVED_FOR_COLUMN_ALIAS: &[Keyword] = &[
     Keyword::INTO,
     Keyword::END,
 ];
+
+/// Can't be used as a column alias, so that `SELECT <expr> alias`
+/// can be parsed unambiguously without looking ahead.
+pub const RESERVED_FOR_GRANT_PERMISSIONS: &[Keyword] = &[
+    // Reserved as both a table and a column alias:
+    Keyword::ON,
+    Keyword::WITH,
+    Keyword::EXPLAIN,
+    Keyword::ANALYZE,
+    Keyword::WHERE,
+    Keyword::GROUP,
+    Keyword::SORT,
+    Keyword::HAVING,
+    Keyword::ORDER,
+    Keyword::TOP,
+    Keyword::LATERAL,
+    Keyword::VIEW,
+    Keyword::LIMIT,
+    Keyword::OFFSET,
+    Keyword::FETCH,
+    Keyword::UNION,
+    Keyword::EXCEPT,
+    Keyword::INTERSECT,
+    Keyword::CLUSTER,
+    Keyword::DISTRIBUTE,
+    Keyword::RETURNING,
+    // Reserved only as a column alias in the `SELECT` clause
+    Keyword::FROM,
+    Keyword::INTO,
+    Keyword::END,
+];

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3288,9 +3288,7 @@ impl<'a> Parser<'a> {
                 break;
             } else if self.options.trailing_commas {
                 match self.peek_token().token {
-                    Token::Word(kw)
-                        if keywords::RESERVED_FOR_GRANT_PERMISSIONS.contains(&kw.keyword) =>
-                    {
+                    Token::Word(kw) if kw.keyword == Keyword::ON => {
                         break;
                     }
                     Token::RParen

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8895,7 +8895,7 @@ fn parse_trailing_comma() {
     );
 
     trailing_commas.one_statement_parses_to(
-        "GRANT USAGE, SELECT, INSERT ON p TO u",
+        "GRANT USAGE, SELECT, INSERT, ON p TO u",
         "GRANT USAGE, SELECT, INSERT ON p TO u",
     );
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8894,6 +8894,11 @@ fn parse_trailing_comma() {
         "CREATE TABLE employees (name TEXT, age INT)",
     );
 
+    trailing_commas.one_statement_parses_to(
+        "GRANT USAGE, SELECT, INSERT ON p TO u",
+        "GRANT USAGE, SELECT, INSERT ON p TO u",
+    );
+
     trailing_commas.verified_stmt("SELECT album_id, name FROM track");
 
     trailing_commas.verified_stmt("SELECT * FROM track ORDER BY milliseconds");
@@ -8911,6 +8916,13 @@ fn parse_trailing_comma() {
             .parse_sql_statements("SELECT name, age, from employees;")
             .unwrap_err(),
         ParserError::ParserError("Expected an expression, found: from".to_string())
+    );
+
+    assert_eq!(
+        trailing_commas
+            .parse_sql_statements("REVOKE USAGE, SELECT, ON p TO u")
+            .unwrap_err(),
+        ParserError::ParserError("Expected a privilege keyword, found: ON".to_string())
     );
 
     assert_eq!(


### PR DESCRIPTION
This PR should close #1211 and is a follow-up to #1212 which ignores trailing commas option when parsing DCLs.

Tests included.

cc @lovasoa 