### PR TITLE
Add support of parsing ON CLUSTER in ALTER TABLE for ClickHouse

### DIFF
--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -126,7 +126,7 @@ pub struct CreateTable {
     pub on_commit: Option<OnCommit>,
     /// ClickHouse "ON CLUSTER" clause:
     /// <https://clickhouse.com/docs/en/sql-reference/distributed-ddl/>
-    pub on_cluster: Option<String>,
+    pub on_cluster: Option<Ident>,
     /// ClickHouse "PRIMARY KEY " clause.
     /// <https://clickhouse.com/docs/en/sql-reference/statements/create/table/>
     pub primary_key: Option<Box<Expr>>,

--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -206,11 +206,7 @@ impl Display for CreateTable {
             name = self.name,
         )?;
         if let Some(on_cluster) = &self.on_cluster {
-            write!(
-                f,
-                " ON CLUSTER {}",
-                on_cluster.replace('{', "'{").replace('}', "}'")
-            )?;
+            write!(f, " ON CLUSTER {}", on_cluster)?;
         }
         if !self.columns.is_empty() || !self.constraints.is_empty() {
             write!(f, " ({}", display_comma_separated(&self.columns))?;

--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -73,7 +73,7 @@ pub struct CreateTableBuilder {
     pub default_charset: Option<String>,
     pub collation: Option<String>,
     pub on_commit: Option<OnCommit>,
-    pub on_cluster: Option<String>,
+    pub on_cluster: Option<Ident>,
     pub primary_key: Option<Box<Expr>>,
     pub order_by: Option<OneOrManyWithParens<Expr>>,
     pub partition_by: Option<Box<Expr>>,
@@ -261,7 +261,7 @@ impl CreateTableBuilder {
         self
     }
 
-    pub fn on_cluster(mut self, on_cluster: Option<String>) -> Self {
+    pub fn on_cluster(mut self, on_cluster: Option<Ident>) -> Self {
         self.on_cluster = on_cluster;
         self
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2165,7 +2165,7 @@ pub enum Statement {
         /// ClickHouse dialect supports `ON CLUSTER` clause for ALTER TABLE
         /// For example: `ALTER TABLE table_name ON CLUSTER cluster_name ADD COLUMN c UInt32`
         /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/alter/update)
-        on_cluster: Option<String>,
+        on_cluster: Option<Ident>,
     },
     /// ```sql
     /// ALTER INDEX

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2162,6 +2162,10 @@ pub enum Statement {
         only: bool,
         operations: Vec<AlterTableOperation>,
         location: Option<HiveSetLocation>,
+        /// ClickHouse dialect supports `ON CLUSTER` clause for ALTER TABLE
+        /// For example: `ALTER TABLE table_name ON CLUSTER cluster_name ADD COLUMN c UInt32`
+        /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/alter)
+        on_cluster: Option<String>,
     },
     /// ```sql
     /// ALTER INDEX
@@ -3623,6 +3627,7 @@ impl fmt::Display for Statement {
                 only,
                 operations,
                 location,
+                on_cluster,
             } => {
                 write!(f, "ALTER TABLE ")?;
                 if *if_exists {
@@ -3631,9 +3636,13 @@ impl fmt::Display for Statement {
                 if *only {
                     write!(f, "ONLY ")?;
                 }
+                write!(f, "{name} ", name = name)?;
+                if let Some(cluster) = on_cluster {
+                    write!(f, "ON CLUSTER {cluster} ")?;
+                }
                 write!(
                     f,
-                    "{name} {operations}",
+                    "{operations}",
                     operations = display_comma_separated(operations)
                 )?;
                 if let Some(loc) = location {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2164,7 +2164,7 @@ pub enum Statement {
         location: Option<HiveSetLocation>,
         /// ClickHouse dialect supports `ON CLUSTER` clause for ALTER TABLE
         /// For example: `ALTER TABLE table_name ON CLUSTER cluster_name ADD COLUMN c UInt32`
-        /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/alter)
+        /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/alter/update)
         on_cluster: Option<String>,
     },
     /// ```sql

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5372,6 +5372,19 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn parse_optional_on_cluster(&mut self) -> Result<Option<String>, ParserError> {
+        if self.parse_keywords(&[Keyword::ON, Keyword::CLUSTER]) {
+            let next_token = self.next_token();
+            match next_token.token {
+                Token::SingleQuotedString(s) => Ok(Some(format!("'{}'", s))),
+                Token::Word(s) => Ok(Some(s.to_string())),
+                _ => self.expected("identifier or cluster literal", next_token)?,
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn parse_create_table(
         &mut self,
         or_replace: bool,
@@ -5384,16 +5397,7 @@ impl<'a> Parser<'a> {
         let table_name = self.parse_object_name(allow_unquoted_hyphen)?;
 
         // Clickhouse has `ON CLUSTER 'cluster'` syntax for DDLs
-        let on_cluster = if self.parse_keywords(&[Keyword::ON, Keyword::CLUSTER]) {
-            let next_token = self.next_token();
-            match next_token.token {
-                Token::SingleQuotedString(s) => Some(s),
-                Token::Word(s) => Some(s.to_string()),
-                _ => self.expected("identifier or cluster literal", next_token)?,
-            }
-        } else {
-            None
-        };
+        let on_cluster = self.parse_optional_on_cluster()?;
 
         let like = if self.parse_keyword(Keyword::LIKE) || self.parse_keyword(Keyword::ILIKE) {
             self.parse_object_name(allow_unquoted_hyphen).ok()
@@ -6576,6 +6580,7 @@ impl<'a> Parser<'a> {
                 let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
                 let only = self.parse_keyword(Keyword::ONLY); // [ ONLY ]
                 let table_name = self.parse_object_name(false)?;
+                let on_cluster = self.parse_optional_on_cluster()?;
                 let operations = self.parse_comma_separated(Parser::parse_alter_table_operation)?;
 
                 let mut location = None;
@@ -6597,6 +6602,7 @@ impl<'a> Parser<'a> {
                     only,
                     operations,
                     location,
+                    on_cluster,
                 })
             }
             Keyword::INDEX => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5372,14 +5372,9 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_optional_on_cluster(&mut self) -> Result<Option<String>, ParserError> {
+    fn parse_optional_on_cluster(&mut self) -> Result<Option<Ident>, ParserError> {
         if self.parse_keywords(&[Keyword::ON, Keyword::CLUSTER]) {
-            let next_token = self.next_token();
-            match next_token.token {
-                Token::SingleQuotedString(s) => Ok(Some(format!("'{}'", s))),
-                Token::Word(s) => Ok(Some(s.to_string())),
-                _ => self.expected("identifier or cluster literal", next_token)?,
-            }
+            Ok(Some(self.parse_identifier(false)?))
         } else {
             Ok(None)
         }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -274,6 +274,7 @@ pub fn alter_table_op_with_name(stmt: Statement, expected_name: &str) -> AlterTa
             if_exists,
             only: is_only,
             operations,
+            on_cluster: _,
             location: _,
         } => {
             assert_eq!(name.to_string(), expected_name);

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -25,7 +25,6 @@ use sqlparser::ast::Value::Number;
 use sqlparser::ast::*;
 use sqlparser::dialect::ClickHouseDialect;
 use sqlparser::dialect::GenericDialect;
-use sqlparser::parser::ParserError::ParserError;
 
 #[test]
 fn parse_map_access_expr() {
@@ -1090,27 +1089,6 @@ fn parse_create_table_on_commit_and_as_query() {
         }
         _ => unreachable!(),
     }
-}
-
-#[test]
-fn test_alter_table_with_on_cluster() {
-    let sql = "ALTER TABLE t ON CLUSTER 'cluster' ADD CONSTRAINT bar PRIMARY KEY (baz)";
-    match clickhouse_and_generic().verified_stmt(sql) {
-        Statement::AlterTable {
-            name, on_cluster, ..
-        } => {
-            assert_eq!(name.to_string(), "t");
-            assert_eq!(on_cluster, Some("'cluster'".to_string()));
-        }
-        _ => unreachable!(),
-    }
-
-    let res = clickhouse_and_generic()
-        .parse_sql_statements("ALTER TABLE t ON CLUSTER 123 ADD CONSTRAINT bar PRIMARY KEY (baz)");
-    assert_eq!(
-        res.unwrap_err(),
-        ParserError("Expected: identifier or cluster literal, found: 123".to_string())
-    )
 }
 
 fn clickhouse() -> TestedDialects {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3506,7 +3506,7 @@ fn parse_create_table_on_cluster() {
     let sql = "CREATE TABLE t ON CLUSTER '{cluster}' (a INT, b INT)";
     match generic.verified_stmt(sql) {
         Statement::CreateTable(CreateTable { on_cluster, .. }) => {
-            assert_eq!(on_cluster.unwrap(), "{cluster}".to_string());
+            assert_eq!(on_cluster.unwrap(), "'{cluster}'".to_string());
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3823,6 +3823,27 @@ fn parse_alter_table() {
 }
 
 #[test]
+fn test_alter_table_with_on_cluster() {
+    let sql = "ALTER TABLE t ON CLUSTER 'cluster' ADD CONSTRAINT bar PRIMARY KEY (baz)";
+    match all_dialects().verified_stmt(sql) {
+        Statement::AlterTable {
+            name, on_cluster, ..
+        } => {
+            std::assert_eq!(name.to_string(), "t");
+            std::assert_eq!(on_cluster, Some("'cluster'".to_string()));
+        }
+        _ => unreachable!(),
+    }
+
+    let res = all_dialects()
+        .parse_sql_statements("ALTER TABLE t ON CLUSTER 123 ADD CONSTRAINT bar PRIMARY KEY (baz)");
+    std::assert_eq!(
+        res.unwrap_err(),
+        ParserError::ParserError("Expected: identifier or cluster literal, found: 123".to_string())
+    )
+}
+
+#[test]
 fn parse_alter_index() {
     let rename_index = "ALTER INDEX idx RENAME TO new_idx";
     match verified_stmt(rename_index) {

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1975,6 +1975,7 @@ fn parse_alter_table_add_column() {
             only,
             operations,
             location: _,
+            on_cluster: _,
         } => {
             assert_eq!(name.to_string(), "tab");
             assert!(!if_exists);
@@ -2004,6 +2005,7 @@ fn parse_alter_table_add_column() {
             only,
             operations,
             location: _,
+            on_cluster: _,
         } => {
             assert_eq!(name.to_string(), "tab");
             assert!(!if_exists);
@@ -2041,6 +2043,7 @@ fn parse_alter_table_add_columns() {
             only,
             operations,
             location: _,
+            on_cluster: _,
         } => {
             assert_eq!(name.to_string(), "tab");
             assert!(!if_exists);

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -677,6 +677,7 @@ fn parse_alter_table_add_columns() {
             only,
             operations,
             location: _,
+            on_cluster: _,
         } => {
             assert_eq!(name.to_string(), "tab");
             assert!(if_exists);
@@ -759,6 +760,7 @@ fn parse_alter_table_owner_to() {
                 only: _,
                 operations,
                 location: _,
+                on_cluster: _,
             } => {
                 assert_eq!(name.to_string(), "tab");
                 assert_eq!(


### PR DESCRIPTION
ClickHouse dialect supports `ON CLUSTER` clause for ALTER TABLE:

```sql
ALTER TABLE table_name ON CLUSTER cluster_name ADD COLUMN c UInt32
```

Please refer to: https://clickhouse.com/docs/en/sql-reference/statements/alter