### PR TITLE
Enable PARTITION BY feature for PostgreSQL while parsing the create table statement

### DIFF
--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -496,9 +496,9 @@ impl TryFrom<Statement> for CreateTableBuilder {
     }
 }
 
-/// Helper return type when parsing configuration for a BigQuery `CREATE TABLE` statement.
+/// Helper return type when parsing configuration for a `CREATE TABLE` statement.
 #[derive(Default)]
-pub(crate) struct BigQueryTableConfiguration {
+pub(crate) struct CreateTableConfiguration {
     pub partition_by: Option<Box<Expr>>,
     pub cluster_by: Option<WrappedCollection<Vec<Ident>>>,
     pub options: Option<Vec<SqlOption>>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5416,7 +5416,8 @@ impl<'a> Parser<'a> {
             None
         };
 
-        let big_query_config = if dialect_of!(self is BigQueryDialect | GenericDialect) {
+        let big_query_config = if dialect_of!(self is BigQueryDialect | PostgreSqlDialect | GenericDialect)
+        {
             self.parse_optional_big_query_create_table_config()?
         } else {
             Default::default()


### PR DESCRIPTION
This closes #1281.

PARTITION BY has been supported but wasn't enabled for the PostgreSQL dialect, this PR only enables it and adds a test case to make sure it works well.