### PR TITLE
Add support of `FREEZE|UNFREEZE PARTITION` syntax for ClickHouse

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -87,6 +87,20 @@ pub enum AlterTableOperation {
         // See `AttachPartition` for more details
         partition: Partition,
     },
+    /// `FREEZE PARTITION <partition_expr>`
+    /// Note: this is a ClickHouse-specific operation, please refer to
+    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/alter/partition#freeze-partition)
+    FreezePartition {
+        partition: Partition,
+        with_name: Option<Ident>,
+    },
+    /// `UNFREEZE PARTITION <partition_expr>`
+    /// Note: this is a ClickHouse-specific operation, please refer to
+    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/alter/partition#unfreeze-partition)
+    UnfreezePartition {
+        partition: Partition,
+        with_name: Option<Ident>,
+    },
     /// `DROP PRIMARY KEY`
     ///
     /// Note: this is a MySQL-specific operation.
@@ -378,6 +392,26 @@ impl fmt::Display for AlterTableOperation {
                     "SET TBLPROPERTIES({})",
                     display_comma_separated(table_properties)
                 )
+            }
+            AlterTableOperation::FreezePartition {
+                partition,
+                with_name,
+            } => {
+                write!(f, "FREEZE {partition}")?;
+                if let Some(name) = with_name {
+                    write!(f, " WITH NAME {name}")?;
+                }
+                Ok(())
+            }
+            AlterTableOperation::UnfreezePartition {
+                partition,
+                with_name,
+            } => {
+                write!(f, "UNFREEZE {partition}")?;
+                if let Some(name) = with_name {
+                    write!(f, " WITH NAME {name}")?;
+                }
+                Ok(())
             }
         }
     }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -760,6 +760,7 @@ define_keywords!(
     UNBOUNDED,
     UNCACHE,
     UNCOMMITTED,
+    UNFREEZE,
     UNION,
     UNIQUE,
     UNKNOWN,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6479,6 +6479,34 @@ impl<'a> Parser<'a> {
             AlterTableOperation::DetachPartition {
                 partition: self.parse_part_or_partition()?,
             }
+        } else if dialect_of!(self is ClickHouseDialect|GenericDialect)
+            && self.parse_keyword(Keyword::FREEZE)
+        {
+            let partition = self.parse_part_or_partition()?;
+            let with_name = if self.parse_keyword(Keyword::WITH) {
+                self.expect_keyword(Keyword::NAME)?;
+                Some(self.parse_identifier(false)?)
+            } else {
+                None
+            };
+            AlterTableOperation::FreezePartition {
+                partition,
+                with_name,
+            }
+        } else if dialect_of!(self is ClickHouseDialect|GenericDialect)
+            && self.parse_keyword(Keyword::UNFREEZE)
+        {
+            let partition = self.parse_part_or_partition()?;
+            let with_name = if self.parse_keyword(Keyword::WITH) {
+                self.expect_keyword(Keyword::NAME)?;
+                Some(self.parse_identifier(false)?)
+            } else {
+                None
+            };
+            AlterTableOperation::UnfreezePartition {
+                partition,
+                with_name,
+            }
         } else {
             let options: Vec<SqlOption> =
                 self.parse_options_with_keywords(&[Keyword::SET, Keyword::TBLPROPERTIES])?;


### PR DESCRIPTION
ClickHouse supports using the FREEZE|UNFREEZE operation in ALTER TABLE to freeze or unfreeze partition.

References:

- https://clickhouse.com/docs/en/sql-reference/statements/alter/partition#freeze-partition
- https://clickhouse.com/docs/en/sql-reference/statements/alter/partition#unfreeze-partition