### PR TITLE
Fix quoted identifier regression edge-case with "from" in SELECT

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10309,7 +10309,7 @@ impl<'a> Parser<'a> {
             Expr::Wildcard => Ok(SelectItem::Wildcard(
                 self.parse_wildcard_additional_options()?,
             )),
-            Expr::Identifier(v) if v.value.to_lowercase() == "from" => {
+            Expr::Identifier(v) if v.value.to_lowercase() == "from" && v.quote_style.is_none() => {
                 parser_err!(
                     format!("Expected an expression, found: {}", v),
                     self.peek_token().location

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8959,7 +8959,7 @@ fn parse_non_latin_identifiers() {
 
 #[test]
 fn parse_trailing_comma() {
-    // At the moment, Duck DB is the only dialect that allows
+    // At the moment, DuckDB is the only dialect that allows
     // trailing commas anywhere in the query
     let trailing_commas = TestedDialects {
         dialects: vec![Box::new(DuckDbDialect {})],
@@ -8992,10 +8992,15 @@ fn parse_trailing_comma() {
     );
 
     trailing_commas.verified_stmt("SELECT album_id, name FROM track");
-
     trailing_commas.verified_stmt("SELECT * FROM track ORDER BY milliseconds");
-
     trailing_commas.verified_stmt("SELECT DISTINCT ON (album_id) name FROM track");
+
+    // check quoted "from" identifier edge-case
+    trailing_commas.one_statement_parses_to(
+        r#"SELECT "from", FROM "from""#,
+        r#"SELECT "from" FROM "from""#,
+    );
+    trailing_commas.verified_stmt(r#"SELECT "from" FROM "from""#);
 
     // doesn't allow any trailing commas
     let trailing_commas = TestedDialects {


### PR DESCRIPTION
#1212 introduced a regression in the recently released 0.48, disallowing the (valid) quoted identifier `"from"` in SELECT clauses, eg:

```sql
SELECT dt, rate, "to", "from" FROM fx_rates
```
Improved the check by additionally confirming that the _potentially_ invalid `from` is not quoted, and added coverage.

---

FYI: this was caught by our (Polars) SQL unit tests while I was looking to upgrade us to 0.48 to take advantage of a couple of small PRs I added recently. Not sure if you usually make minor point releases to address regressions? If not, we can wait until 0.49 (or temporarily point to the fix on a branch), so no rush if that's the case 👍 