### PR TITLE
Improve error messages with additional colons

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3116,7 +3116,7 @@ impl<'a> Parser<'a> {
     /// Report `found` was encountered instead of `expected`
     pub fn expected<T>(&self, expected: &str, found: TokenWithLocation) -> Result<T, ParserError> {
         parser_err!(
-            format!("Expected {expected}, found: {found}"),
+            format!("Expected: {expected}, found: {found}"),
             found.location
         )
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11581,7 +11581,7 @@ mod tests {
         assert_eq!(
             ast,
             Err(ParserError::TokenizerError(
-                "Unterminated string literal at Line: 1, Column 5".to_string()
+                "Unterminated string literal at Line: 1, Column: 5".to_string()
             ))
         );
     }
@@ -11593,7 +11593,7 @@ mod tests {
         assert_eq!(
             ast,
             Err(ParserError::ParserError(
-                "Expected [NOT] NULL or TRUE|FALSE or [NOT] DISTINCT FROM after IS, found: a at Line: 1, Column 16"
+                "Expected: [NOT] NULL or TRUE|FALSE or [NOT] DISTINCT FROM after IS, found: a at Line: 1, Column: 16"
                     .to_string()
             ))
         );

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1816,7 +1816,7 @@ mod tests {
             use std::error::Error;
             assert!(err.source().is_none());
         }
-        assert_eq!(err.to_string(), "test at Line: 1, Column 1");
+        assert_eq!(err.to_string(), "test at Line: 1, Column: 1");
     }
 
     #[test]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -429,7 +429,7 @@ impl fmt::Display for Location {
         write!(
             f,
             // TODO: use standard compiler location syntax (<path>:<line>:<col>)
-            " at Line: {}, Column {}",
+            " at Line: {}, Column: {}",
             self.line, self.column,
         )
     }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -535,7 +535,7 @@ fn parse_invalid_brackets() {
         bigquery_and_generic()
             .parse_sql_statements(sql)
             .unwrap_err(),
-        ParserError::ParserError("Expected (, found: >".to_string())
+        ParserError::ParserError("Expected: (, found: >".to_string())
     );
 
     let sql = "CREATE TABLE table (x STRUCT<STRUCT<INT64>>>)";
@@ -544,7 +544,7 @@ fn parse_invalid_brackets() {
             .parse_sql_statements(sql)
             .unwrap_err(),
         ParserError::ParserError(
-            "Expected ',' or ')' after column definition, found: >".to_string()
+            "Expected: ',' or ')' after column definition, found: >".to_string()
         )
     );
 }
@@ -1753,11 +1753,11 @@ fn parse_merge_invalid_statements() {
     for (sql, err_msg) in [
         (
             "MERGE T USING U ON TRUE WHEN MATCHED BY TARGET AND 1 THEN DELETE",
-            "Expected THEN, found: BY",
+            "Expected: THEN, found: BY",
         ),
         (
             "MERGE T USING U ON TRUE WHEN MATCHED BY SOURCE AND 1 THEN DELETE",
-            "Expected THEN, found: BY",
+            "Expected: THEN, found: BY",
         ),
         (
             "MERGE T USING U ON TRUE WHEN NOT MATCHED BY SOURCE THEN INSERT(a) VALUES (b)",
@@ -1898,13 +1898,13 @@ fn parse_big_query_declare() {
 
     let error_sql = "DECLARE x";
     assert_eq!(
-        ParserError::ParserError("Expected a data type name, found: EOF".to_owned()),
+        ParserError::ParserError("Expected: a data type name, found: EOF".to_owned()),
         bigquery().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE x 42";
     assert_eq!(
-        ParserError::ParserError("Expected a data type name, found: 42".to_owned()),
+        ParserError::ParserError("Expected: a data type name, found: 42".to_owned()),
         bigquery().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -2069,7 +2069,7 @@ fn test_bigquery_create_function() {
                 "AS ((SELECT 1 FROM mytable)) ",
                 "OPTIONS(a = [1, 2])",
             ),
-            "Expected end of statement, found: OPTIONS",
+            "Expected: end of statement, found: OPTIONS",
         ),
         (
             concat!(
@@ -2077,7 +2077,7 @@ fn test_bigquery_create_function() {
                 "IMMUTABLE ",
                 "AS ((SELECT 1 FROM mytable)) ",
             ),
-            "Expected AS, found: IMMUTABLE",
+            "Expected: AS, found: IMMUTABLE",
         ),
         (
             concat!(
@@ -2085,7 +2085,7 @@ fn test_bigquery_create_function() {
                 "AS \"console.log('hello');\" ",
                 "LANGUAGE js ",
             ),
-            "Expected end of statement, found: LANGUAGE",
+            "Expected: end of statement, found: LANGUAGE",
         ),
     ];
     for (sql, error) in error_sqls {
@@ -2116,7 +2116,7 @@ fn test_bigquery_trim() {
     // missing comma separation
     let error_sql = "SELECT TRIM('xyz' 'a')";
     assert_eq!(
-        ParserError::ParserError("Expected ), found: 'a'".to_owned()),
+        ParserError::ParserError("Expected: ), found: 'a'".to_owned()),
         bigquery().parse_sql_statements(error_sql).unwrap_err()
     );
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -115,7 +115,7 @@ fn parse_replace_into() {
     let sql = "REPLACE INTO public.customer (id, name, active) VALUES (1, 2, 3)";
 
     assert_eq!(
-        ParserError::ParserError("Unsupported statement REPLACE at Line: 1, Column 9".to_string()),
+        ParserError::ParserError("Unsupported statement REPLACE at Line: 1, Column: 9".to_string()),
         Parser::parse_sql(&dialect, sql,).unwrap_err(),
     )
 }
@@ -199,7 +199,7 @@ fn parse_insert_default_values() {
     let insert_with_columns_and_default_values = "INSERT INTO test_table (test_col) DEFAULT VALUES";
     assert_eq!(
         ParserError::ParserError(
-            "Expected SELECT, VALUES, or a subquery in the query body, found: DEFAULT".to_string()
+            "Expected: SELECT, VALUES, or a subquery in the query body, found: DEFAULT".to_string()
         ),
         parse_sql_statements(insert_with_columns_and_default_values).unwrap_err()
     );
@@ -207,20 +207,20 @@ fn parse_insert_default_values() {
     let insert_with_default_values_and_hive_after_columns =
         "INSERT INTO test_table DEFAULT VALUES (some_column)";
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: (".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: (".to_string()),
         parse_sql_statements(insert_with_default_values_and_hive_after_columns).unwrap_err()
     );
 
     let insert_with_default_values_and_hive_partition =
         "INSERT INTO test_table DEFAULT VALUES PARTITION (some_column)";
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: PARTITION".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: PARTITION".to_string()),
         parse_sql_statements(insert_with_default_values_and_hive_partition).unwrap_err()
     );
 
     let insert_with_default_values_and_values_list = "INSERT INTO test_table DEFAULT VALUES (1)";
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: (".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: (".to_string()),
         parse_sql_statements(insert_with_default_values_and_values_list).unwrap_err()
     );
 }
@@ -319,14 +319,14 @@ fn parse_update() {
     let sql = "UPDATE t WHERE 1";
     let res = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected SET, found: WHERE".to_string()),
+        ParserError::ParserError("Expected: SET, found: WHERE".to_string()),
         res.unwrap_err()
     );
 
     let sql = "UPDATE t SET a = 1 extrabadstuff";
     let res = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: extrabadstuff".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: extrabadstuff".to_string()),
         res.unwrap_err()
     );
 }
@@ -577,7 +577,7 @@ fn parse_delete_without_from_error() {
     let dialects = all_dialects_except(|d| d.is::<BigQueryDialect>() || d.is::<GenericDialect>());
     let res = dialects.parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected FROM, found: WHERE".to_string()),
+        ParserError::ParserError("Expected: FROM, found: WHERE".to_string()),
         res.unwrap_err()
     );
 }
@@ -892,7 +892,7 @@ fn parse_select_distinct_on() {
 fn parse_select_distinct_missing_paren() {
     let result = parse_sql_statements("SELECT DISTINCT (name, id FROM customer");
     assert_eq!(
-        ParserError::ParserError("Expected ), found: FROM".to_string()),
+        ParserError::ParserError("Expected: ), found: FROM".to_string()),
         result.unwrap_err(),
     );
 }
@@ -936,7 +936,7 @@ fn parse_select_into() {
     let sql = "SELECT * INTO table0 asdf FROM table1";
     let result = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: asdf".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: asdf".to_string()),
         result.unwrap_err()
     )
 }
@@ -973,7 +973,7 @@ fn parse_select_wildcard() {
     let sql = "SELECT * + * FROM foo;";
     let result = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: +".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: +".to_string()),
         result.unwrap_err(),
     );
 }
@@ -1002,7 +1002,7 @@ fn parse_column_aliases() {
         assert_eq!(&Expr::Value(number("1")), right.as_ref());
         assert_eq!(&Ident::new("newname"), alias);
     } else {
-        panic!("Expected ExprWithAlias")
+        panic!("Expected: ExprWithAlias")
     }
 
     // alias without AS is parsed correctly:
@@ -1013,13 +1013,13 @@ fn parse_column_aliases() {
 fn test_eof_after_as() {
     let res = parse_sql_statements("SELECT foo AS");
     assert_eq!(
-        ParserError::ParserError("Expected an identifier after AS, found: EOF".to_string()),
+        ParserError::ParserError("Expected: an identifier after AS, found: EOF".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("SELECT 1 FROM foo AS");
     assert_eq!(
-        ParserError::ParserError("Expected an identifier after AS, found: EOF".to_string()),
+        ParserError::ParserError("Expected: an identifier after AS, found: EOF".to_string()),
         res.unwrap_err()
     );
 }
@@ -1104,7 +1104,7 @@ fn parse_not() {
 fn parse_invalid_infix_not() {
     let res = parse_sql_statements("SELECT c FROM t WHERE c NOT (");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: NOT".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: NOT".to_string()),
         res.unwrap_err(),
     );
 }
@@ -1177,11 +1177,11 @@ fn parse_exponent_in_select() -> Result<(), ParserError> {
 
     let select = match select.pop().unwrap() {
         Statement::Query(inner) => *inner,
-        _ => panic!("Expected Query"),
+        _ => panic!("Expected: Query"),
     };
     let select = match *select.body {
         SetExpr::Select(inner) => *inner,
-        _ => panic!("Expected SetExpr::Select"),
+        _ => panic!("Expected: SetExpr::Select"),
     };
 
     assert_eq!(
@@ -1810,7 +1810,7 @@ fn parse_in_error() {
     let sql = "SELECT * FROM customers WHERE segment in segment";
     let res = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected (, found: segment".to_string()),
+        ParserError::ParserError("Expected: (, found: segment".to_string()),
         res.unwrap_err()
     );
 }
@@ -2023,14 +2023,14 @@ fn parse_tuple_invalid() {
     let sql = "select (1";
     let res = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected ), found: EOF".to_string()),
+        ParserError::ParserError("Expected: ), found: EOF".to_string()),
         res.unwrap_err()
     );
 
     let sql = "select (), 2";
     let res = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected an expression:, found: )".to_string()),
+        ParserError::ParserError("Expected: an expression:, found: )".to_string()),
         res.unwrap_err()
     );
 }
@@ -2442,7 +2442,7 @@ fn parse_extract() {
     let dialects = all_dialects_except(|d| d.is::<SnowflakeDialect>() || d.is::<GenericDialect>());
     let res = dialects.parse_sql_statements("SELECT EXTRACT(JIFFY FROM d)");
     assert_eq!(
-        ParserError::ParserError("Expected date/time field, found: JIFFY".to_string()),
+        ParserError::ParserError("Expected: date/time field, found: JIFFY".to_string()),
         res.unwrap_err()
     );
 }
@@ -2481,7 +2481,7 @@ fn parse_ceil_datetime() {
     let dialects = all_dialects_except(|d| d.is::<SnowflakeDialect>() || d.is::<GenericDialect>());
     let res = dialects.parse_sql_statements("SELECT CEIL(d TO JIFFY) FROM df");
     assert_eq!(
-        ParserError::ParserError("Expected date/time field, found: JIFFY".to_string()),
+        ParserError::ParserError("Expected: date/time field, found: JIFFY".to_string()),
         res.unwrap_err()
     );
 }
@@ -2508,7 +2508,7 @@ fn parse_floor_datetime() {
     let dialects = all_dialects_except(|d| d.is::<SnowflakeDialect>() || d.is::<GenericDialect>());
     let res = dialects.parse_sql_statements("SELECT FLOOR(d TO JIFFY) FROM df");
     assert_eq!(
-        ParserError::ParserError("Expected date/time field, found: JIFFY".to_string()),
+        ParserError::ParserError("Expected: date/time field, found: JIFFY".to_string()),
         res.unwrap_err()
     );
 }
@@ -2709,7 +2709,7 @@ fn parse_window_function_null_treatment_arg() {
     let sql = "SELECT LAG(1 IGNORE NULLS) IGNORE NULLS OVER () FROM t1";
     assert_eq!(
         dialects.parse_sql_statements(sql).unwrap_err(),
-        ParserError::ParserError("Expected end of statement, found: NULLS".to_string())
+        ParserError::ParserError("Expected: end of statement, found: NULLS".to_string())
     );
 
     let sql = "SELECT LAG(1 IGNORE NULLS) IGNORE NULLS OVER () FROM t1";
@@ -2717,7 +2717,7 @@ fn parse_window_function_null_treatment_arg() {
         all_dialects_where(|d| !d.supports_window_function_null_treatment_arg())
             .parse_sql_statements(sql)
             .unwrap_err(),
-        ParserError::ParserError("Expected ), found: IGNORE".to_string())
+        ParserError::ParserError("Expected: ), found: IGNORE".to_string())
     );
 }
 
@@ -2907,13 +2907,13 @@ fn parse_create_table() {
     assert!(res
         .unwrap_err()
         .to_string()
-        .contains("Expected \',\' or \')\' after column definition, found: GARBAGE"));
+        .contains("Expected: \',\' or \')\' after column definition, found: GARBAGE"));
 
     let res = parse_sql_statements("CREATE TABLE t (a int NOT NULL CONSTRAINT foo)");
     assert!(res
         .unwrap_err()
         .to_string()
-        .contains("Expected constraint details after CONSTRAINT <name>"));
+        .contains("Expected: constraint details after CONSTRAINT <name>"));
 }
 
 #[test]
@@ -3052,7 +3052,7 @@ fn parse_create_table_with_constraint_characteristics() {
     assert!(res
         .unwrap_err()
         .to_string()
-        .contains("Expected \',\' or \')\' after column definition, found: NOT"));
+        .contains("Expected: \',\' or \')\' after column definition, found: NOT"));
 
     let res = parse_sql_statements("CREATE TABLE t (
         a int NOT NULL,
@@ -3061,7 +3061,7 @@ fn parse_create_table_with_constraint_characteristics() {
     assert!(res
         .unwrap_err()
         .to_string()
-        .contains("Expected \',\' or \')\' after column definition, found: ENFORCED"));
+        .contains("Expected: \',\' or \')\' after column definition, found: ENFORCED"));
 
     let res = parse_sql_statements("CREATE TABLE t (
         a int NOT NULL,
@@ -3070,7 +3070,7 @@ fn parse_create_table_with_constraint_characteristics() {
     assert!(res
         .unwrap_err()
         .to_string()
-        .contains("Expected \',\' or \')\' after column definition, found: INITIALLY"));
+        .contains("Expected: \',\' or \')\' after column definition, found: INITIALLY"));
 }
 
 #[test]
@@ -3161,7 +3161,7 @@ fn parse_create_table_column_constraint_characteristics() {
     assert!(res
         .unwrap_err()
         .to_string()
-        .contains("Expected one of DEFERRED or IMMEDIATE, found: BADVALUE"));
+        .contains("Expected: one of DEFERRED or IMMEDIATE, found: BADVALUE"));
 
     let res = parse_sql_statements(
         "CREATE TABLE t (a int NOT NULL UNIQUE INITIALLY IMMEDIATE DEFERRABLE INITIALLY DEFERRED)",
@@ -3260,7 +3260,7 @@ fn parse_create_table_hive_array() {
 
     assert_eq!(
         dialects.parse_sql_statements(sql).unwrap_err(),
-        ParserError::ParserError("Expected >, found: )".to_string())
+        ParserError::ParserError("Expected: >, found: )".to_string())
     );
 }
 
@@ -4035,7 +4035,7 @@ fn parse_alter_table_alter_column_type() {
     let res =
         dialect.parse_sql_statements(&format!("{alter_stmt} ALTER COLUMN is_active TYPE TEXT"));
     assert_eq!(
-        ParserError::ParserError("Expected SET/DROP NOT NULL, SET DEFAULT, or SET DATA TYPE after ALTER COLUMN, found: TYPE".to_string()),
+        ParserError::ParserError("Expected: SET/DROP NOT NULL, SET DEFAULT, or SET DATA TYPE after ALTER COLUMN, found: TYPE".to_string()),
         res.unwrap_err()
     );
 
@@ -4043,7 +4043,7 @@ fn parse_alter_table_alter_column_type() {
         "{alter_stmt} ALTER COLUMN is_active SET DATA TYPE TEXT USING 'text'"
     ));
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: USING".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: USING".to_string()),
         res.unwrap_err()
     );
 }
@@ -4082,7 +4082,7 @@ fn parse_alter_table_drop_constraint() {
 
     let res = parse_sql_statements(&format!("{alter_stmt} DROP CONSTRAINT is_active TEXT"));
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: TEXT".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: TEXT".to_string()),
         res.unwrap_err()
     );
 }
@@ -4091,14 +4091,14 @@ fn parse_alter_table_drop_constraint() {
 fn parse_bad_constraint() {
     let res = parse_sql_statements("ALTER TABLE tab ADD");
     assert_eq!(
-        ParserError::ParserError("Expected identifier, found: EOF".to_string()),
+        ParserError::ParserError("Expected: identifier, found: EOF".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("CREATE TABLE tab (foo int,");
     assert_eq!(
         ParserError::ParserError(
-            "Expected column name or constraint definition, found: EOF".to_string()
+            "Expected: column name or constraint definition, found: EOF".to_string()
         ),
         res.unwrap_err()
     );
@@ -4440,7 +4440,7 @@ fn parse_window_clause() {
     let dialects = all_dialects_except(|d| d.is::<BigQueryDialect>() || d.is::<GenericDialect>());
     let res = dialects.parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected (, found: window2".to_string()),
+        ParserError::ParserError("Expected: (, found: window2".to_string()),
         res.unwrap_err()
     );
 }
@@ -4851,13 +4851,13 @@ fn parse_interval() {
 
     let result = parse_sql_statements("SELECT INTERVAL '1' SECOND TO SECOND");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: SECOND".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: SECOND".to_string()),
         result.unwrap_err(),
     );
 
     let result = parse_sql_statements("SELECT INTERVAL '10' HOUR (1) TO HOUR (2)");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: (".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: (".to_string()),
         result.unwrap_err(),
     );
 
@@ -5198,13 +5198,13 @@ fn parse_table_function() {
 
     let res = parse_sql_statements("SELECT * FROM TABLE '1' AS a");
     assert_eq!(
-        ParserError::ParserError("Expected (, found: \'1\'".to_string()),
+        ParserError::ParserError("Expected: (, found: \'1\'".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("SELECT * FROM TABLE (FUN(a) AS a");
     assert_eq!(
-        ParserError::ParserError("Expected ), found: AS".to_string()),
+        ParserError::ParserError("Expected: ), found: AS".to_string()),
         res.unwrap_err()
     );
 }
@@ -5752,7 +5752,7 @@ fn parse_natural_join() {
 
     let sql = "SELECT * FROM t1 natural";
     assert_eq!(
-        ParserError::ParserError("Expected a join type after NATURAL, found: EOF".to_string()),
+        ParserError::ParserError("Expected: a join type after NATURAL, found: EOF".to_string()),
         parse_sql_statements(sql).unwrap_err(),
     );
 }
@@ -5833,7 +5833,7 @@ fn parse_join_syntax_variants() {
 
     let res = parse_sql_statements("SELECT * FROM a OUTER JOIN b ON 1");
     assert_eq!(
-        ParserError::ParserError("Expected APPLY, found: JOIN".to_string()),
+        ParserError::ParserError("Expected: APPLY, found: JOIN".to_string()),
         res.unwrap_err()
     );
 }
@@ -5871,7 +5871,7 @@ fn parse_ctes() {
         Expr::Subquery(ref subquery) => {
             assert_ctes_in_select(&cte_sqls, subquery.as_ref());
         }
-        _ => panic!("Expected subquery"),
+        _ => panic!("Expected: subquery"),
     }
     // CTE in a derived table
     let sql = &format!("SELECT * FROM ({with})");
@@ -5880,13 +5880,13 @@ fn parse_ctes() {
         TableFactor::Derived { subquery, .. } => {
             assert_ctes_in_select(&cte_sqls, subquery.as_ref())
         }
-        _ => panic!("Expected derived table"),
+        _ => panic!("Expected: derived table"),
     }
     // CTE in a view
     let sql = &format!("CREATE VIEW v AS {with}");
     match verified_stmt(sql) {
         Statement::CreateView { query, .. } => assert_ctes_in_select(&cte_sqls, &query),
-        _ => panic!("Expected CREATE VIEW"),
+        _ => panic!("Expected: CREATE VIEW"),
     }
     // CTE in a CTE...
     let sql = &format!("WITH outer_cte AS ({with}) SELECT * FROM outer_cte");
@@ -6047,7 +6047,7 @@ fn parse_multiple_statements() {
         // Check that forgetting the semicolon results in an error:
         let res = parse_sql_statements(&(sql1.to_owned() + " " + sql2_kw + sql2_rest));
         assert_eq!(
-            ParserError::ParserError("Expected end of statement, found: ".to_string() + sql2_kw),
+            ParserError::ParserError("Expected: end of statement, found: ".to_string() + sql2_kw),
             res.unwrap_err()
         );
     }
@@ -6102,7 +6102,7 @@ fn parse_overlay() {
         "SELECT OVERLAY('abccccde' PLACING 'abc' FROM 3 FOR 12)",
     );
     assert_eq!(
-        ParserError::ParserError("Expected PLACING, found: FROM".to_owned()),
+        ParserError::ParserError("Expected: PLACING, found: FROM".to_owned()),
         parse_sql_statements("SELECT OVERLAY('abccccde' FROM 3)").unwrap_err(),
     );
 
@@ -6151,7 +6151,7 @@ fn parse_trim() {
     );
 
     assert_eq!(
-        ParserError::ParserError("Expected ), found: 'xyz'".to_owned()),
+        ParserError::ParserError("Expected: ), found: 'xyz'".to_owned()),
         parse_sql_statements("SELECT TRIM(FOO 'xyz' FROM 'xyzfooxyz')").unwrap_err()
     );
 
@@ -6173,7 +6173,7 @@ fn parse_trim() {
         options: None,
     };
     assert_eq!(
-        ParserError::ParserError("Expected ), found: 'a'".to_owned()),
+        ParserError::ParserError("Expected: ), found: 'a'".to_owned()),
         all_expected_snowflake
             .parse_sql_statements("SELECT TRIM('xyz', 'a')")
             .unwrap_err()
@@ -6210,7 +6210,7 @@ fn parse_exists_subquery() {
         .parse_sql_statements("SELECT EXISTS (");
     assert_eq!(
         ParserError::ParserError(
-            "Expected SELECT, VALUES, or a subquery in the query body, found: EOF".to_string()
+            "Expected: SELECT, VALUES, or a subquery in the query body, found: EOF".to_string()
         ),
         res.unwrap_err(),
     );
@@ -6219,7 +6219,7 @@ fn parse_exists_subquery() {
         .parse_sql_statements("SELECT EXISTS (NULL)");
     assert_eq!(
         ParserError::ParserError(
-            "Expected SELECT, VALUES, or a subquery in the query body, found: NULL".to_string()
+            "Expected: SELECT, VALUES, or a subquery in the query body, found: NULL".to_string()
         ),
         res.unwrap_err(),
     );
@@ -6581,7 +6581,7 @@ fn parse_drop_table() {
 
     let sql = "DROP TABLE";
     assert_eq!(
-        ParserError::ParserError("Expected identifier, found: EOF".to_string()),
+        ParserError::ParserError("Expected: identifier, found: EOF".to_string()),
         parse_sql_statements(sql).unwrap_err(),
     );
 
@@ -6613,7 +6613,7 @@ fn parse_drop_view() {
 fn parse_invalid_subquery_without_parens() {
     let res = parse_sql_statements("SELECT SELECT 1 FROM bar WHERE 1=1 FROM baz");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: 1".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: 1".to_string()),
         res.unwrap_err()
     );
 }
@@ -6826,7 +6826,7 @@ fn lateral_derived() {
     let sql = "SELECT * FROM LATERAL UNNEST ([10,20,30]) as numbers WITH OFFSET;";
     let res = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: WITH".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: WITH".to_string()),
         res.unwrap_err()
     );
 
@@ -6834,7 +6834,7 @@ fn lateral_derived() {
     let res = parse_sql_statements(sql);
     assert_eq!(
         ParserError::ParserError(
-            "Expected SELECT, VALUES, or a subquery in the query body, found: b".to_string()
+            "Expected: SELECT, VALUES, or a subquery in the query body, found: b".to_string()
         ),
         res.unwrap_err()
     );
@@ -6952,19 +6952,19 @@ fn parse_start_transaction() {
 
     let res = parse_sql_statements("START TRANSACTION ISOLATION LEVEL BAD");
     assert_eq!(
-        ParserError::ParserError("Expected isolation level, found: BAD".to_string()),
+        ParserError::ParserError("Expected: isolation level, found: BAD".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("START TRANSACTION BAD");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: BAD".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: BAD".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("START TRANSACTION READ ONLY,");
     assert_eq!(
-        ParserError::ParserError("Expected transaction mode, found: EOF".to_string()),
+        ParserError::ParserError("Expected: transaction mode, found: EOF".to_string()),
         res.unwrap_err()
     );
 }
@@ -7050,8 +7050,8 @@ fn parse_set_variable() {
     }
 
     let error_sqls = [
-        ("SET (a, b, c) = (1, 2, 3", "Expected ), found: EOF"),
-        ("SET (a, b, c) = 1, 2, 3", "Expected (, found: 1"),
+        ("SET (a, b, c) = (1, 2, 3", "Expected: ), found: EOF"),
+        ("SET (a, b, c) = 1, 2, 3", "Expected: (, found: 1"),
     ];
     for (sql, error) in error_sqls {
         assert_eq!(
@@ -8051,19 +8051,19 @@ fn parse_offset_and_limit() {
     // Can't repeat OFFSET / LIMIT
     let res = parse_sql_statements("SELECT foo FROM bar OFFSET 2 OFFSET 2");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: OFFSET".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: OFFSET".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("SELECT foo FROM bar LIMIT 2 LIMIT 2");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: LIMIT".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: LIMIT".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("SELECT foo FROM bar OFFSET 2 LIMIT 2 OFFSET 2");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: OFFSET".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: OFFSET".to_string()),
         res.unwrap_err()
     );
 }
@@ -8132,7 +8132,7 @@ fn parse_position_negative() {
     let sql = "SELECT POSITION(foo IN) from bar";
     let res = parse_sql_statements(sql);
     assert_eq!(
-        ParserError::ParserError("Expected an expression:, found: )".to_string()),
+        ParserError::ParserError("Expected: an expression:, found: )".to_string()),
         res.unwrap_err()
     );
 }
@@ -8190,7 +8190,7 @@ fn parse_is_boolean() {
     let res = parse_sql_statements(sql);
     assert_eq!(
         ParserError::ParserError(
-            "Expected [NOT] NULL or TRUE|FALSE or [NOT] DISTINCT FROM after IS, found: 0"
+            "Expected: [NOT] NULL or TRUE|FALSE or [NOT] DISTINCT FROM after IS, found: 0"
                 .to_string()
         ),
         res.unwrap_err()
@@ -8383,7 +8383,7 @@ fn parse_cache_table() {
     let res = parse_sql_statements("CACHE TABLE 'table_name' foo");
     assert_eq!(
         ParserError::ParserError(
-            "Expected SELECT, VALUES, or a subquery in the query body, found: foo".to_string()
+            "Expected: SELECT, VALUES, or a subquery in the query body, found: foo".to_string()
         ),
         res.unwrap_err()
     );
@@ -8391,7 +8391,7 @@ fn parse_cache_table() {
     let res = parse_sql_statements("CACHE flag TABLE 'table_name' OPTIONS('K1'='V1') foo");
     assert_eq!(
         ParserError::ParserError(
-            "Expected SELECT, VALUES, or a subquery in the query body, found: foo".to_string()
+            "Expected: SELECT, VALUES, or a subquery in the query body, found: foo".to_string()
         ),
         res.unwrap_err()
     );
@@ -8399,7 +8399,7 @@ fn parse_cache_table() {
     let res = parse_sql_statements("CACHE TABLE 'table_name' AS foo");
     assert_eq!(
         ParserError::ParserError(
-            "Expected SELECT, VALUES, or a subquery in the query body, found: foo".to_string()
+            "Expected: SELECT, VALUES, or a subquery in the query body, found: foo".to_string()
         ),
         res.unwrap_err()
     );
@@ -8407,26 +8407,26 @@ fn parse_cache_table() {
     let res = parse_sql_statements("CACHE flag TABLE 'table_name' OPTIONS('K1'='V1') AS foo");
     assert_eq!(
         ParserError::ParserError(
-            "Expected SELECT, VALUES, or a subquery in the query body, found: foo".to_string()
+            "Expected: SELECT, VALUES, or a subquery in the query body, found: foo".to_string()
         ),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("CACHE 'table_name'");
     assert_eq!(
-        ParserError::ParserError("Expected a `TABLE` keyword, found: 'table_name'".to_string()),
+        ParserError::ParserError("Expected: a `TABLE` keyword, found: 'table_name'".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("CACHE 'table_name' OPTIONS('K1'='V1')");
     assert_eq!(
-        ParserError::ParserError("Expected a `TABLE` keyword, found: OPTIONS".to_string()),
+        ParserError::ParserError("Expected: a `TABLE` keyword, found: OPTIONS".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("CACHE flag 'table_name' OPTIONS('K1'='V1')");
     assert_eq!(
-        ParserError::ParserError("Expected a `TABLE` keyword, found: 'table_name'".to_string()),
+        ParserError::ParserError("Expected: a `TABLE` keyword, found: 'table_name'".to_string()),
         res.unwrap_err()
     );
 }
@@ -8451,19 +8451,19 @@ fn parse_uncache_table() {
 
     let res = parse_sql_statements("UNCACHE TABLE 'table_name' foo");
     assert_eq!(
-        ParserError::ParserError("Expected an `EOF`, found: foo".to_string()),
+        ParserError::ParserError("Expected: an `EOF`, found: foo".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("UNCACHE 'table_name' foo");
     assert_eq!(
-        ParserError::ParserError("Expected a `TABLE` keyword, found: 'table_name'".to_string()),
+        ParserError::ParserError("Expected: a `TABLE` keyword, found: 'table_name'".to_string()),
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("UNCACHE IF EXISTS 'table_name' foo");
     assert_eq!(
-        ParserError::ParserError("Expected a `TABLE` keyword, found: IF".to_string()),
+        ParserError::ParserError("Expected: a `TABLE` keyword, found: IF".to_string()),
         res.unwrap_err()
     );
 }
@@ -8927,7 +8927,7 @@ fn parse_trailing_comma() {
             .parse_sql_statements("CREATE TABLE employees (name text, age int,)")
             .unwrap_err(),
         ParserError::ParserError(
-            "Expected column name or constraint definition, found: )".to_string()
+            "Expected: column name or constraint definition, found: )".to_string()
         )
     );
 }
@@ -8955,7 +8955,7 @@ fn parse_projection_trailing_comma() {
         trailing_commas
             .parse_sql_statements("SELECT * FROM track ORDER BY milliseconds,")
             .unwrap_err(),
-        ParserError::ParserError("Expected an expression:, found: EOF".to_string())
+        ParserError::ParserError("Expected: an expression:, found: EOF".to_string())
     );
 
     assert_eq!(
@@ -8963,7 +8963,7 @@ fn parse_projection_trailing_comma() {
             .parse_sql_statements("CREATE TABLE employees (name text, age int,)")
             .unwrap_err(),
         ParserError::ParserError(
-            "Expected column name or constraint definition, found: )".to_string()
+            "Expected: column name or constraint definition, found: )".to_string()
         ),
     );
 }
@@ -9962,14 +9962,14 @@ fn tests_select_values_without_parens_and_set_op() {
             assert_eq!(SetOperator::Union, op);
             match *left {
                 SetExpr::Select(_) => {}
-                _ => panic!("Expected a SELECT statement"),
+                _ => panic!("Expected: a SELECT statement"),
             }
             match *right {
                 SetExpr::Select(_) => {}
-                _ => panic!("Expected a SELECT statement"),
+                _ => panic!("Expected: a SELECT statement"),
             }
         }
-        _ => panic!("Expected a SET OPERATION"),
+        _ => panic!("Expected: a SET OPERATION"),
     }
 }
 
@@ -10003,7 +10003,7 @@ fn parse_select_wildcard_with_except() {
             .parse_sql_statements("SELECT * EXCEPT () FROM employee_table")
             .unwrap_err()
             .to_string(),
-        "sql parser error: Expected identifier, found: )"
+        "sql parser error: Expected: identifier, found: )"
     );
 }
 

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -64,7 +64,7 @@ fn test_databricks_exists() {
     let res = databricks().parse_sql_statements("SELECT EXISTS (");
     assert_eq!(
         // TODO: improve this error message...
-        ParserError::ParserError("Expected an expression:, found: EOF".to_string()),
+        ParserError::ParserError("Expected: an expression:, found: EOF".to_string()),
         res.unwrap_err(),
     );
 }

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -284,7 +284,7 @@ fn set_statement_with_minus() {
     assert_eq!(
         hive().parse_sql_statements("SET hive.tez.java.opts = -"),
         Err(ParserError::ParserError(
-            "Expected variable value, found: EOF".to_string()
+            "Expected: variable value, found: EOF".to_string()
         ))
     )
 }
@@ -327,14 +327,14 @@ fn parse_create_function() {
     assert_eq!(
         unsupported_dialects.parse_sql_statements(sql).unwrap_err(),
         ParserError::ParserError(
-            "Expected an object type after CREATE, found: FUNCTION".to_string()
+            "Expected: an object type after CREATE, found: FUNCTION".to_string()
         )
     );
 
     let sql = "CREATE TEMPORARY FUNCTION mydb.myfunc AS 'org.random.class.Name' USING JAR";
     assert_eq!(
         hive().parse_sql_statements(sql).unwrap_err(),
-        ParserError::ParserError("Expected literal string, found: EOF".to_string()),
+        ParserError::ParserError("Expected: literal string, found: EOF".to_string()),
     );
 }
 
@@ -398,7 +398,7 @@ fn parse_delimited_identifiers() {
             assert_eq!(&Expr::Identifier(Ident::with_quote('"', "simple id")), expr);
             assert_eq!(&Ident::with_quote('"', "column alias"), alias);
         }
-        _ => panic!("Expected ExprWithAlias"),
+        _ => panic!("Expected: ExprWithAlias"),
     }
 
     hive().verified_stmt(r#"CREATE TABLE "foo" ("bar" "int")"#);

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -481,7 +481,7 @@ fn parse_convert() {
 
     let error_sql = "SELECT CONVERT(INT, 'foo',) FROM T";
     assert_eq!(
-        ParserError::ParserError("Expected an expression:, found: )".to_owned()),
+        ParserError::ParserError("Expected: an expression:, found: )".to_owned()),
         ms().parse_sql_statements(error_sql).unwrap_err()
     );
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -2518,7 +2518,7 @@ fn parse_fulltext_expression() {
 }
 
 #[test]
-#[should_panic = "Expected FULLTEXT or SPATIAL option without constraint name, found: cons"]
+#[should_panic = "Expected: FULLTEXT or SPATIAL option without constraint name, found: cons"]
 fn parse_create_table_with_fulltext_definition_should_not_accept_constraint_name() {
     mysql_and_generic().verified_stmt("CREATE TABLE tb (c1 INT, CONSTRAINT cons FULLTEXT (c1))");
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -648,7 +648,7 @@ fn parse_alter_table_alter_column_add_generated() {
         "ALTER TABLE t ALTER COLUMN id ADD GENERATED ( INCREMENT 1 MINVALUE 1 )",
     );
     assert_eq!(
-        ParserError::ParserError("Expected AS, found: (".to_string()),
+        ParserError::ParserError("Expected: AS, found: (".to_string()),
         res.unwrap_err()
     );
 
@@ -656,14 +656,14 @@ fn parse_alter_table_alter_column_add_generated() {
         "ALTER TABLE t ALTER COLUMN id ADD GENERATED AS IDENTITY ( INCREMENT )",
     );
     assert_eq!(
-        ParserError::ParserError("Expected a value, found: )".to_string()),
+        ParserError::ParserError("Expected: a value, found: )".to_string()),
         res.unwrap_err()
     );
 
     let res =
         pg().parse_sql_statements("ALTER TABLE t ALTER COLUMN id ADD GENERATED AS IDENTITY (");
     assert_eq!(
-        ParserError::ParserError("Expected ), found: EOF".to_string()),
+        ParserError::ParserError("Expected: ), found: EOF".to_string()),
         res.unwrap_err()
     );
 }
@@ -733,25 +733,25 @@ fn parse_create_table_if_not_exists() {
 fn parse_bad_if_not_exists() {
     let res = pg().parse_sql_statements("CREATE TABLE NOT EXISTS uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: EXISTS".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: EXISTS".to_string()),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF EXISTS uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: EXISTS".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: EXISTS".to_string()),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: uk_cities".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: uk_cities".to_string()),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF NOT uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: NOT".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: NOT".to_string()),
         res.unwrap_err()
     );
 }
@@ -1300,21 +1300,21 @@ fn parse_set() {
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET"),
         Err(ParserError::ParserError(
-            "Expected identifier, found: EOF".to_string()
+            "Expected: identifier, found: EOF".to_string()
         )),
     );
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET a b"),
         Err(ParserError::ParserError(
-            "Expected equals sign or TO, found: b".to_string()
+            "Expected: equals sign or TO, found: b".to_string()
         )),
     );
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET a ="),
         Err(ParserError::ParserError(
-            "Expected variable value, found: EOF".to_string()
+            "Expected: variable value, found: EOF".to_string()
         )),
     );
 }
@@ -2685,7 +2685,7 @@ fn parse_json_table_is_not_reserved() {
             name: ObjectName(name),
             ..
         } => assert_eq!("JSON_TABLE", name[0].value),
-        other => panic!("Expected JSON_TABLE to be parsed as a table name, but got {other:?}"),
+        other => panic!("Expected: JSON_TABLE to be parsed as a table name, but got {other:?}"),
     }
 }
 
@@ -2874,7 +2874,7 @@ fn parse_escaped_literal_string() {
             .parse_sql_statements(sql)
             .unwrap_err()
             .to_string(),
-        "sql parser error: Unterminated encoded string literal at Line: 1, Column 8"
+        "sql parser error: Unterminated encoded string literal at Line: 1, Column: 8"
     );
 
     let sql = r"SELECT E'\u0001', E'\U0010FFFF', E'\xC', E'\x25', E'\2', E'\45', E'\445'";
@@ -2917,7 +2917,7 @@ fn parse_escaped_literal_string() {
                     .parse_sql_statements(sql)
                     .unwrap_err()
                     .to_string(),
-                "sql parser error: Unterminated encoded string literal at Line: 1, Column 8"
+                "sql parser error: Unterminated encoded string literal at Line: 1, Column: 8"
             );
         }
     }
@@ -3455,7 +3455,7 @@ fn parse_delimited_identifiers() {
             assert_eq!(&Expr::Identifier(Ident::with_quote('"', "simple id")), expr);
             assert_eq!(&Ident::with_quote('"', "column alias"), alias);
         }
-        _ => panic!("Expected ExprWithAlias"),
+        _ => panic!("Expected: ExprWithAlias"),
     }
 
     pg().verified_stmt(r#"CREATE TABLE "foo" ("bar" "int")"#);

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -385,14 +385,14 @@ fn test_snowflake_create_invalid_local_global_table() {
     assert_eq!(
         snowflake().parse_sql_statements("CREATE LOCAL GLOBAL TABLE my_table (a INT)"),
         Err(ParserError::ParserError(
-            "Expected an SQL statement, found: LOCAL".to_string()
+            "Expected: an SQL statement, found: LOCAL".to_string()
         ))
     );
 
     assert_eq!(
         snowflake().parse_sql_statements("CREATE GLOBAL LOCAL TABLE my_table (a INT)"),
         Err(ParserError::ParserError(
-            "Expected an SQL statement, found: GLOBAL".to_string()
+            "Expected: an SQL statement, found: GLOBAL".to_string()
         ))
     );
 }
@@ -402,21 +402,21 @@ fn test_snowflake_create_invalid_temporal_table() {
     assert_eq!(
         snowflake().parse_sql_statements("CREATE TEMP TEMPORARY TABLE my_table (a INT)"),
         Err(ParserError::ParserError(
-            "Expected an object type after CREATE, found: TEMPORARY".to_string()
+            "Expected: an object type after CREATE, found: TEMPORARY".to_string()
         ))
     );
 
     assert_eq!(
         snowflake().parse_sql_statements("CREATE TEMP VOLATILE TABLE my_table (a INT)"),
         Err(ParserError::ParserError(
-            "Expected an object type after CREATE, found: VOLATILE".to_string()
+            "Expected: an object type after CREATE, found: VOLATILE".to_string()
         ))
     );
 
     assert_eq!(
         snowflake().parse_sql_statements("CREATE TEMP TRANSIENT TABLE my_table (a INT)"),
         Err(ParserError::ParserError(
-            "Expected an object type after CREATE, found: TRANSIENT".to_string()
+            "Expected: an object type after CREATE, found: TRANSIENT".to_string()
         ))
     );
 }
@@ -851,7 +851,7 @@ fn parse_semi_structured_data_traversal() {
             .parse_sql_statements("SELECT a:42")
             .unwrap_err()
             .to_string(),
-        "sql parser error: Expected variant object key name, found: 42"
+        "sql parser error: Expected: variant object key name, found: 42"
     );
 }
 
@@ -908,7 +908,7 @@ fn parse_delimited_identifiers() {
             assert_eq!(&Expr::Identifier(Ident::with_quote('"', "simple id")), expr);
             assert_eq!(&Ident::with_quote('"', "column alias"), alias);
         }
-        _ => panic!("Expected ExprWithAlias"),
+        _ => panic!("Expected: ExprWithAlias"),
     }
 
     snowflake().verified_stmt(r#"CREATE TABLE "foo" ("bar" "int")"#);
@@ -1034,7 +1034,7 @@ fn test_select_wildcard_with_exclude_and_rename() {
             .parse_sql_statements("SELECT * RENAME col_a AS col_b EXCLUDE col_z FROM data")
             .unwrap_err()
             .to_string(),
-        "sql parser error: Expected end of statement, found: EXCLUDE"
+        "sql parser error: Expected: end of statement, found: EXCLUDE"
     );
 }
 
@@ -1134,13 +1134,13 @@ fn parse_snowflake_declare_cursor() {
 
     let error_sql = "DECLARE c1 CURSOR SELECT id FROM invoices";
     assert_eq!(
-        ParserError::ParserError("Expected FOR, found: SELECT".to_owned()),
+        ParserError::ParserError("Expected: FOR, found: SELECT".to_owned()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE c1 CURSOR res";
     assert_eq!(
-        ParserError::ParserError("Expected FOR, found: res".to_owned()),
+        ParserError::ParserError("Expected: FOR, found: res".to_owned()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -1188,13 +1188,13 @@ fn parse_snowflake_declare_result_set() {
 
     let error_sql = "DECLARE res RESULTSET DEFAULT";
     assert_eq!(
-        ParserError::ParserError("Expected an expression:, found: EOF".to_owned()),
+        ParserError::ParserError("Expected: an expression:, found: EOF".to_owned()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE res RESULTSET :=";
     assert_eq!(
-        ParserError::ParserError("Expected an expression:, found: EOF".to_owned()),
+        ParserError::ParserError("Expected: an expression:, found: EOF".to_owned()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -1280,19 +1280,19 @@ fn parse_snowflake_declare_variable() {
 
     let error_sql = "DECLARE profit INT 2";
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: 2".to_owned()),
+        ParserError::ParserError("Expected: end of statement, found: 2".to_owned()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE profit INT DEFAULT";
     assert_eq!(
-        ParserError::ParserError("Expected an expression:, found: EOF".to_owned()),
+        ParserError::ParserError("Expected: an expression:, found: EOF".to_owned()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE profit DEFAULT";
     assert_eq!(
-        ParserError::ParserError("Expected an expression:, found: EOF".to_owned()),
+        ParserError::ParserError("Expected: an expression:, found: EOF".to_owned()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -1327,7 +1327,7 @@ fn parse_snowflake_declare_multi_statements() {
 
     let error_sql = "DECLARE profit DEFAULT 42 c1 CURSOR FOR res;";
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: c1".to_owned()),
+        ParserError::ParserError("Expected: end of statement, found: c1".to_owned()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -1902,7 +1902,7 @@ fn test_snowflake_trim() {
     // missing comma separation
     let error_sql = "SELECT TRIM('xyz' 'a')";
     assert_eq!(
-        ParserError::ParserError("Expected ), found: 'a'".to_owned()),
+        ParserError::ParserError("Expected: ), found: 'a'".to_owned()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -2064,7 +2064,7 @@ fn test_select_wildcard_with_ilike_double_quote() {
     let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE "%id" FROM tbl"#);
     assert_eq!(
         res.unwrap_err().to_string(),
-        "sql parser error: Expected ilike pattern, found: \"%id\""
+        "sql parser error: Expected: ilike pattern, found: \"%id\""
     );
 }
 
@@ -2073,7 +2073,7 @@ fn test_select_wildcard_with_ilike_number() {
     let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE 42 FROM tbl"#);
     assert_eq!(
         res.unwrap_err().to_string(),
-        "sql parser error: Expected ilike pattern, found: 42"
+        "sql parser error: Expected: ilike pattern, found: 42"
     );
 }
 
@@ -2082,7 +2082,7 @@ fn test_select_wildcard_with_ilike_replace() {
     let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE '%id%' EXCLUDE col FROM tbl"#);
     assert_eq!(
         res.unwrap_err().to_string(),
-        "sql parser error: Expected end of statement, found: EXCLUDE"
+        "sql parser error: Expected: end of statement, found: EXCLUDE"
     );
 }
 

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -428,7 +428,7 @@ fn invalid_empty_list() {
     let sql = "SELECT * FROM t1 WHERE a IN (,,)";
     let sqlite = sqlite_with_options(ParserOptions::new().with_trailing_commas(true));
     assert_eq!(
-        "sql parser error: Expected an expression:, found: ,",
+        "sql parser error: Expected: an expression:, found: ,",
         sqlite.parse_sql_statements(sql).unwrap_err().to_string()
     );
 }
@@ -452,17 +452,17 @@ fn parse_start_transaction_with_modifier() {
     };
     let res = unsupported_dialects.parse_sql_statements("BEGIN DEFERRED");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: DEFERRED".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: DEFERRED".to_string()),
         res.unwrap_err(),
     );
     let res = unsupported_dialects.parse_sql_statements("BEGIN IMMEDIATE");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: IMMEDIATE".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: IMMEDIATE".to_string()),
         res.unwrap_err(),
     );
     let res = unsupported_dialects.parse_sql_statements("BEGIN EXCLUSIVE");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: EXCLUSIVE".to_string()),
+        ParserError::ParserError("Expected: end of statement, found: EXCLUSIVE".to_string()),
         res.unwrap_err(),
     );
 }


### PR DESCRIPTION
This should close #1259.

Added colons at the end of `Expected` and `Column` in ParserErrors.
Tests are also updated and they passed.

I do think this creates another "issue":
Currently, a lot of errors read nice without the colon after `Expected`:
"Expected an expression, found: ... "
and others would not read nice:
"Expected (, found: ..."

But with this change, we would flip these experiences:
"Expected: an expression, found: ..." and "Expected (, found: ..."

I do think we should keep the colons, but change the error messages, this is a bit much more work, but if asked i can do it.