### PR TITLE
Support `Dialect` level precedence, update Postgres `Dialect` to match Postgres

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -151,7 +151,7 @@ pub enum BinaryOperator {
     Arrow,
     /// The `->>` operator.
     ///
-    /// On PostgreSQL, this operator that extracts a JSON object field or JSON
+    /// On PostgreSQL, this operator extracts a JSON object field or JSON
     /// array element and converts it to text, for example `'{"a":"b"}'::json
     /// ->> 'a'` or `[1, 2, 3]'::json ->> 2`.
     ///

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -44,10 +44,10 @@ pub use self::postgresql::PostgreSqlDialect;
 pub use self::redshift::RedshiftSqlDialect;
 pub use self::snowflake::SnowflakeDialect;
 pub use self::sqlite::SQLiteDialect;
-pub use crate::keywords;
 use crate::ast::{Expr, Statement};
-use crate::parser::{Parser, ParserError};
+pub use crate::keywords;
 use crate::keywords::Keyword;
+use crate::parser::{Parser, ParserError};
 use crate::tokenizer::Token;
 
 #[cfg(not(feature = "std"))]

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -44,7 +44,7 @@ pub use self::redshift::RedshiftSqlDialect;
 pub use self::snowflake::SnowflakeDialect;
 pub use self::sqlite::SQLiteDialect;
 pub use crate::keywords;
-use crate::parser::{Parser, ParserError};
+use crate::parser::{Parser, ParserError, Precedence};
 
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
@@ -304,6 +304,10 @@ pub trait Dialect: Debug + Any {
     fn parse_statement(&self, _parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
         // return None to fall back to the default behavior
         None
+    }
+
+    fn precedence_numeric(&self, p: Precedence) -> u8 {
+        p.numeric()
     }
 }
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -24,11 +24,12 @@ mod redshift;
 mod snowflake;
 mod sqlite;
 
-use crate::ast::{Expr, Statement};
 use core::any::{Any, TypeId};
 use core::fmt::Debug;
 use core::iter::Peekable;
 use core::str::Chars;
+
+use log::debug;
 
 pub use self::ansi::AnsiDialect;
 pub use self::bigquery::BigQueryDialect;
@@ -44,13 +45,13 @@ pub use self::redshift::RedshiftSqlDialect;
 pub use self::snowflake::SnowflakeDialect;
 pub use self::sqlite::SQLiteDialect;
 pub use crate::keywords;
+use crate::ast::{Expr, Statement};
 use crate::parser::{Parser, ParserError};
-
 use crate::keywords::Keyword;
 use crate::tokenizer::Token;
+
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
-use log::debug;
 
 /// Convenience check if a [`Parser`] uses a certain dialect.
 ///
@@ -304,7 +305,9 @@ pub trait Dialect: Debug + Any {
         None
     }
 
-    /// Get the precedence of the next token
+    /// Get the precedence of the next token. This "full" method means all precedence logic and remain
+    /// in the dialect. while still allowing overriding the `get_next_precedence` method with the option to
+    /// fallback to the default behavior.
     ///
     /// Higher number => higher precedence
     fn get_next_precedence_full(&self, parser: &Parser) -> Result<u8, ParserError> {

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -9,6 +9,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use log::debug;
 
 use crate::ast::{CommentObject, Statement};
 use crate::dialect::Dialect;
@@ -19,6 +20,24 @@ use crate::tokenizer::Token;
 /// A [`Dialect`] for [PostgreSQL](https://www.postgresql.org/)
 #[derive(Debug)]
 pub struct PostgreSqlDialect {}
+
+
+// based on https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE
+const DOUBLE_COLON_PREC: u8 = 140;
+const BRACKET_PREC: u8 = 130;
+const COLLATE_PREC: u8 = 120;
+const AT_TZ_PREC: u8 = 110;
+const CARET_PREC: u8 = 100;
+const MUL_DIV_MOD_OP_PREC: u8 = 90;
+const PLUS_MINUS_PREC: u8 = 80;
+const PG_OTHER_PREC: u8 = 70;
+const BETWEEN_LIKE_PREC: u8 = 60;
+const EQ_PREC: u8 = 50;
+const IS_PREC: u8 = 40;
+const NOT_PREC: u8 = 30;
+const AND_PREC: u8 = 20;
+const OR_PREC: u8 = 10;
+const UNKNOWN_PREC: u8 = 0;
 
 impl Dialect for PostgreSqlDialect {
     fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
@@ -65,6 +84,97 @@ impl Dialect for PostgreSqlDialect {
                 | '`'
                 | '?'
         )
+    }
+
+    fn get_next_precedence(&self, parser: &Parser) -> Option<Result<u8, ParserError>> {
+        // return None to fall back to the default behavior
+
+        let token = parser.peek_token();
+        debug!("get_next_precedence() {:?}", token);
+        let precedence = match token.token {
+            Token::Word(w) if w.keyword == Keyword::OR => OR_PREC,
+            Token::Word(w) if w.keyword == Keyword::AND => AND_PREC,
+            Token::Word(w) if w.keyword == Keyword::AT => {
+                match (parser.peek_nth_token(1).token, parser.peek_nth_token(2).token) {
+                    (Token::Word(w), Token::Word(w2))
+                        if w.keyword == Keyword::TIME && w2.keyword == Keyword::ZONE =>
+                    {
+                        AT_TZ_PREC
+                    }
+                    _ => UNKNOWN_PREC,
+                }
+            }
+
+            Token::Word(w) if w.keyword == Keyword::NOT => match parser.peek_nth_token(1).token {
+                // The precedence of NOT varies depending on keyword that
+                // follows it. If it is followed by IN, BETWEEN, or LIKE,
+                // it takes on the precedence of those tokens. Otherwise, it
+                // is not an infix operator, and therefore has zero
+                // precedence.
+                Token::Word(w) if w.keyword == Keyword::IN => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::BETWEEN => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::LIKE => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::ILIKE => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::RLIKE => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::REGEXP => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::SIMILAR => BETWEEN_LIKE_PREC,
+                _ => NOT_PREC,
+            },
+            Token::Word(w) if w.keyword == Keyword::IS => IS_PREC,
+            Token::Word(w) if w.keyword == Keyword::IN => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::BETWEEN => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::LIKE => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::ILIKE => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::RLIKE => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::REGEXP => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::SIMILAR => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::OPERATOR => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::DIV => MUL_DIV_MOD_OP_PREC,
+            Token::Word(w) if w.keyword == Keyword::COLLATE => COLLATE_PREC,
+            Token::Eq
+            | Token::Lt
+            | Token::LtEq
+            | Token::Neq
+            | Token::Gt
+            | Token::GtEq
+            | Token::DoubleEq
+            | Token::Tilde
+            | Token::TildeAsterisk
+            | Token::ExclamationMarkTilde
+            | Token::ExclamationMarkTildeAsterisk
+            | Token::DoubleTilde
+            | Token::DoubleTildeAsterisk
+            | Token::ExclamationMarkDoubleTilde
+            | Token::ExclamationMarkDoubleTildeAsterisk
+            | Token::Spaceship => EQ_PREC,
+            Token::Caret => CARET_PREC,
+            Token::Plus | Token::Minus => PLUS_MINUS_PREC,
+            Token::Mul | Token::Div | Token::Mod => MUL_DIV_MOD_OP_PREC,
+            Token::DoubleColon => DOUBLE_COLON_PREC,
+            Token::LBracket => BRACKET_PREC,
+            Token::Arrow
+            | Token::LongArrow
+            | Token::HashArrow
+            | Token::HashLongArrow
+            | Token::AtArrow
+            | Token::ArrowAt
+            | Token::HashMinus
+            | Token::AtQuestion
+            | Token::AtAt
+            | Token::Question
+            | Token::QuestionAnd
+            | Token::QuestionPipe
+            | Token::ExclamationMark
+            | Token::Overlap
+            | Token::CaretAt
+            | Token::StringConcat
+            | Token::Sharp
+            | Token::ShiftRight
+            | Token::ShiftLeft
+            | Token::CustomBinaryOperator(_) => PG_OTHER_PREC,
+            _ => UNKNOWN_PREC,
+        };
+        Some(Ok(precedence))
     }
 
     fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -14,15 +14,29 @@ use log::debug;
 use crate::ast::{CommentObject, Statement};
 use crate::dialect::Dialect;
 use crate::keywords::Keyword;
-use crate::parser::{Parser, ParserError, Precedence};
+use crate::parser::{Parser, ParserError};
 use crate::tokenizer::Token;
 
 /// A [`Dialect`] for [PostgreSQL](https://www.postgresql.org/)
 #[derive(Debug)]
 pub struct PostgreSqlDialect {}
 
+const DOUBLE_COLON_PREC: u8 = 140;
 const BRACKET_PREC: u8 = 130;
 const COLLATE_PREC: u8 = 120;
+const AT_TZ_PREC: u8 = 110;
+const CARET_PREC: u8 = 100;
+const MUL_DIV_MOD_OP_PREC: u8 = 90;
+const PLUS_MINUS_PREC: u8 = 80;
+// there's no XOR operator in PostgreSQL, but support it here to avoid breaking tests
+const XOR_PREC: u8 = 75;
+const PG_OTHER_PREC: u8 = 70;
+const BETWEEN_LIKE_PREC: u8 = 60;
+const EQ_PREC: u8 = 50;
+const IS_PREC: u8 = 40;
+const NOT_PREC: u8 = 30;
+const AND_PREC: u8 = 20;
+const OR_PREC: u8 = 10;
 
 impl Dialect for PostgreSqlDialect {
     fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
@@ -75,14 +89,10 @@ impl Dialect for PostgreSqlDialect {
         let token = parser.peek_token();
         debug!("get_next_precedence() {:?}", token);
 
-        macro_rules! p {
-            ($precedence:ident) => {self.precedence_numeric(Precedence::$precedence)};
-        }
-
         let precedence = match token.token {
-            Token::Word(w) if w.keyword == Keyword::OR => p!(Or),
-            Token::Word(w) if w.keyword == Keyword::XOR => p!(Xor),
-            Token::Word(w) if w.keyword == Keyword::AND => p!(And),
+            Token::Word(w) if w.keyword == Keyword::OR => OR_PREC,
+            Token::Word(w) if w.keyword == Keyword::XOR => XOR_PREC,
+            Token::Word(w) if w.keyword == Keyword::AND => AND_PREC,
             Token::Word(w) if w.keyword == Keyword::AT => {
                 match (
                     parser.peek_nth_token(1).token,
@@ -91,9 +101,9 @@ impl Dialect for PostgreSqlDialect {
                     (Token::Word(w), Token::Word(w2))
                         if w.keyword == Keyword::TIME && w2.keyword == Keyword::ZONE =>
                     {
-                        p!(AtTz)
+                        AT_TZ_PREC
                     }
-                    _ => p!(Unknown),
+                    _ => self.prec_unknown(),
                 }
             }
 
@@ -103,25 +113,25 @@ impl Dialect for PostgreSqlDialect {
                 // it takes on the precedence of those tokens. Otherwise, it
                 // is not an infix operator, and therefore has zero
                 // precedence.
-                Token::Word(w) if w.keyword == Keyword::IN => p!(Between),
-                Token::Word(w) if w.keyword == Keyword::BETWEEN => p!(Between),
-                Token::Word(w) if w.keyword == Keyword::LIKE => p!(Between),
-                Token::Word(w) if w.keyword == Keyword::ILIKE => p!(Between),
-                Token::Word(w) if w.keyword == Keyword::RLIKE => p!(Between),
-                Token::Word(w) if w.keyword == Keyword::REGEXP => p!(Between),
-                Token::Word(w) if w.keyword == Keyword::SIMILAR => p!(Between),
-                _ => p!(Unknown),
+                Token::Word(w) if w.keyword == Keyword::IN => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::BETWEEN => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::LIKE => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::ILIKE => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::RLIKE => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::REGEXP => BETWEEN_LIKE_PREC,
+                Token::Word(w) if w.keyword == Keyword::SIMILAR => BETWEEN_LIKE_PREC,
+                _ => self.prec_unknown(),
             },
-            Token::Word(w) if w.keyword == Keyword::IS => p!(Is),
-            Token::Word(w) if w.keyword == Keyword::IN => p!(Between),
-            Token::Word(w) if w.keyword == Keyword::BETWEEN => p!(Between),
-            Token::Word(w) if w.keyword == Keyword::LIKE => p!(Between),
-            Token::Word(w) if w.keyword == Keyword::ILIKE => p!(Between),
-            Token::Word(w) if w.keyword == Keyword::RLIKE => p!(Between),
-            Token::Word(w) if w.keyword == Keyword::REGEXP => p!(Between),
-            Token::Word(w) if w.keyword == Keyword::SIMILAR => p!(Between),
-            Token::Word(w) if w.keyword == Keyword::OPERATOR => p!(Between),
-            Token::Word(w) if w.keyword == Keyword::DIV => p!(MulDivModOp),
+            Token::Word(w) if w.keyword == Keyword::IS => IS_PREC,
+            Token::Word(w) if w.keyword == Keyword::IN => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::BETWEEN => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::LIKE => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::ILIKE => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::RLIKE => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::REGEXP => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::SIMILAR => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::OPERATOR => BETWEEN_LIKE_PREC,
+            Token::Word(w) if w.keyword == Keyword::DIV => MUL_DIV_MOD_OP_PREC,
             Token::Word(w) if w.keyword == Keyword::COLLATE => COLLATE_PREC,
             Token::Eq
             | Token::Lt
@@ -138,13 +148,11 @@ impl Dialect for PostgreSqlDialect {
             | Token::DoubleTildeAsterisk
             | Token::ExclamationMarkDoubleTilde
             | Token::ExclamationMarkDoubleTildeAsterisk
-            | Token::Spaceship => p!(Eq),
-            Token::Pipe => p!(Pipe),
-            Token::Caret => p!(Caret),
-            Token::Ampersand => p!(Ampersand),
-            Token::Plus | Token::Minus => p!(PlusMinus),
-            Token::Mul | Token::Div | Token::Mod => p!(MulDivModOp),
-            Token::DoubleColon => p!(DoubleColon),
+            | Token::Spaceship => EQ_PREC,
+            Token::Caret => CARET_PREC,
+            Token::Plus | Token::Minus => PLUS_MINUS_PREC,
+            Token::Mul | Token::Div | Token::Mod => MUL_DIV_MOD_OP_PREC,
+            Token::DoubleColon => DOUBLE_COLON_PREC,
             Token::LBracket => BRACKET_PREC,
             Token::Arrow
             | Token::LongArrow
@@ -165,8 +173,10 @@ impl Dialect for PostgreSqlDialect {
             | Token::Sharp
             | Token::ShiftRight
             | Token::ShiftLeft
-            | Token::CustomBinaryOperator(_) => p!(PgOther),
-            _ => p!(Unknown),
+            | Token::Pipe
+            | Token::Ampersand
+            | Token::CustomBinaryOperator(_) => PG_OTHER_PREC,
+            _ => self.prec_unknown(),
         };
         Some(Ok(precedence))
     }
@@ -187,42 +197,24 @@ impl Dialect for PostgreSqlDialect {
         true
     }
 
-    /*
-    const DOUBLE_COLON_PREC: u8 = 140;
-    const BRACKET_PREC: u8 = 130;
-    const COLLATE_PREC: u8 = 120;
-    const AT_TZ_PREC: u8 = 110;
-    const CARET_PREC: u8 = 100;
-    const MUL_DIV_MOD_OP_PREC: u8 = 90;
-    const PLUS_MINUS_PREC: u8 = 80;
-    const PG_OTHER_PREC: u8 = 70;
-    const BETWEEN_LIKE_PREC: u8 = 60;
-    const EQ_PREC: u8 = 50;
-    const IS_PREC: u8 = 40;
-    const NOT_PREC: u8 = 30;
-    const AND_PREC: u8 = 20;
-    const OR_PREC: u8 = 10;
-    const UNKNOWN_PREC: u8 = 0;
-     */
-    /// based on https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE
-    fn precedence_numeric(&self, p: Precedence) -> u8 {
-        match p {
-            Precedence::DoubleColon => 140,
-            Precedence::AtTz => 110,
-            Precedence::MulDivModOp => 90,
-            Precedence::PlusMinus => 80,
-            Precedence::Caret => 110,
-            Precedence::Between => 60,
-            Precedence::Eq => 50,
-            Precedence::Like => 60,
-            Precedence::Is => 40,
-            Precedence::PgOther | Precedence::Pipe | Precedence::Ampersand => 70,
-            Precedence::UnaryNot => 30,
-            Precedence::And => 20,
-            Precedence::Xor => 79,
-            Precedence::Or => 10,
-            Precedence::Unknown => 0,
-        }
+    fn prec_mul_div_mod_op(&self) -> u8 {
+        MUL_DIV_MOD_OP_PREC
+    }
+
+    fn prec_plus_minus(&self) -> u8 {
+        PLUS_MINUS_PREC
+    }
+
+    fn prec_between(&self) -> u8 {
+        BETWEEN_LIKE_PREC
+    }
+
+    fn prec_like(&self) -> u8 {
+        BETWEEN_LIKE_PREC
+    }
+
+    fn prec_unary_not(&self) -> u8 {
+        NOT_PREC
     }
 }
 

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -145,6 +145,15 @@ impl Dialect for SnowflakeDialect {
 
         None
     }
+
+    fn get_next_precedence(&self, parser: &Parser) -> Option<Result<u8, ParserError>> {
+        let token = parser.peek_token();
+        // Snowflake supports the `:` cast operator unlike other dialects
+        match token.token {
+            Token::Colon => Some(Ok(self.prec_double_colon())),
+            _ => None,
+        }
+    }
 }
 
 /// Parse snowflake create table statement.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -871,7 +871,7 @@ impl<'a> Parser<'a> {
     /// Parse a new expression.
     pub fn parse_expr(&mut self) -> Result<Expr, ParserError> {
         let _guard = self.recursion_counter.try_decrease()?;
-        self.parse_subexpr(0)
+        self.parse_subexpr(self.dialect.prec_unknown())
     }
 
     /// Parse tokens until the precedence changes.
@@ -893,7 +893,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_interval_expr(&mut self) -> Result<Expr, ParserError> {
-        let precedence = 0;
+        let precedence = self.dialect.prec_unknown();
         let mut expr = self.parse_prefix()?;
 
         loop {
@@ -914,9 +914,9 @@ impl<'a> Parser<'a> {
         let token = self.peek_token();
 
         match token.token {
-            Token::Word(w) if w.keyword == Keyword::AND => Ok(0),
-            Token::Word(w) if w.keyword == Keyword::OR => Ok(0),
-            Token::Word(w) if w.keyword == Keyword::XOR => Ok(0),
+            Token::Word(w) if w.keyword == Keyword::AND => Ok(self.dialect.prec_unknown()),
+            Token::Word(w) if w.keyword == Keyword::OR => Ok(self.dialect.prec_unknown()),
+            Token::Word(w) if w.keyword == Keyword::XOR => Ok(self.dialect.prec_unknown()),
             _ => self.get_next_precedence(),
         }
     }
@@ -1075,7 +1075,7 @@ impl<'a> Parser<'a> {
                     self.parse_bigquery_struct_literal()
                 }
                 Keyword::PRIOR if matches!(self.state, ParserState::ConnectBy) => {
-                    let expr = self.parse_subexpr(self.prec(Precedence::PlusMinus))?;
+                    let expr = self.parse_subexpr(self.dialect.prec_plus_minus())?;
                     Ok(Expr::Prior(Box::new(expr)))
                 }
                 Keyword::MAP if self.peek_token() == Token::LBrace && self.dialect.support_map_literal_syntax() => {
@@ -1163,7 +1163,7 @@ impl<'a> Parser<'a> {
                 };
                 Ok(Expr::UnaryOp {
                     op,
-                    expr: Box::new(self.parse_subexpr(self.prec(Precedence::MulDivModOp))?),
+                    expr: Box::new(self.parse_subexpr(self.dialect.prec_mul_div_mod_op())?),
                 })
             }
             tok @ Token::DoubleExclamationMark
@@ -1183,7 +1183,7 @@ impl<'a> Parser<'a> {
                 };
                 Ok(Expr::UnaryOp {
                     op,
-                    expr: Box::new(self.parse_subexpr(self.prec(Precedence::PlusMinus))?),
+                    expr: Box::new(self.parse_subexpr(self.dialect.prec_plus_minus())?),
                 })
             }
             Token::EscapedStringLiteral(_) if dialect_of!(self is PostgreSqlDialect | GenericDialect) =>
@@ -1712,7 +1712,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_position_expr(&mut self, ident: Ident) -> Result<Expr, ParserError> {
-        let between_prec = self.prec(Precedence::Between);
+        let between_prec = self.dialect.prec_between();
         let position_expr = self.maybe_parse(|p| {
             // PARSE SELECT POSITION('@' in field)
             p.expect_token(&Token::LParen)?;
@@ -1968,12 +1968,12 @@ impl<'a> Parser<'a> {
                 }
                 _ => Ok(Expr::UnaryOp {
                     op: UnaryOperator::Not,
-                    expr: Box::new(self.parse_subexpr(self.prec(Precedence::UnaryNot))?),
+                    expr: Box::new(self.parse_subexpr(self.dialect.prec_unary_not())?),
                 }),
             },
             _ => Ok(Expr::UnaryOp {
                 op: UnaryOperator::Not,
-                expr: Box::new(self.parse_subexpr(self.prec(Precedence::UnaryNot))?),
+                expr: Box::new(self.parse_subexpr(self.dialect.prec_unary_not())?),
             }),
         }
     }
@@ -2649,7 +2649,7 @@ impl<'a> Parser<'a> {
                         Ok(Expr::RLike {
                             negated,
                             expr: Box::new(expr),
-                            pattern: Box::new(self.parse_subexpr(self.prec(Precedence::Like))?),
+                            pattern: Box::new(self.parse_subexpr(self.dialect.prec_like())?),
                             regexp,
                         })
                     } else if self.parse_keyword(Keyword::IN) {
@@ -2660,21 +2660,21 @@ impl<'a> Parser<'a> {
                         Ok(Expr::Like {
                             negated,
                             expr: Box::new(expr),
-                            pattern: Box::new(self.parse_subexpr(self.prec(Precedence::Like))?),
+                            pattern: Box::new(self.parse_subexpr(self.dialect.prec_like())?),
                             escape_char: self.parse_escape_char()?,
                         })
                     } else if self.parse_keyword(Keyword::ILIKE) {
                         Ok(Expr::ILike {
                             negated,
                             expr: Box::new(expr),
-                            pattern: Box::new(self.parse_subexpr(self.prec(Precedence::Like))?),
+                            pattern: Box::new(self.parse_subexpr(self.dialect.prec_like())?),
                             escape_char: self.parse_escape_char()?,
                         })
                     } else if self.parse_keywords(&[Keyword::SIMILAR, Keyword::TO]) {
                         Ok(Expr::SimilarTo {
                             negated,
                             expr: Box::new(expr),
-                            pattern: Box::new(self.parse_subexpr(self.prec(Precedence::Like))?),
+                            pattern: Box::new(self.parse_subexpr(self.dialect.prec_like())?),
                             escape_char: self.parse_escape_char()?,
                         })
                     } else {
@@ -2949,9 +2949,9 @@ impl<'a> Parser<'a> {
     pub fn parse_between(&mut self, expr: Expr, negated: bool) -> Result<Expr, ParserError> {
         // Stop parsing subexpressions for <low> and <high> on tokens with
         // precedence lower than that of `BETWEEN`, such as `AND`, `IS`, etc.
-        let low = self.parse_subexpr(self.prec(Precedence::Between))?;
+        let low = self.parse_subexpr(self.dialect.prec_between())?;
         self.expect_keyword(Keyword::AND)?;
-        let high = self.parse_subexpr(self.prec(Precedence::Between))?;
+        let high = self.parse_subexpr(self.dialect.prec_between())?;
         Ok(Expr::Between {
             expr: Box::new(expr),
             negated,
@@ -2972,108 +2972,7 @@ impl<'a> Parser<'a> {
 
     /// Get the precedence of the next token
     pub fn get_next_precedence(&self) -> Result<u8, ParserError> {
-        // allow the dialect to override precedence logic
-        if let Some(precedence) = self.dialect.get_next_precedence(self) {
-            return precedence;
-        }
-
-        macro_rules! p {
-            ($precedence:ident) => {self.prec(Precedence::$precedence)};
-        }
-
-        let token = self.peek_token();
-        debug!("get_next_precedence() {:?}", token);
-        match token.token {
-            Token::Word(w) if w.keyword == Keyword::OR => Ok(p!(Or)),
-            Token::Word(w) if w.keyword == Keyword::AND => Ok(p!(And)),
-            Token::Word(w) if w.keyword == Keyword::XOR => Ok(p!(Xor)),
-
-            Token::Word(w) if w.keyword == Keyword::AT => {
-                match (self.peek_nth_token(1).token, self.peek_nth_token(2).token) {
-                    (Token::Word(w), Token::Word(w2))
-                        if w.keyword == Keyword::TIME && w2.keyword == Keyword::ZONE =>
-                    {
-                        Ok(p!(AtTz))
-                    }
-                    _ => Ok(p!(Unknown)),
-                }
-            }
-
-            Token::Word(w) if w.keyword == Keyword::NOT => match self.peek_nth_token(1).token {
-                // The precedence of NOT varies depending on keyword that
-                // follows it. If it is followed by IN, BETWEEN, or LIKE,
-                // it takes on the precedence of those tokens. Otherwise, it
-                // is not an infix operator, and therefore has zero
-                // precedence.
-                Token::Word(w) if w.keyword == Keyword::IN => Ok(p!(Between)),
-                Token::Word(w) if w.keyword == Keyword::BETWEEN => Ok(p!(Between)),
-                Token::Word(w) if w.keyword == Keyword::LIKE => Ok(p!(Like)),
-                Token::Word(w) if w.keyword == Keyword::ILIKE => Ok(p!(Like)),
-                Token::Word(w) if w.keyword == Keyword::RLIKE => Ok(p!(Like)),
-                Token::Word(w) if w.keyword == Keyword::REGEXP => Ok(p!(Like)),
-                Token::Word(w) if w.keyword == Keyword::SIMILAR => Ok(p!(Like)),
-                _ => Ok(p!(Unknown)),
-            },
-            Token::Word(w) if w.keyword == Keyword::IS => Ok(p!(Is)),
-            Token::Word(w) if w.keyword == Keyword::IN => Ok(p!(Between)),
-            Token::Word(w) if w.keyword == Keyword::BETWEEN => Ok(p!(Between)),
-            Token::Word(w) if w.keyword == Keyword::LIKE => Ok(p!(Like)),
-            Token::Word(w) if w.keyword == Keyword::ILIKE => Ok(p!(Like)),
-            Token::Word(w) if w.keyword == Keyword::RLIKE => Ok(p!(Like)),
-            Token::Word(w) if w.keyword == Keyword::REGEXP => Ok(p!(Like)),
-            Token::Word(w) if w.keyword == Keyword::SIMILAR => Ok(p!(Like)),
-            Token::Word(w) if w.keyword == Keyword::OPERATOR => Ok(p!(Between)),
-            Token::Word(w) if w.keyword == Keyword::DIV => Ok(p!(MulDivModOp)),
-            Token::Eq
-            | Token::Lt
-            | Token::LtEq
-            | Token::Neq
-            | Token::Gt
-            | Token::GtEq
-            | Token::DoubleEq
-            | Token::Tilde
-            | Token::TildeAsterisk
-            | Token::ExclamationMarkTilde
-            | Token::ExclamationMarkTildeAsterisk
-            | Token::DoubleTilde
-            | Token::DoubleTildeAsterisk
-            | Token::ExclamationMarkDoubleTilde
-            | Token::ExclamationMarkDoubleTildeAsterisk
-            | Token::Spaceship => Ok(p!(Eq)),
-            Token::Pipe => Ok(p!(Pipe)),
-            Token::Caret | Token::Sharp | Token::ShiftRight | Token::ShiftLeft => {
-                Ok(p!(Caret))
-            }
-            Token::Ampersand => Ok(p!(Ampersand)),
-            Token::Plus | Token::Minus => Ok(p!(PlusMinus)),
-            Token::Mul | Token::Div | Token::DuckIntDiv | Token::Mod | Token::StringConcat => {
-                Ok(p!(MulDivModOp))
-            }
-            Token::DoubleColon
-            | Token::ExclamationMark
-            | Token::LBracket
-            | Token::Overlap
-            | Token::CaretAt => Ok(p!(DoubleColon)),
-            Token::Colon if dialect_of!(self is SnowflakeDialect) => Ok(p!(DoubleColon)),
-            Token::Arrow
-            | Token::LongArrow
-            | Token::HashArrow
-            | Token::HashLongArrow
-            | Token::AtArrow
-            | Token::ArrowAt
-            | Token::HashMinus
-            | Token::AtQuestion
-            | Token::AtAt
-            | Token::Question
-            | Token::QuestionAnd
-            | Token::QuestionPipe
-            | Token::CustomBinaryOperator(_) => Ok(p!(PgOther)),
-            _ => Ok(p!(Unknown)),
-        }
-    }
-
-    fn prec(&self, p: Precedence) -> u8 {
-        self.dialect.precedence_numeric(p)
+        self.dialect.get_next_precedence_full(self)
     }
 
     /// Return the first non-whitespace token that has not yet been processed
@@ -8040,7 +7939,7 @@ impl<'a> Parser<'a> {
                 format_clause: None,
             })
         } else {
-            let body = self.parse_boxed_query_body(0)?;
+            let body = self.parse_boxed_query_body(self.dialect.prec_unknown())?;
 
             let order_by = if self.parse_keywords(&[Keyword::ORDER, Keyword::BY]) {
                 let order_by_exprs = self.parse_comma_separated(Parser::parse_order_by_expr)?;
@@ -11389,62 +11288,6 @@ impl<'a> Parser<'a> {
     /// Consume the parser and return its underlying token buffer
     pub fn into_tokens(self) -> Vec<TokenWithLocation> {
         self.tokens
-    }
-}
-
-
-/// Use to define the lexical Precedence of operators.
-///
-/// Numeric values of enum members are used to define the default precedence of the operators.
-///
-/// Uses (APPROXIMATELY) <https://www.postgresql.org/docs/7.0/operators.htm#AEN2026> as a reference
-/// higher number = higher precedence
-///
-/// NOTE: The pg documentation is incomplete, e.g. the AT TIME ZONE operator
-///       actually has higher precedence than addition.
-///       See <https://postgrespro.com/list/thread-id/2673331>.
-#[derive(Debug, Clone, Copy)]
-#[repr(u8)]
-pub enum Precedence {
-    DoubleColon,
-    AtTz,
-    MulDivModOp,
-    PlusMinus,
-    Xor,
-    Ampersand,
-    Caret,
-    Pipe,
-    Between,
-    Eq,
-    Like,
-    Is,
-    PgOther,
-    UnaryNot,
-    And,
-    Or,
-    Unknown,
-}
-
-impl Precedence {
-    pub fn numeric(&self) -> u8 {
-        match self {
-            Precedence::DoubleColon => 50,
-            Precedence::AtTz => 41,
-            Precedence::MulDivModOp => 40,
-            Precedence::PlusMinus => 30,
-            Precedence::Xor => 24,
-            Precedence::Ampersand => 23,
-            Precedence::Caret => 22,
-            Precedence::Pipe => 21,
-            Precedence::Between | Precedence::Eq => 20,
-            Precedence::Like => 19,
-            Precedence::Is => 17,
-            Precedence::PgOther => 16,
-            Precedence::UnaryNot => 15,
-            Precedence::And => 10,
-            Precedence::Or => 5,
-            Precedence::Unknown => 0,
-        }
     }
 }
 


### PR DESCRIPTION
~~This is ugly but working, I wanted to get feedback before proceeding.~~ I think this is now in a good state, definitely ready to review.

This solves https://github.com/sqlparser-rs/sqlparser-rs/issues/814#issuecomment-2196624432, e.g. it gives the right AST for `SELECT foo->'bar'='spam'` etc.

But before I go further, I want to confirm a few things?

### Can we update precedence globally?

The claim at 

https://github.com/sqlparser-rs/sqlparser-rs/blob/cc13841a370190df00cfc623593453054ac187e9/src/parser/mod.rs#L2972

Isn't really true at all, `sqlparser-rs` doesn't use the lexical precedence from PostgreSQL 7, even if it did, that's extremely old.

Could we just update those values to reference [a more recent version](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE)?

I assume not since that order is presumably a not-too-bad approximation for lots of databases, and changing it would be a big breaking change

### Can we even update `PostgresSQL` dialect

Presumably people are relying on the current logic, will you even accept a PR to update `PostgreSqlDialect` even if it's wrong now?

Or should a create a `RecentPostgreSqlDialect` as a new dialect?

### What about operators that don't work in some dialects?

Postgres doesn't actually support `XOR`, but there are tests asserting that it works, do you want to keep supporting it with an invented precedence, or cause an error?

### Can I move precedence numbers to the `Dialect` trait?

The `Precedence` enum shown here is pretty ugly, would you mind me moving the precedence stuff, including the default implementation of `get_next_precedence` to the `Dialect` trait?