### PR TITLE
Parse SETTINGS clause for ClickHouse table-valued functions

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -50,8 +50,8 @@ pub use self::query::{
     OffsetRows, OrderBy, OrderByExpr, PivotValueSource, Query, RenameSelectItem,
     RepetitionQuantifier, ReplaceSelectElement, ReplaceSelectItem, RowsPerMatch, Select,
     SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, Setting, SymbolDefinition, Table,
-    TableAlias, TableFactor, TableVersion, TableWithJoins, Top, TopQuantity, ValueTableMode,
-    Values, WildcardAdditionalOptions, With, WithFill,
+    TableAlias, TableFactor, TableFunctionArgs, TableVersion, TableWithJoins, Top, TopQuantity,
+    ValueTableMode, Values, WildcardAdditionalOptions, With, WithFill,
 };
 pub use self::value::{
     escape_double_quote_string, escape_quoted_string, DateTimeField, DollarQuotedString,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -899,11 +899,16 @@ impl fmt::Display for ExprWithAlias {
     }
 }
 
+/// Arguments to a table-valued function
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct TableFunctionArgs {
     pub args: Vec<FunctionArg>,
+    /// ClickHouse-specific SETTINGS clause.
+    /// For example,
+    /// `SELECT * FROM executable('generate_random.py', TabSeparated, 'id UInt32, random String', SETTINGS send_chunk_header = false, pool_size = 16)`
+    /// [`executable` table function](https://clickhouse.com/docs/en/engines/table-functions/executable)
     pub settings: Option<Vec<Setting>>,
 }
 

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1330,7 +1330,10 @@ impl fmt::Display for TableFactor {
                     write!(f, "(")?;
                     write!(f, "{}", display_comma_separated(&args.args))?;
                     if let Some(ref settings) = args.settings {
-                        write!(f, ", SETTINGS {}", display_comma_separated(settings))?;
+                        if !args.args.is_empty() {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "SETTINGS {}", display_comma_separated(settings))?;
                     }
                     write!(f, ")")?;
                 }

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1093,7 +1093,7 @@ fn parse_create_table_on_commit_and_as_query() {
 
 #[test]
 fn parse_select_table_function_settings() {
-    let sql = r#"SELECT * FROM table_function(arg, SETTINGS setting = 3)"#;
+    let sql = r#"SELECT * FROM table_function(arg, SETTINGS s0 = 3, s1 = 's')"#;
     match clickhouse_and_generic().verified_stmt(sql) {
         Statement::Query(q) => {
             let from = &q.body.as_select().unwrap().from;
@@ -1110,10 +1110,16 @@ fn parse_select_table_function_settings() {
                     );
                     assert_eq!(
                         args.settings,
-                        Some(vec![Setting {
-                            key: "setting".into(),
-                            value: Value::Number("3".into(), false)
-                        }])
+                        Some(vec![
+                            Setting {
+                                key: "s0".into(),
+                                value: Value::Number("3".into(), false)
+                            },
+                            Setting {
+                                key: "s1".into(),
+                                value: Value::SingleQuotedString("s".into())
+                            }
+                        ])
                     )
                 }
                 _ => unreachable!(),

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1113,7 +1113,7 @@ fn parse_select_table_function_settings() {
                         Some(vec![
                             Setting {
                                 key: "s0".into(),
-                                value: Value::Number("3".into(), false)
+                                value: Value::Number("3".parse().unwrap(), false)
                             },
                             Setting {
                                 key: "s1".into(),

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1093,39 +1093,78 @@ fn parse_create_table_on_commit_and_as_query() {
 
 #[test]
 fn parse_select_table_function_settings() {
-    let sql = r#"SELECT * FROM table_function(arg, SETTINGS s0 = 3, s1 = 's')"#;
-    match clickhouse_and_generic().verified_stmt(sql) {
-        Statement::Query(q) => {
-            let from = &q.body.as_select().unwrap().from;
-            assert_eq!(from.len(), 1);
-            assert_eq!(from[0].joins, vec![]);
-            match &from[0].relation {
-                Table { args, .. } => {
-                    let args = args.as_ref().unwrap();
-                    assert_eq!(
-                        args.args,
-                        vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                            Expr::Identifier("arg".into())
-                        ))]
-                    );
-                    assert_eq!(
-                        args.settings,
-                        Some(vec![
-                            Setting {
-                                key: "s0".into(),
-                                value: Value::Number("3".parse().unwrap(), false)
-                            },
-                            Setting {
-                                key: "s1".into(),
-                                value: Value::SingleQuotedString("s".into())
-                            }
-                        ])
-                    )
+    fn check_settings(sql: &str, expected: &TableFunctionArgs) {
+        match clickhouse_and_generic().verified_stmt(sql) {
+            Statement::Query(q) => {
+                let from = &q.body.as_select().unwrap().from;
+                assert_eq!(from.len(), 1);
+                assert_eq!(from[0].joins, vec![]);
+                match &from[0].relation {
+                    Table { args, .. } => {
+                        let args = args.as_ref().unwrap();
+                        assert_eq!(args, expected);
+                    }
+                    _ => unreachable!(),
                 }
-                _ => unreachable!(),
             }
+            _ => unreachable!(),
         }
-        _ => unreachable!(),
+    }
+    check_settings(
+        "SELECT * FROM table_function(arg, SETTINGS s0 = 3, s1 = 's')",
+        &TableFunctionArgs {
+            args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
+                Expr::Identifier("arg".into()),
+            ))],
+
+            settings: Some(vec![
+                Setting {
+                    key: "s0".into(),
+                    value: Value::Number("3".parse().unwrap(), false),
+                },
+                Setting {
+                    key: "s1".into(),
+                    value: Value::SingleQuotedString("s".into()),
+                },
+            ]),
+        },
+    );
+    check_settings(
+        r#"SELECT * FROM table_function(arg)"#,
+        &TableFunctionArgs {
+            args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
+                Expr::Identifier("arg".into()),
+            ))],
+            settings: None,
+        },
+    );
+    check_settings(
+        "SELECT * FROM table_function(SETTINGS s0 = 3, s1 = 's')",
+        &TableFunctionArgs {
+            args: vec![],
+            settings: Some(vec![
+                Setting {
+                    key: "s0".into(),
+                    value: Value::Number("3".parse().unwrap(), false),
+                },
+                Setting {
+                    key: "s1".into(),
+                    value: Value::SingleQuotedString("s".into()),
+                },
+            ]),
+        },
+    );
+    let invalid_cases = vec![
+        "SELECT * FROM t(SETTINGS a)",
+        "SELECT * FROM t(SETTINGS a=)",
+        "SELECT * FROM t(SETTINGS a=1, b)",
+        "SELECT * FROM t(SETTINGS a=1, b=)",
+        "SELECT * FROM t(SETTINGS a=1, b=c)",
+    ];
+    for sql in invalid_cases {
+        clickhouse_and_generic()
+            .parse_sql_statements(sql)
+            .expect_err("Expected: SETTINGS key = value, found: ");
     }
 }
 


### PR DESCRIPTION
Allows parsing the [`executable`](https://clickhouse.com/docs/en/engines/table-functions/executable) table-valued function, for example