### PR TITLE
Allow to use `()` as the GROUP BY nothing

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1474,6 +1474,11 @@ impl<'a> Parser<'a> {
                 let result = self.parse_comma_separated(|p| p.parse_tuple(true, true))?;
                 self.expect_token(&Token::RParen)?;
                 Ok(Expr::Rollup(result))
+            } else if self.consume_tokens(&[Token::LParen, Token::RParen]) {
+                // PostgreSQL allow to use empty tuple as a group by expression,
+                // e.g. `GROUP BY (), name`. Please refer to GROUP BY Clause section in
+                // [PostgreSQL](https://www.postgresql.org/docs/16/sql-select.html)
+                Ok(Expr::Tuple(vec![]))
             } else {
                 self.parse_expr()
             }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -42,6 +42,7 @@ mod test_utils;
 
 #[cfg(test)]
 use pretty_assertions::assert_eq;
+use sqlparser::ast::Expr::Identifier;
 use sqlparser::test_utils::all_dialects_except;
 
 #[test]
@@ -10130,4 +10131,31 @@ fn parse_auto_increment_too_large() {
         .parse_statements();
 
     assert!(res.is_err(), "{res:?}");
+}
+
+#[test]
+fn test_group_by_nothing() {
+    let Select { group_by, .. } = all_dialects_where(|d| d.supports_group_by_expr())
+        .verified_only_select("SELECT count(1) FROM t GROUP BY ()");
+    {
+        std::assert_eq!(
+            GroupByExpr::Expressions(vec![Expr::Tuple(vec![])], vec![]),
+            group_by
+        );
+    }
+
+    let Select { group_by, .. } = all_dialects_where(|d| d.supports_group_by_expr())
+        .verified_only_select("SELECT name, count(1) FROM t GROUP BY name, ()");
+    {
+        std::assert_eq!(
+            GroupByExpr::Expressions(
+                vec![
+                    Identifier(Ident::new("name".to_string())),
+                    Expr::Tuple(vec![])
+                ],
+                vec![]
+            ),
+            group_by
+        );
+    }
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -18,7 +18,6 @@
 mod test_utils;
 use test_utils::*;
 
-use sqlparser::ast::Expr::Identifier;
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, PostgreSqlDialect};
 use sqlparser::parser::ParserError;
@@ -4440,32 +4439,5 @@ fn test_table_unnest_with_ordinality() {
             ..
         } => {}
         _ => panic!("Expecting TableFactor::UNNEST with ordinality"),
-    }
-}
-
-#[test]
-fn test_group_by_nothing() {
-    let Select { group_by, .. } =
-        pg_and_generic().verified_only_select("SELECT count(1) FROM t GROUP BY ()");
-    {
-        assert_eq!(
-            GroupByExpr::Expressions(vec![Expr::Tuple(vec![])], vec![]),
-            group_by
-        );
-    }
-
-    let Select { group_by, .. } =
-        pg_and_generic().verified_only_select("SELECT name, count(1) FROM t GROUP BY name, ()");
-    {
-        assert_eq!(
-            GroupByExpr::Expressions(
-                vec![
-                    Identifier(Ident::new("name".to_string())),
-                    Expr::Tuple(vec![])
-                ],
-                vec![]
-            ),
-            group_by
-        );
     }
 }


### PR DESCRIPTION
Currently, PostgreSQL supports using `()` as one of the group by elements that represent the meaning of nothing. Please refer to the GROUP BY Clause section in [PostgreSQL](https://www.postgresql.org/docs/16/sql-select.html).

This PR will close #1092.