### PR TITLE
fix: only require `DESCRIBE TABLE` for Snowflake and ClickHouse dialect

### DIFF
--- a/src/dialect/clickhouse.rs
+++ b/src/dialect/clickhouse.rs
@@ -33,4 +33,8 @@ impl Dialect for ClickHouseDialect {
     fn supports_select_wildcard_except(&self) -> bool {
         true
     }
+
+    fn describe_requires_table_keyword(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -495,7 +495,7 @@ pub trait Dialect: Debug + Any {
     /// Defaults to false.
     ///
     /// If true, the following statement is valid: `DESCRIBE TABLE my_table`
-    /// If false, the following statement is valid: `DESCRIBE my_table`
+    /// If false, the following statements are valid: `DESCRIBE my_table` and `DESCRIBE table`
     fn describe_requires_table_keyword(&self) -> bool {
         false
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -485,8 +485,19 @@ pub trait Dialect: Debug + Any {
         }
     }
 
+    /// Returns the precedence when the precedence is otherwise unknown
     fn prec_unknown(&self) -> u8 {
         0
+    }
+
+    /// Returns true if this dialect requires the `TABLE` keyword after `DESCRIBE`
+    ///
+    /// Defaults to false.
+    ///
+    /// If true, the following statement is valid: `DESCRIBE TABLE my_table`
+    /// If false, the following statement is valid: `DESCRIBE my_table`
+    fn describe_requires_table_keyword(&self) -> bool {
+        false
     }
 }
 

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -154,6 +154,10 @@ impl Dialect for SnowflakeDialect {
             _ => None,
         }
     }
+
+    fn describe_requires_table_keyword(&self) -> bool {
+        true
+    }
 }
 
 /// Parse snowflake create table statement.

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1376,6 +1376,36 @@ fn parse_select_table_function_settings() {
     }
 }
 
+#[test]
+fn explain_describe() {
+    clickhouse().verified_stmt("DESCRIBE test.table");
+    clickhouse().verified_stmt("DESCRIBE TABLE test.table");
+}
+
+#[test]
+fn explain_desc() {
+    clickhouse().verified_stmt("DESC test.table");
+    clickhouse().verified_stmt("DESC TABLE test.table");
+}
+
+#[test]
+fn parse_explain_table() {
+    match clickhouse().verified_stmt("EXPLAIN TABLE test_identifier") {
+        Statement::ExplainTable {
+            describe_alias,
+            hive_format,
+            has_table_keyword,
+            table_name,
+        } => {
+            pretty_assertions::assert_eq!(describe_alias, DescribeAlias::Explain);
+            pretty_assertions::assert_eq!(hive_format, None);
+            pretty_assertions::assert_eq!(has_table_keyword, true);
+            pretty_assertions::assert_eq!("test_identifier", table_name.to_string());
+        }
+        _ => panic!("Unexpected Statement, must be ExplainTable"),
+    }
+}
+
 fn clickhouse() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(ClickHouseDialect {})],

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4301,29 +4301,16 @@ fn parse_explain_table() {
     validate_explain("EXPLAIN test_identifier", DescribeAlias::Explain, false);
     validate_explain("DESCRIBE test_identifier", DescribeAlias::Describe, false);
     validate_explain("DESC test_identifier", DescribeAlias::Desc, false);
-    validate_explain(
-        "EXPLAIN TABLE test_identifier",
-        DescribeAlias::Explain,
-        true,
-    );
-    validate_explain(
-        "DESCRIBE TABLE test_identifier",
-        DescribeAlias::Describe,
-        true,
-    );
-    validate_explain("DESC TABLE test_identifier", DescribeAlias::Desc, true);
 }
 
 #[test]
 fn explain_describe() {
     verified_stmt("DESCRIBE test.table");
-    verified_stmt("DESCRIBE TABLE test.table");
 }
 
 #[test]
 fn explain_desc() {
     verified_stmt("DESC test.table");
-    verified_stmt("DESC TABLE test.table");
 }
 
 #[test]

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -21,7 +21,7 @@ use sqlparser::ast::{
     UnaryOperator, Value,
 };
 use sqlparser::dialect::{GenericDialect, HiveDialect, MsSqlDialect};
-use sqlparser::parser::{ParserError, ParserOptions};
+use sqlparser::parser::ParserError;
 use sqlparser::test_utils::*;
 
 #[test]
@@ -35,18 +35,11 @@ fn parse_table_create() {
     hive().verified_stmt(serdeproperties);
 }
 
-fn generic(options: Option<ParserOptions>) -> TestedDialects {
-    TestedDialects {
-        dialects: vec![Box::new(GenericDialect {})],
-        options,
-    }
-}
-
 #[test]
 fn parse_describe() {
-    let describe = r#"DESCRIBE namespace.`table`"#;
-    hive().verified_stmt(describe);
-    generic(None).verified_stmt(describe);
+    hive_and_generic().verified_stmt(r#"DESCRIBE namespace.`table`"#);
+    hive_and_generic().verified_stmt(r#"DESCRIBE namespace.table"#);
+    hive_and_generic().verified_stmt(r#"DESCRIBE table"#);
 }
 
 #[test]
@@ -411,6 +404,13 @@ fn parse_delimited_identifiers() {
 fn hive() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(HiveDialect {})],
+        options: None,
+    }
+}
+
+fn hive_and_generic() -> TestedDialects {
+    TestedDialects {
+        dialects: vec![Box::new(HiveDialect {}), Box::new(GenericDialect {})],
         options: None,
     }
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2292,3 +2292,33 @@ fn test_parse_position() {
     snowflake().verified_query("SELECT position('an', 'banana', 1)");
     snowflake().verified_query("SELECT n, h, POSITION(n IN h) FROM pos");
 }
+
+#[test]
+fn explain_describe() {
+    snowflake().verified_stmt("DESCRIBE test.table");
+    snowflake().verified_stmt("DESCRIBE TABLE test.table");
+}
+
+#[test]
+fn explain_desc() {
+    snowflake().verified_stmt("DESC test.table");
+    snowflake().verified_stmt("DESC TABLE test.table");
+}
+
+#[test]
+fn parse_explain_table() {
+    match snowflake().verified_stmt("EXPLAIN TABLE test_identifier") {
+        Statement::ExplainTable {
+            describe_alias,
+            hive_format,
+            has_table_keyword,
+            table_name,
+        } => {
+            assert_eq!(describe_alias, DescribeAlias::Explain);
+            assert_eq!(hive_format, None);
+            assert_eq!(has_table_keyword, true);
+            assert_eq!("test_identifier", table_name.to_string());
+        }
+        _ => panic!("Unexpected Statement, must be ExplainTable"),
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/sqlparser-rs/sqlparser-rs/issues/1385

# Rationale
@git-hulk  added support for `DESCRIBE TABLE <..>` syntax for ClickHouse and Snowflake in https://github.com/sqlparser-rs/sqlparser-rs/pull/1351 

Unfrtunately, this seems to have caused a regression in `describe table` (aka describing a table named `table` which apparently we do in the DataFusion tests) which we did not have test coverage for

# Changes
1. Only require the `DESCRIBE TABLE` keyword for ClickHouse and Snowflake dialects
2. Update the tests to match, update coverage
