### PR TITLE
Allow to use the TABLE keyword in DESC|DESCRIBE|EXPLAIN TABLE statement

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2699,6 +2699,11 @@ pub enum Statement {
         describe_alias: DescribeAlias,
         /// Hive style `FORMATTED | EXTENDED`
         hive_format: Option<HiveDescribeFormat>,
+        /// Snowflake and ClickHouse support `DESC|DESCRIBE TABLE <table_name>` syntax
+        ///
+        /// [Snowflake](https://docs.snowflake.com/en/sql-reference/sql/desc-table.html)
+        /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/describe-table)
+        has_table_keyword: bool,
         /// Table name
         #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
         table_name: ObjectName,
@@ -2872,12 +2877,16 @@ impl fmt::Display for Statement {
             Statement::ExplainTable {
                 describe_alias,
                 hive_format,
+                has_table_keyword,
                 table_name,
             } => {
                 write!(f, "{describe_alias} ")?;
 
                 if let Some(format) = hive_format {
                     write!(f, "{} ", format)?;
+                }
+                if *has_table_keyword {
+                    write!(f, "TABLE ")?;
                 }
 
                 write!(f, "{table_name}")

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7972,10 +7972,13 @@ impl<'a> Parser<'a> {
                     _ => {}
                 }
 
+                // only allow to use TABLE keyword for DESC|DESCRIBE statement
+                let has_table_keyword = self.parse_keyword(Keyword::TABLE);
                 let table_name = self.parse_object_name(false)?;
                 Ok(Statement::ExplainTable {
                     describe_alias,
                     hive_format,
+                    has_table_keyword,
                     table_name,
                 })
             }


### PR DESCRIPTION
This closes #1160.