### PR TITLE
Fix CI error message in CI

### DIFF
--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8970,7 +8970,7 @@ fn parse_trailing_comma() {
         trailing_commas
             .parse_sql_statements("REVOKE USAGE, SELECT, ON p TO u")
             .unwrap_err(),
-        ParserError::ParserError("Expected a privilege keyword, found: ON".to_string())
+        ParserError::ParserError("Expected: a privilege keyword, found: ON".to_string())
     );
 
     assert_eq!(


### PR DESCRIPTION
An error started happening after I merged https://github.com/sqlparser-rs/sqlparser-rs/pull/1318

I believe it is a logical conflict with https://github.com/sqlparser-rs/sqlparser-rs/pull/1319

Here is an example failure: https://github.com/sqlparser-rs/sqlparser-rs/actions/runs/9838692665/job/27159117248?pr=1314

```
---- parse_trailing_comma stdout ----
thread 'parse_trailing_comma' panicked at tests/sqlparser_common.rs:8969:5:
assertion failed: `(left == right)`

Diff < left / right > :
 ParserError(
<    "Expected: a privilege keyword, found: ON",
>    "Expected a privilege keyword, found: ON",
 )
```
