### PR TITLE
Allow semi-colon at the end of UNCACHE statement

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3611,21 +3611,13 @@ impl<'a> Parser<'a> {
 
     /// Parse a UNCACHE TABLE statement
     pub fn parse_uncache_table(&mut self) -> Result<Statement, ParserError> {
-        let has_table = self.parse_keyword(Keyword::TABLE);
-        if has_table {
-            let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
-            let table_name = self.parse_object_name(false)?;
-            if self.peek_token().token == Token::EOF {
-                Ok(Statement::UNCache {
-                    table_name,
-                    if_exists,
-                })
-            } else {
-                self.expected("an `EOF`", self.peek_token())
-            }
-        } else {
-            self.expected("a `TABLE` keyword", self.peek_token())
-        }
+        self.expect_keyword(Keyword::TABLE)?;
+        let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
+        let table_name = self.parse_object_name(false)?;
+        Ok(Statement::UNCache {
+            table_name,
+            if_exists,
+        })
     }
 
     /// SQLite-specific `CREATE VIRTUAL TABLE`

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8451,19 +8451,31 @@ fn parse_uncache_table() {
 
     let res = parse_sql_statements("UNCACHE TABLE 'table_name' foo");
     assert_eq!(
+<<<<<<< HEAD
         ParserError::ParserError("Expected: an `EOF`, found: foo".to_string()),
+=======
+        ParserError::ParserError("Expected: end of statement, found: foo".to_string()),
+>>>>>>> c2fb339 (change tests)
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("UNCACHE 'table_name' foo");
     assert_eq!(
+<<<<<<< HEAD
         ParserError::ParserError("Expected: a `TABLE` keyword, found: 'table_name'".to_string()),
+=======
+        ParserError::ParserError("Expected: TABLE, found: 'table_name'".to_string()),
+>>>>>>> c2fb339 (change tests)
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("UNCACHE IF EXISTS 'table_name' foo");
     assert_eq!(
+<<<<<<< HEAD
         ParserError::ParserError("Expected: a `TABLE` keyword, found: IF".to_string()),
+=======
+        ParserError::ParserError("Expected: TABLE, found: IF".to_string()),
+>>>>>>> c2fb339 (change tests)
         res.unwrap_err()
     );
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8451,31 +8451,19 @@ fn parse_uncache_table() {
 
     let res = parse_sql_statements("UNCACHE TABLE 'table_name' foo");
     assert_eq!(
-<<<<<<< HEAD
-        ParserError::ParserError("Expected: an `EOF`, found: foo".to_string()),
-=======
         ParserError::ParserError("Expected: end of statement, found: foo".to_string()),
->>>>>>> c2fb339 (change tests)
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("UNCACHE 'table_name' foo");
     assert_eq!(
-<<<<<<< HEAD
-        ParserError::ParserError("Expected: a `TABLE` keyword, found: 'table_name'".to_string()),
-=======
         ParserError::ParserError("Expected: TABLE, found: 'table_name'".to_string()),
->>>>>>> c2fb339 (change tests)
         res.unwrap_err()
     );
 
     let res = parse_sql_statements("UNCACHE IF EXISTS 'table_name' foo");
     assert_eq!(
-<<<<<<< HEAD
-        ParserError::ParserError("Expected: a `TABLE` keyword, found: IF".to_string()),
-=======
         ParserError::ParserError("Expected: TABLE, found: IF".to_string()),
->>>>>>> c2fb339 (change tests)
         res.unwrap_err()
     );
 }


### PR DESCRIPTION
Closes #1244.

The function that parses UNCACHE statements now also accepts a semi-colon as the end of the statement.

Had to modify one test because the error message `expected ...` now also contains the semi-colon.