### PR TITLE
Allow to use the GLOBAL keyword before the join operator

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1537,6 +1537,9 @@ impl Display for TableVersion {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct Join {
     pub relation: TableFactor,
+    /// ClickHouse supports the optional `GLOBAL` keyword before the join operator.
+    /// See [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/select/join)
+    pub global: bool,
     pub join_operator: JoinOperator,
 }
 
@@ -1563,6 +1566,10 @@ impl fmt::Display for Join {
             }
             Suffix(constraint)
         }
+        if self.global {
+            write!(f, " GLOBAL")?;
+        }
+
         match &self.join_operator {
             JoinOperator::Inner(constraint) => write!(
                 f,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -850,6 +850,7 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::USING,
     Keyword::CLUSTER,
     Keyword::DISTRIBUTE,
+    Keyword::GLOBAL,
     // for MSSQL-specific OUTER APPLY (seems reserved in most dialects)
     Keyword::OUTER,
     Keyword::SET,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9003,6 +9003,7 @@ impl<'a> Parser<'a> {
         // a table alias.
         let mut joins = vec![];
         loop {
+            let global = self.parse_keyword(Keyword::GLOBAL);
             let join = if self.parse_keyword(Keyword::CROSS) {
                 let join_operator = if self.parse_keyword(Keyword::JOIN) {
                     JoinOperator::CrossJoin
@@ -9014,6 +9015,7 @@ impl<'a> Parser<'a> {
                 };
                 Join {
                     relation: self.parse_table_factor()?,
+                    global,
                     join_operator,
                 }
             } else if self.parse_keyword(Keyword::OUTER) {
@@ -9021,6 +9023,7 @@ impl<'a> Parser<'a> {
                 self.expect_keyword(Keyword::APPLY)?;
                 Join {
                     relation: self.parse_table_factor()?,
+                    global,
                     join_operator: JoinOperator::OuterApply,
                 }
             } else if self.parse_keyword(Keyword::ASOF) {
@@ -9030,6 +9033,7 @@ impl<'a> Parser<'a> {
                 let match_condition = self.parse_parenthesized(Self::parse_expr)?;
                 Join {
                     relation,
+                    global,
                     join_operator: JoinOperator::AsOf {
                         match_condition,
                         constraint: self.parse_join_constraint(false)?,
@@ -9115,6 +9119,7 @@ impl<'a> Parser<'a> {
                 let join_constraint = self.parse_join_constraint(natural)?;
                 Join {
                     relation,
+                    global,
                     join_operator: join_operator_type(join_constraint),
                 }
             };

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -331,6 +331,7 @@ pub fn table_with_alias(name: impl Into<String>, alias: impl Into<String>) -> Ta
 pub fn join(relation: TableFactor) -> Join {
     Join {
         relation,
+        global: false,
         join_operator: JoinOperator::Inner(JoinConstraint::Natural),
     }
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1557,6 +1557,7 @@ fn parse_join_constraint_unnest_alias() {
                 with_offset_alias: None,
                 with_ordinality: false,
             },
+            global: false,
             join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("c1".into())),
                 op: BinaryOperator::Eq,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1891,6 +1891,7 @@ fn parse_update_with_joins() {
                             partitions: vec![],
                             with_ordinality: false,
                         },
+                        global: false,
                         join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
                             left: Box::new(Expr::CompoundIdentifier(vec![
                                 Ident::new("o"),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4102,6 +4102,7 @@ fn parse_join_constraint_unnest_alias() {
                 with_offset_alias: None,
                 with_ordinality: false,
             },
+            global: false,
             join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("c1".into())),
                 op: BinaryOperator::Eq,

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2206,6 +2206,7 @@ fn asof_joins() {
             relation: table_with_alias("trades_unixtime", "tu"),
             joins: vec![Join {
                 relation: table_with_alias("quotes_unixtime", "qu"),
+                global: false,
                 join_operator: JoinOperator::AsOf {
                     match_condition: Expr::BinaryOp {
                         left: Box::new(Expr::CompoundIdentifier(vec![


### PR DESCRIPTION
ClickHouse supports the GLOBAL keyworld while joining the right table,

for the syntax, please refer to:

```SQL
SELECT <expr_list>
FROM <left_table>
[GLOBAL] [INNER|LEFT|RIGHT|FULL|CROSS] [OUTER|SEMI|ANTI|ANY|ALL|ASOF] JOIN <right_table>
(ON <expr_list>)|(USING <column_list>)
```

Reference: https://clickhouse.com/docs/en/sql-reference/statements/select/join