### PR TITLE
Make `Parser::maybe_parse` pub

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3491,7 +3491,7 @@ impl<'a> Parser<'a> {
 
     /// Run a parser method `f`, reverting back to the current position if unsuccessful.
     #[must_use]
-    fn maybe_parse<T, F>(&mut self, mut f: F) -> Option<T>
+    pub fn maybe_parse<T, F>(&mut self, mut f: F) -> Option<T>
     where
         F: FnMut(&mut Parser) -> Result<T, ParserError>,
     {


### PR DESCRIPTION
This method is useful for wrapping sqlparser's parser to parse custom syntax, falling back to the upstream implementation. For example:
```rust
enum CustomStatement {
    CreateCustom {
        or_replace: bool,
        thingy: String,
    },
    Statement(Statement),
}

fn parse_custom_create(parser: &mut Parser) -> Result<CustomStatement, ParserError> {
    if let Some(custom) = parser.maybe_parse(|parser| {
        let or_replace = parser.parse_keywords(&[Keyword::OR, Keyword::REPLACE]);
        parse_create_custom(or_replace)
    }) {
        Ok(custom)
    } else {
        Ok(CustomStatement::Statement(parser.parse_create()?))
    }
}
```

Without access to `maybe_parse`, this would ~not be possible~ be very inconvenient