### PR TITLE
Support `SETTINGS` pairs for ClickHouse dialect

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -48,7 +48,7 @@ pub use self::query::{
     MatchRecognizePattern, MatchRecognizeSymbol, Measure, NamedWindowDefinition, NamedWindowExpr,
     NonBlock, Offset, OffsetRows, OrderByExpr, PivotValueSource, Query, RenameSelectItem,
     RepetitionQuantifier, ReplaceSelectElement, ReplaceSelectItem, RowsPerMatch, Select,
-    SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, SymbolDefinition, Table,
+    SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, Setting, SymbolDefinition, Table,
     TableAlias, TableFactor, TableVersion, TableWithJoins, Top, TopQuantity, ValueTableMode,
     Values, WildcardAdditionalOptions, With,
 };

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -50,6 +50,10 @@ pub struct Query {
     /// `FOR JSON { AUTO | PATH } [ , INCLUDE_NULL_VALUES ]`
     /// (MSSQL-specific)
     pub for_clause: Option<ForClause>,
+    /// ClickHouse syntax: `SELECT * FROM t SETTINGS key1 = value1, key2 = value2`
+    ///
+    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/select#settings-in-select-query)
+    pub settings: Option<Vec<Setting>>,
 }
 
 impl fmt::Display for Query {
@@ -69,6 +73,9 @@ impl fmt::Display for Query {
         }
         if !self.limit_by.is_empty() {
             write!(f, " BY {}", display_separated(&self.limit_by, ", "))?;
+        }
+        if let Some(ref settings) = self.settings {
+            write!(f, " SETTINGS {}", display_comma_separated(settings))?;
         }
         if let Some(ref fetch) = self.fetch {
             write!(f, " {fetch}")?;
@@ -825,6 +832,20 @@ impl fmt::Display for ConnectBy {
             condition = self.condition,
             relationships = display_comma_separated(&self.relationships)
         )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct Setting {
+    pub key: Ident,
+    pub value: Value,
+}
+
+impl fmt::Display for Setting {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} = {}", self.key, self.value)
     }
 }
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -650,6 +650,7 @@ define_keywords!(
     SESSION_USER,
     SET,
     SETS,
+    SETTINGS,
     SHARE,
     SHOW,
     SIMILAR,
@@ -850,6 +851,8 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::FOR,
     // for MYSQL PARTITION SELECTION
     Keyword::PARTITION,
+    // for ClickHouse SELECT * FROM t SETTINGS ...
+    Keyword::SETTINGS,
     // for Snowflake START WITH .. CONNECT BY
     Keyword::START,
     Keyword::CONNECT,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7933,13 +7933,11 @@ impl<'a> Parser<'a> {
             let settings = if dialect_of!(self is ClickHouseDialect|GenericDialect)
                 && self.parse_keyword(Keyword::SETTINGS)
             {
-                let mut key_values: Vec<Setting> = vec![];
-                self.parse_comma_separated(|p| {
+                let key_values = self.parse_comma_separated(|p| {
                     let key = p.parse_identifier(false)?;
                     p.expect_token(&Token::Eq)?;
                     let value = p.parse_value()?;
-                    key_values.push(Setting { key, value });
-                    Ok(())
+                    Ok(Setting { key, value })
                 })?;
                 Some(key_values)
             } else {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7934,15 +7934,13 @@ impl<'a> Parser<'a> {
                 && self.parse_keyword(Keyword::SETTINGS)
             {
                 let mut key_values: Vec<Setting> = vec![];
-                loop {
-                    let key = self.parse_identifier(false)?;
-                    self.expect_token(&Token::Eq)?;
-                    let value = self.parse_value()?;
+                self.parse_comma_separated(|p| {
+                    let key = p.parse_identifier(false)?;
+                    p.expect_token(&Token::Eq)?;
+                    let value = p.parse_value()?;
                     key_values.push(Setting { key, value });
-                    if !self.consume_token(&Token::Comma) {
-                        break;
-                    }
-                }
+                    Ok(())
+                })?;
                 Some(key_values)
             } else {
                 None

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -413,6 +413,7 @@ fn parse_update_set_from() {
                         fetch: None,
                         locks: vec![],
                         for_clause: None,
+                        settings: None,
                     }),
                     alias: Some(TableAlias {
                         name: Ident::new("t2"),
@@ -3427,6 +3428,7 @@ fn parse_create_table_as_table() {
         fetch: None,
         locks: vec![],
         for_clause: None,
+        settings: None,
     });
 
     match verified_stmt(sql1) {
@@ -3452,6 +3454,7 @@ fn parse_create_table_as_table() {
         fetch: None,
         locks: vec![],
         for_clause: None,
+        settings: None,
     });
 
     match verified_stmt(sql2) {
@@ -4996,6 +4999,7 @@ fn parse_interval_and_or_xor() {
         fetch: None,
         locks: vec![],
         for_clause: None,
+        settings: None,
     }))];
 
     assert_eq!(actual_ast, expected_ast);
@@ -7649,6 +7653,7 @@ fn parse_merge() {
                         fetch: None,
                         locks: vec![],
                         for_clause: None,
+                        settings: None,
                     }),
                     alias: Some(TableAlias {
                         name: Ident {
@@ -9156,6 +9161,7 @@ fn parse_unload() {
                 locks: vec![],
                 for_clause: None,
                 order_by: vec![],
+                settings: None,
             }),
             to: Ident {
                 value: "s3://...".to_string(),

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -103,6 +103,7 @@ fn parse_create_procedure() {
                 locks: vec![],
                 for_clause: None,
                 order_by: vec![],
+                settings: None,
                 body: Box::new(SetExpr::Select(Box::new(Select {
                     distinct: None,
                     top: None,
@@ -546,6 +547,7 @@ fn parse_substring_in_select() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 }),
                 query
             );

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -925,6 +925,7 @@ fn parse_escaped_quote_identifiers_with_escape() {
             fetch: None,
             locks: vec![],
             for_clause: None,
+            settings: None,
         }))
     );
 }
@@ -972,6 +973,7 @@ fn parse_escaped_quote_identifiers_with_no_escape() {
             fetch: None,
             locks: vec![],
             for_clause: None,
+            settings: None,
         }))
     );
 }
@@ -1016,6 +1018,7 @@ fn parse_escaped_backticks_with_escape() {
             fetch: None,
             locks: vec![],
             for_clause: None,
+            settings: None,
         }))
     );
 }
@@ -1060,6 +1063,7 @@ fn parse_escaped_backticks_with_no_escape() {
             fetch: None,
             locks: vec![],
             for_clause: None,
+            settings: None,
         }))
     );
 }
@@ -1264,6 +1268,7 @@ fn parse_simple_insert() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 })),
                 source
             );
@@ -1306,6 +1311,7 @@ fn parse_ignore_insert() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 })),
                 source
             );
@@ -1348,6 +1354,7 @@ fn parse_priority_insert() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 })),
                 source
             );
@@ -1387,6 +1394,7 @@ fn parse_priority_insert() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 })),
                 source
             );
@@ -1434,6 +1442,7 @@ fn parse_insert_as() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 })),
                 source
             );
@@ -1493,6 +1502,7 @@ fn parse_insert_as() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 })),
                 source
             );
@@ -1536,6 +1546,7 @@ fn parse_replace_insert() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 })),
                 source
             );
@@ -1573,6 +1584,7 @@ fn parse_empty_row_insert() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 })),
                 source
             );
@@ -1633,6 +1645,7 @@ fn parse_insert_with_on_duplicate_update() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 })),
                 source
             );
@@ -2273,6 +2286,7 @@ fn parse_substring_in_select() {
                     fetch: None,
                     locks: vec![],
                     for_clause: None,
+                    settings: None,
                 }),
                 query
             );
@@ -2578,6 +2592,7 @@ fn parse_hex_string_introducer() {
             fetch: None,
             locks: vec![],
             for_clause: None,
+            settings: None,
         }))
     )
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1093,6 +1093,7 @@ fn parse_copy_to() {
                 fetch: None,
                 locks: vec![],
                 for_clause: None,
+                settings: None,
             })),
             to: true,
             target: CopyTarget::File {
@@ -2421,6 +2422,7 @@ fn parse_array_subquery_expr() {
                 fetch: None,
                 locks: vec![],
                 for_clause: None,
+                settings: None,
             })),
             filter: None,
             null_treatment: None,
@@ -3941,7 +3943,8 @@ fn test_simple_postgres_insert_with_alias() {
                 offset: None,
                 fetch: None,
                 locks: vec![],
-                for_clause: None
+                for_clause: None,
+                settings: None,
             })),
             partitioned: None,
             after_columns: vec![],
@@ -4008,7 +4011,8 @@ fn test_simple_postgres_insert_with_alias() {
                 offset: None,
                 fetch: None,
                 locks: vec![],
-                for_clause: None
+                for_clause: None,
+                settings: None,
             })),
             partitioned: None,
             after_columns: vec![],
@@ -4071,7 +4075,8 @@ fn test_simple_insert_with_quoted_alias() {
                 offset: None,
                 fetch: None,
                 locks: vec![],
-                for_clause: None
+                for_clause: None,
+                settings: None,
             })),
             partitioned: None,
             after_columns: vec![],


### PR DESCRIPTION
SETTINGS in query is supported by ClickHouse, for example:

```
SELECT * FROM t SETTINGS max_threads = 1, max_block_size = 10000
```

For more information, please refer to:

https://clickhouse.com/docs/en/sql-reference/statements/select#settings-in-select-query