### PR TITLE
rename `get_next_precedence_full` to `get_next_precedence_default`

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -350,7 +350,7 @@ pub trait Dialect: Debug + Any {
     ///
     /// The default implementation is used for many dialects, but can be
     /// overridden to provide dialect-specific behavior.
-    fn get_next_precedence_full(&self, parser: &Parser) -> Result<u8, ParserError> {
+    fn get_next_precedence_default(&self, parser: &Parser) -> Result<u8, ParserError> {
         if let Some(precedence) = self.get_next_precedence(parser) {
             return precedence;
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2984,7 +2984,7 @@ impl<'a> Parser<'a> {
 
     /// Get the precedence of the next token
     pub fn get_next_precedence(&self) -> Result<u8, ParserError> {
-        self.dialect.get_next_precedence_full(self)
+        self.dialect.get_next_precedence_default(self)
     }
 
     /// Return the first non-whitespace token that has not yet been processed


### PR DESCRIPTION
As discussed in https://github.com/sqlparser-rs/sqlparser-rs/pull/1366#discussion_r1707608291, follow on from #1360.