### PR TITLE
Fix AS query clause should be after the create table options

### DIFF
--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -418,9 +418,6 @@ impl Display for CreateTable {
             write!(f, " WITH TAG ({})", display_comma_separated(tag.as_slice()))?;
         }
 
-        if let Some(query) = &self.query {
-            write!(f, " AS {query}")?;
-        }
         if let Some(default_charset) = &self.default_charset {
             write!(f, " DEFAULT CHARSET={default_charset}")?;
         }
@@ -439,6 +436,9 @@ impl Display for CreateTable {
         }
         if self.strict {
             write!(f, " STRICT")?;
+        }
+        if let Some(query) = &self.query {
+            write!(f, " AS {query}")?;
         }
         Ok(())
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5422,13 +5422,6 @@ impl<'a> Parser<'a> {
             Default::default()
         };
 
-        // Parse optional `AS ( query )`
-        let query = if self.parse_keyword(Keyword::AS) {
-            Some(self.parse_boxed_query()?)
-        } else {
-            None
-        };
-
         let default_charset = if self.parse_keywords(&[Keyword::DEFAULT, Keyword::CHARSET]) {
             self.expect_token(&Token::Eq)?;
             let next_token = self.next_token();
@@ -5469,6 +5462,13 @@ impl<'a> Parser<'a> {
             };
 
         let strict = self.parse_keyword(Keyword::STRICT);
+
+        // Parse optional `AS ( query )`
+        let query = if self.parse_keyword(Keyword::AS) {
+            Some(self.parse_boxed_query()?)
+        } else {
+            None
+        };
 
         let comment = if self.parse_keyword(Keyword::COMMENT) {
             let _ = self.consume_token(&Token::Eq);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5463,13 +5463,6 @@ impl<'a> Parser<'a> {
 
         let strict = self.parse_keyword(Keyword::STRICT);
 
-        // Parse optional `AS ( query )`
-        let query = if self.parse_keyword(Keyword::AS) {
-            Some(self.parse_boxed_query()?)
-        } else {
-            None
-        };
-
         let comment = if self.parse_keyword(Keyword::COMMENT) {
             let _ = self.consume_token(&Token::Eq);
             let next_token = self.next_token();
@@ -5477,6 +5470,13 @@ impl<'a> Parser<'a> {
                 Token::SingleQuotedString(str) => Some(CommentDef::WithoutEq(str)),
                 _ => self.expected("comment", next_token)?,
             }
+        } else {
+            None
+        };
+
+        // Parse optional `AS ( query )`
+        let query = if self.parse_keyword(Keyword::AS) {
+            Some(self.parse_boxed_query()?)
         } else {
             None
         };

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -813,6 +813,33 @@ fn parse_create_table_collate() {
 }
 
 #[test]
+fn parse_create_table_both_options_and_as_query() {
+    let sql = "CREATE TABLE foo (id INT(11)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb4_0900_ai_ci AS SELECT 1";
+    match mysql_and_generic().verified_stmt(sql) {
+        Statement::CreateTable(CreateTable {
+            name,
+            collation,
+            query,
+            ..
+        }) => {
+            assert_eq!(name.to_string(), "foo");
+            assert_eq!(collation, Some("utf8mb4_0900_ai_ci".to_string()));
+            assert_eq!(
+                query.unwrap().body.as_select().unwrap().projection,
+                vec![SelectItem::UnnamedExpr(Expr::Value(number("1")))]
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    let sql = r"CREATE TABLE foo (id INT(11)) ENGINE=InnoDB AS SELECT 1 DEFAULT CHARSET=utf8mb3";
+    assert!(matches!(
+        mysql_and_generic().parse_sql_statements(sql),
+        Err(ParserError::ParserError(_))
+    ));
+}
+
+#[test]
 fn parse_create_table_comment_character_set() {
     let sql = "CREATE TABLE foo (s TEXT CHARACTER SET utf8mb4 COMMENT 'comment')";
     match mysql().verified_stmt(sql) {


### PR DESCRIPTION
According to MySQL[1] and PostgreSQL[2] create table syntax, the AS query should be sit after the table options. But it is parsed before table options include CHARSET and COLLATE, as well as ON COMMIT clause. This PR resolves this issue by moving the position of AS query, and the issue #1274 will be aslo resolved after this PR.

MySQL:

```SQL
CREATE [TEMPORARY] TABLE [IF NOT EXISTS] tbl_name
    [(create_definition,...)]
    [table_options]
    [partition_options]
    [IGNORE | REPLACE]
    [AS] query_expression
```

PostgreSQL:

```SQL
CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXISTS ] table_name
    [ (column_name [, ...] ) ]
    [ USING method ]
    [ WITH ( storage_parameter [= value] [, ... ] ) | WITHOUT OIDS ]
    [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
    [ TABLESPACE tablespace_name ]
    AS query
    [ WITH [ NO ] DATA ]
```

[1] https://dev.mysql.com/doc/refman/8.0/en/create-table.html
[2] https://www.postgresql.org/docs/current/sql-createtableas.html