### PR TITLE
Fix Snowflake `SELECT *` wildcard `REPLACE ... RENAME` order

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -547,19 +547,20 @@ impl fmt::Display for IdentWithAlias {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct WildcardAdditionalOptions {
     /// `[ILIKE...]`.
-    /// Snowflake syntax: <https://docs.snowflake.com/en/sql-reference/sql/select>
+    ///  Snowflake syntax: <https://docs.snowflake.com/en/sql-reference/sql/select#parameters>
     pub opt_ilike: Option<IlikeSelectItem>,
     /// `[EXCLUDE...]`.
     pub opt_exclude: Option<ExcludeSelectItem>,
     /// `[EXCEPT...]`.
     ///  Clickhouse syntax: <https://clickhouse.com/docs/en/sql-reference/statements/select#except>
     pub opt_except: Option<ExceptSelectItem>,
-    /// `[RENAME ...]`.
-    pub opt_rename: Option<RenameSelectItem>,
     /// `[REPLACE]`
     ///  BigQuery syntax: <https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace>
     ///  Clickhouse syntax: <https://clickhouse.com/docs/en/sql-reference/statements/select#replace>
+    ///  Snowflake syntax: <https://docs.snowflake.com/en/sql-reference/sql/select#parameters>
     pub opt_replace: Option<ReplaceSelectItem>,
+    /// `[RENAME ...]`.
+    pub opt_rename: Option<RenameSelectItem>,
 }
 
 impl fmt::Display for WildcardAdditionalOptions {
@@ -573,11 +574,11 @@ impl fmt::Display for WildcardAdditionalOptions {
         if let Some(except) = &self.opt_except {
             write!(f, " {except}")?;
         }
-        if let Some(rename) = &self.opt_rename {
-            write!(f, " {rename}")?;
-        }
         if let Some(replace) = &self.opt_replace {
             write!(f, " {replace}")?;
+        }
+        if let Some(rename) = &self.opt_rename {
+            write!(f, " {rename}")?;
         }
         Ok(())
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10175,15 +10175,14 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
-        let opt_rename = if dialect_of!(self is GenericDialect | SnowflakeDialect) {
-            self.parse_optional_select_item_rename()?
+        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect | ClickHouseDialect | DuckDbDialect | SnowflakeDialect)
+        {
+            self.parse_optional_select_item_replace()?
         } else {
             None
         };
-
-        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect | ClickHouseDialect |  DuckDbDialect | SnowflakeDialect)
-        {
-            self.parse_optional_select_item_replace()?
+        let opt_rename = if dialect_of!(self is GenericDialect | SnowflakeDialect) {
+            self.parse_optional_select_item_rename()?
         } else {
             None
         };


### PR DESCRIPTION
Affects parsing of Snowflake `SELECT * <opts>` wildcard options that contain _both_ `RENAME` and `REPLACE` options.

As per the Snowflake docs[^1]:
```
If you specify REPLACE and RENAME:
You must specify REPLACE first
```
Made a minor fix and added a unit test to validate it and provide the missing coverage.

[^1]: https://docs.snowflake.com/en/sql-reference/sql/select#parameters