### PR TITLE
feat: support different USE statement syntaxes

### DIFF
--- a/src/ast/dcl.rs
+++ b/src/ast/dcl.rs
@@ -193,3 +193,30 @@ impl fmt::Display for AlterRoleOperation {
         }
     }
 }
+
+/// A `USE` (`Statement::Use`) operation
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum Use {
+    Catalog(ObjectName),   // e.g. `USE CATALOG foo.bar`
+    Schema(ObjectName),    // e.g. `USE SCHEMA foo.bar`
+    Database(ObjectName),  // e.g. `USE DATABASE foo.bar`
+    Warehouse(ObjectName), // e.g. `USE WAREHOUSE foo.bar`
+    Object(ObjectName),    // e.g. `USE foo.bar`
+    Default,               // e.g. `USE DEFAULT`
+}
+
+impl fmt::Display for Use {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("USE ")?;
+        match self {
+            Use::Catalog(name) => write!(f, "CATALOG {}", name),
+            Use::Schema(name) => write!(f, "SCHEMA {}", name),
+            Use::Database(name) => write!(f, "DATABASE {}", name),
+            Use::Warehouse(name) => write!(f, "WAREHOUSE {}", name),
+            Use::Object(name) => write!(f, "{}", name),
+            Use::Default => write!(f, "DEFAULT"),
+        }
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2515,11 +2515,13 @@ pub enum Statement {
     /// Note: this is a MySQL-specific statement.
     ShowCollation { filter: Option<ShowStatementFilter> },
     /// ```sql
-    /// USE
+    /// USE [DATABASE|SCHEMA|CATALOG|...] [<db_name>.<schema_name>|<db_name>|<schema_name>]
     /// ```
-    ///
-    /// Note: This is a MySQL-specific statement.
-    Use { db_name: Ident },
+    Use {
+        db_name: Option<Ident>,
+        schema_name: Option<Ident>,
+        keyword: Option<String>,
+    },
     /// ```sql
     /// START  [ TRANSACTION | WORK ] | START TRANSACTION } ...
     /// ```
@@ -4125,8 +4127,26 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::Use { db_name } => {
-                write!(f, "USE {db_name}")?;
+            Statement::Use {
+                db_name,
+                schema_name,
+                keyword,
+            } => {
+                write!(f, "USE")?;
+
+                if let Some(kw) = keyword.as_ref() {
+                    write!(f, " {}", kw)?;
+                }
+
+                if let Some(db_name) = db_name {
+                    write!(f, " {}", db_name)?;
+                    if let Some(schema_name) = schema_name {
+                        write!(f, ".{}", schema_name)?;
+                    }
+                } else if let Some(schema_name) = schema_name {
+                    write!(f, " {}", schema_name)?;
+                }
+
                 Ok(())
             }
             Statement::ShowCollation { filter } => {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -31,7 +31,7 @@ pub use self::data_type::{
     ArrayElemTypeDef, CharLengthUnits, CharacterLength, DataType, ExactNumberInfo,
     StructBracketKind, TimezoneInfo,
 };
-pub use self::dcl::{AlterRoleOperation, ResetConfig, RoleOption, SetConfigValue};
+pub use self::dcl::{AlterRoleOperation, ResetConfig, RoleOption, SetConfigValue, Use};
 pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterTableOperation, ColumnDef, ColumnOption,
     ColumnOptionDef, ConstraintCharacteristics, Deduplicate, DeferrableInitial, GeneratedAs,
@@ -2515,13 +2515,9 @@ pub enum Statement {
     /// Note: this is a MySQL-specific statement.
     ShowCollation { filter: Option<ShowStatementFilter> },
     /// ```sql
-    /// USE [DATABASE|SCHEMA|CATALOG|...] [<db_name>.<schema_name>|<db_name>|<schema_name>]
+    /// `USE ...`
     /// ```
-    Use {
-        db_name: Option<Ident>,
-        schema_name: Option<Ident>,
-        keyword: Option<String>,
-    },
+    Use(Use),
     /// ```sql
     /// START  [ TRANSACTION | WORK ] | START TRANSACTION } ...
     /// ```
@@ -4127,28 +4123,7 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::Use {
-                db_name,
-                schema_name,
-                keyword,
-            } => {
-                write!(f, "USE")?;
-
-                if let Some(kw) = keyword.as_ref() {
-                    write!(f, " {}", kw)?;
-                }
-
-                if let Some(db_name) = db_name {
-                    write!(f, " {}", db_name)?;
-                    if let Some(schema_name) = schema_name {
-                        write!(f, ".{}", schema_name)?;
-                    }
-                } else if let Some(schema_name) = schema_name {
-                    write!(f, " {}", schema_name)?;
-                }
-
-                Ok(())
-            }
+            Statement::Use(use_expr) => use_expr.fmt(f),
             Statement::ShowCollation { filter } => {
                 write!(f, "SHOW COLLATION")?;
                 if let Some(filter) = filter {

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -804,6 +804,7 @@ define_keywords!(
     VIEW,
     VIRTUAL,
     VOLATILE,
+    WAREHOUSE,
     WEEK,
     WHEN,
     WHENEVER,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -137,6 +137,7 @@ define_keywords!(
     CASCADED,
     CASE,
     CAST,
+    CATALOG,
     CEIL,
     CEILING,
     CENTURY,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9225,8 +9225,63 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_use(&mut self) -> Result<Statement, ParserError> {
-        let db_name = self.parse_identifier(false)?;
-        Ok(Statement::Use { db_name })
+        // What should be treated as keyword in given dialect
+        let allowed_keywords = if dialect_of!(self is HiveDialect) {
+            vec![Keyword::DEFAULT]
+        } else if dialect_of!(self is DatabricksDialect) {
+            vec![Keyword::CATALOG, Keyword::DATABASE, Keyword::SCHEMA]
+        } else if dialect_of!(self is SnowflakeDialect) {
+            vec![Keyword::DATABASE, Keyword::SCHEMA]
+        } else {
+            vec![]
+        };
+        let parsed_keyword = self.parse_one_of_keywords(&allowed_keywords);
+
+        // Hive dialect accepts USE DEFAULT; statement without any db specified
+        if dialect_of!(self is HiveDialect) && parsed_keyword == Some(Keyword::DEFAULT) {
+            return Ok(Statement::Use {
+                db_name: None,
+                schema_name: None,
+                keyword: Some("DEFAULT".to_string()),
+            });
+        }
+
+        // Parse the object name, which might be a single identifier or fully qualified name (e.g., x.y)
+        let parts = self.parse_object_name(false)?.0;
+        let (db_name, schema_name) = match parts.len() {
+            1 => {
+                // Single identifier found
+                if dialect_of!(self is DatabricksDialect) {
+                    if parsed_keyword == Some(Keyword::CATALOG) {
+                        // Databricks: CATALOG keyword provided, treat as database name
+                        (Some(parts[0].clone()), None)
+                    } else {
+                        // Databricks: DATABASE, SCHEMA or no keyword provided, treat as schema name
+                        (None, Some(parts[0].clone()))
+                    }
+                } else if dialect_of!(self is SnowflakeDialect)
+                    && parsed_keyword == Some(Keyword::SCHEMA)
+                {
+                    // Snowflake: SCHEMA keyword provided, treat as schema name
+                    (None, Some(parts[0].clone()))
+                } else {
+                    // Other dialects: treat as database name by default
+                    (Some(parts[0].clone()), None)
+                }
+            }
+            2 => (Some(parts[0].clone()), Some(parts[1].clone())),
+            _ => {
+                return Err(ParserError::ParserError(
+                    "Invalid format in the USE statement".to_string(),
+                ))
+            }
+        };
+
+        Ok(Statement::Use {
+            db_name,
+            schema_name,
+            keyword: parsed_keyword.map(|kw| format!("{:?}", kw)),
+        })
     }
 
     pub fn parse_table_and_joins(&mut self) -> Result<TableWithJoins, ParserError> {

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1161,6 +1161,42 @@ fn test_prewhere() {
 }
 
 #[test]
+fn parse_use() {
+    assert_eq!(
+        clickhouse().verified_stmt("USE mydb"),
+        Statement::Use {
+            db_name: Some(Ident::new("mydb")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        clickhouse().verified_stmt("USE DATABASE"),
+        Statement::Use {
+            db_name: Some(Ident::new("DATABASE")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        clickhouse().verified_stmt("USE SCHEMA"),
+        Statement::Use {
+            db_name: Some(Ident::new("SCHEMA")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        clickhouse().verified_stmt("USE CATALOG"),
+        Statement::Use {
+            db_name: Some(Ident::new("CATALOG")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+}
+
+#[test]
 fn test_query_with_format_clause() {
     let format_options = vec!["TabSeparated", "JSONCompact", "NULL"];
     for format in &format_options {

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1162,38 +1162,35 @@ fn test_prewhere() {
 
 #[test]
 fn parse_use() {
-    assert_eq!(
-        clickhouse().verified_stmt("USE mydb"),
-        Statement::Use {
-            db_name: Some(Ident::new("mydb")),
-            schema_name: None,
-            keyword: None
+    let valid_object_names = [
+        "mydb",
+        "SCHEMA",
+        "DATABASE",
+        "CATALOG",
+        "WAREHOUSE",
+        "DEFAULT",
+    ];
+    let quote_styles = ['"', '`'];
+
+    for object_name in &valid_object_names {
+        // Test single identifier without quotes
+        assert_eq!(
+            clickhouse().verified_stmt(&format!("USE {}", object_name)),
+            Statement::Use(Use::Object(ObjectName(vec![Ident::new(
+                object_name.to_string()
+            )])))
+        );
+        for &quote in &quote_styles {
+            // Test single identifier with different type of quotes
+            assert_eq!(
+                clickhouse().verified_stmt(&format!("USE {0}{1}{0}", quote, object_name)),
+                Statement::Use(Use::Object(ObjectName(vec![Ident::with_quote(
+                    quote,
+                    object_name.to_string(),
+                )])))
+            );
         }
-    );
-    assert_eq!(
-        clickhouse().verified_stmt("USE DATABASE"),
-        Statement::Use {
-            db_name: Some(Ident::new("DATABASE")),
-            schema_name: None,
-            keyword: None
-        }
-    );
-    assert_eq!(
-        clickhouse().verified_stmt("USE SCHEMA"),
-        Statement::Use {
-            db_name: Some(Ident::new("SCHEMA")),
-            schema_name: None,
-            keyword: None
-        }
-    );
-    assert_eq!(
-        clickhouse().verified_stmt("USE CATALOG"),
-        Statement::Use {
-            db_name: Some(Ident::new("CATALOG")),
-            schema_name: None,
-            keyword: None
-        }
-    );
+    }
 }
 
 #[test]

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -756,3 +756,55 @@ fn test_duckdb_union_datatype() {
         stmt
     );
 }
+
+#[test]
+fn parse_use() {
+    std::assert_eq!(
+        duckdb().verified_stmt("USE mydb"),
+        Statement::Use {
+            db_name: Some(Ident::new("mydb")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    std::assert_eq!(
+        duckdb().verified_stmt("USE mydb.my_schema"),
+        Statement::Use {
+            db_name: Some(Ident::new("mydb")),
+            schema_name: Some(Ident::new("my_schema")),
+            keyword: None
+        }
+    );
+    assert_eq!(
+        duckdb().verified_stmt("USE DATABASE"),
+        Statement::Use {
+            db_name: Some(Ident::new("DATABASE")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        duckdb().verified_stmt("USE SCHEMA"),
+        Statement::Use {
+            db_name: Some(Ident::new("SCHEMA")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        duckdb().verified_stmt("USE CATALOG"),
+        Statement::Use {
+            db_name: Some(Ident::new("CATALOG")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        duckdb().verified_stmt("USE CATALOG.SCHEMA"),
+        Statement::Use {
+            db_name: Some(Ident::new("CATALOG")),
+            schema_name: Some(Ident::new("SCHEMA")),
+            keyword: None
+        }
+    );
+}

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -401,6 +401,50 @@ fn parse_delimited_identifiers() {
     //TODO verified_stmt(r#"UPDATE foo SET "bar" = 5"#);
 }
 
+#[test]
+fn parse_use() {
+    assert_eq!(
+        hive().verified_stmt("USE mydb"),
+        Statement::Use {
+            db_name: Some(Ident::new("mydb")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        hive().verified_stmt("USE DEFAULT"),
+        Statement::Use {
+            db_name: None,
+            schema_name: None,
+            keyword: Some("DEFAULT".to_string()) // Yes, as keyword not db_name
+        }
+    );
+    assert_eq!(
+        hive().verified_stmt("USE DATABASE"),
+        Statement::Use {
+            db_name: Some(Ident::new("DATABASE")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        hive().verified_stmt("USE SCHEMA"),
+        Statement::Use {
+            db_name: Some(Ident::new("SCHEMA")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        hive().verified_stmt("USE CATALOG"),
+        Statement::Use {
+            db_name: Some(Ident::new("CATALOG")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+}
+
 fn hive() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(HiveDialect {})],

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -18,7 +18,7 @@
 use sqlparser::ast::{
     CreateFunctionBody, CreateFunctionUsing, Expr, Function, FunctionArgumentList,
     FunctionArguments, Ident, ObjectName, OneOrManyWithParens, SelectItem, Statement, TableFactor,
-    UnaryOperator, Value,
+    UnaryOperator, Use, Value,
 };
 use sqlparser::dialect::{GenericDialect, HiveDialect, MsSqlDialect};
 use sqlparser::parser::ParserError;
@@ -403,45 +403,31 @@ fn parse_delimited_identifiers() {
 
 #[test]
 fn parse_use() {
-    assert_eq!(
-        hive().verified_stmt("USE mydb"),
-        Statement::Use {
-            db_name: Some(Ident::new("mydb")),
-            schema_name: None,
-            keyword: None
+    let valid_object_names = ["mydb", "SCHEMA", "DATABASE", "CATALOG", "WAREHOUSE"];
+    let quote_styles = ['\'', '"', '`'];
+    for object_name in &valid_object_names {
+        // Test single identifier without quotes
+        assert_eq!(
+            hive().verified_stmt(&format!("USE {}", object_name)),
+            Statement::Use(Use::Object(ObjectName(vec![Ident::new(
+                object_name.to_string()
+            )])))
+        );
+        for &quote in &quote_styles {
+            // Test single identifier with different type of quotes
+            assert_eq!(
+                hive().verified_stmt(&format!("USE {}{}{}", quote, object_name, quote)),
+                Statement::Use(Use::Object(ObjectName(vec![Ident::with_quote(
+                    quote,
+                    object_name.to_string(),
+                )])))
+            );
         }
-    );
+    }
+    // Test DEFAULT keyword that is special case in Hive
     assert_eq!(
         hive().verified_stmt("USE DEFAULT"),
-        Statement::Use {
-            db_name: None,
-            schema_name: None,
-            keyword: Some("DEFAULT".to_string()) // Yes, as keyword not db_name
-        }
-    );
-    assert_eq!(
-        hive().verified_stmt("USE DATABASE"),
-        Statement::Use {
-            db_name: Some(Ident::new("DATABASE")),
-            schema_name: None,
-            keyword: None
-        }
-    );
-    assert_eq!(
-        hive().verified_stmt("USE SCHEMA"),
-        Statement::Use {
-            db_name: Some(Ident::new("SCHEMA")),
-            schema_name: None,
-            keyword: None
-        }
-    );
-    assert_eq!(
-        hive().verified_stmt("USE CATALOG"),
-        Statement::Use {
-            db_name: Some(Ident::new("CATALOG")),
-            schema_name: None,
-            keyword: None
-        }
+        Statement::Use(Use::Default)
     );
 }
 

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -623,38 +623,34 @@ fn parse_mssql_declare() {
 
 #[test]
 fn parse_use() {
-    assert_eq!(
-        ms().verified_stmt("USE mydb"),
-        Statement::Use {
-            db_name: Some(Ident::new("mydb")),
-            schema_name: None,
-            keyword: None
+    let valid_object_names = [
+        "mydb",
+        "SCHEMA",
+        "DATABASE",
+        "CATALOG",
+        "WAREHOUSE",
+        "DEFAULT",
+    ];
+    let quote_styles = ['\'', '"'];
+    for object_name in &valid_object_names {
+        // Test single identifier without quotes
+        assert_eq!(
+            ms().verified_stmt(&format!("USE {}", object_name)),
+            Statement::Use(Use::Object(ObjectName(vec![Ident::new(
+                object_name.to_string()
+            )])))
+        );
+        for &quote in &quote_styles {
+            // Test single identifier with different type of quotes
+            assert_eq!(
+                ms().verified_stmt(&format!("USE {}{}{}", quote, object_name, quote)),
+                Statement::Use(Use::Object(ObjectName(vec![Ident::with_quote(
+                    quote,
+                    object_name.to_string(),
+                )])))
+            );
         }
-    );
-    assert_eq!(
-        ms().verified_stmt("USE DATABASE"),
-        Statement::Use {
-            db_name: Some(Ident::new("DATABASE")),
-            schema_name: None,
-            keyword: None
-        }
-    );
-    assert_eq!(
-        ms().verified_stmt("USE SCHEMA"),
-        Statement::Use {
-            db_name: Some(Ident::new("SCHEMA")),
-            schema_name: None,
-            keyword: None
-        }
-    );
-    assert_eq!(
-        ms().verified_stmt("USE CATALOG"),
-        Statement::Use {
-            db_name: Some(Ident::new("CATALOG")),
-            schema_name: None,
-            keyword: None
-        }
-    );
+    }
 }
 
 fn ms() -> TestedDialects {

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -621,6 +621,42 @@ fn parse_mssql_declare() {
     );
 }
 
+#[test]
+fn parse_use() {
+    assert_eq!(
+        ms().verified_stmt("USE mydb"),
+        Statement::Use {
+            db_name: Some(Ident::new("mydb")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        ms().verified_stmt("USE DATABASE"),
+        Statement::Use {
+            db_name: Some(Ident::new("DATABASE")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        ms().verified_stmt("USE SCHEMA"),
+        Statement::Use {
+            db_name: Some(Ident::new("SCHEMA")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        ms().verified_stmt("USE CATALOG"),
+        Statement::Use {
+            db_name: Some(Ident::new("CATALOG")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+}
+
 fn ms() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(MsSqlDialect {})],

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -447,7 +447,33 @@ fn parse_use() {
     assert_eq!(
         mysql_and_generic().verified_stmt("USE mydb"),
         Statement::Use {
-            db_name: Ident::new("mydb")
+            db_name: Some(Ident::new("mydb")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        mysql_and_generic().verified_stmt("USE DATABASE"),
+        Statement::Use {
+            db_name: Some(Ident::new("DATABASE")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        mysql_and_generic().verified_stmt("USE SCHEMA"),
+        Statement::Use {
+            db_name: Some(Ident::new("SCHEMA")),
+            schema_name: None,
+            keyword: None
+        }
+    );
+    assert_eq!(
+        mysql_and_generic().verified_stmt("USE CATALOG"),
+        Statement::Use {
+            db_name: Some(Ident::new("CATALOG")),
+            schema_name: None,
+            keyword: None
         }
     );
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -444,38 +444,35 @@ fn parse_show_collation() {
 
 #[test]
 fn parse_use() {
-    assert_eq!(
-        mysql_and_generic().verified_stmt("USE mydb"),
-        Statement::Use {
-            db_name: Some(Ident::new("mydb")),
-            schema_name: None,
-            keyword: None
+    let valid_object_names = [
+        "mydb",
+        "SCHEMA",
+        "DATABASE",
+        "CATALOG",
+        "WAREHOUSE",
+        "DEFAULT",
+    ];
+    let quote_styles = ['\'', '"', '`'];
+    for object_name in &valid_object_names {
+        // Test single identifier without quotes
+        assert_eq!(
+            mysql_and_generic().verified_stmt(&format!("USE {}", object_name)),
+            Statement::Use(Use::Object(ObjectName(vec![Ident::new(
+                object_name.to_string()
+            )])))
+        );
+        for &quote in &quote_styles {
+            // Test single identifier with different type of quotes
+            assert_eq!(
+                mysql_and_generic()
+                    .verified_stmt(&format!("USE {}{}{}", quote, object_name, quote)),
+                Statement::Use(Use::Object(ObjectName(vec![Ident::with_quote(
+                    quote,
+                    object_name.to_string(),
+                )])))
+            );
         }
-    );
-    assert_eq!(
-        mysql_and_generic().verified_stmt("USE DATABASE"),
-        Statement::Use {
-            db_name: Some(Ident::new("DATABASE")),
-            schema_name: None,
-            keyword: None
-        }
-    );
-    assert_eq!(
-        mysql_and_generic().verified_stmt("USE SCHEMA"),
-        Statement::Use {
-            db_name: Some(Ident::new("SCHEMA")),
-            schema_name: None,
-            keyword: None
-        }
-    );
-    assert_eq!(
-        mysql_and_generic().verified_stmt("USE CATALOG"),
-        Statement::Use {
-            db_name: Some(Ident::new("CATALOG")),
-            schema_name: None,
-            keyword: None
-        }
-    );
+    }
 }
 
 #[test]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2325,56 +2325,74 @@ fn parse_explain_table() {
 
 #[test]
 fn parse_use() {
-    std::assert_eq!(
-        snowflake().verified_stmt("USE mydb"),
-        Statement::Use {
-            db_name: Some(Ident::new("mydb")),
-            schema_name: None,
-            keyword: None
+    let valid_object_names = ["mydb", "CATALOG", "DEFAULT"];
+    let quote_styles = ['\'', '"', '`'];
+    for object_name in &valid_object_names {
+        // Test single identifier without quotes
+        std::assert_eq!(
+            snowflake().verified_stmt(&format!("USE {}", object_name)),
+            Statement::Use(Use::Object(ObjectName(vec![Ident::new(
+                object_name.to_string()
+            )])))
+        );
+        for &quote in &quote_styles {
+            // Test single identifier with different type of quotes
+            std::assert_eq!(
+                snowflake().verified_stmt(&format!("USE {}{}{}", quote, object_name, quote)),
+                Statement::Use(Use::Object(ObjectName(vec![Ident::with_quote(
+                    quote,
+                    object_name.to_string(),
+                )])))
+            );
         }
-    );
+    }
+
+    for &quote in &quote_styles {
+        // Test double identifier with different type of quotes
+        std::assert_eq!(
+            snowflake().verified_stmt(&format!("USE {0}CATALOG{0}.{0}my_schema{0}", quote)),
+            Statement::Use(Use::Object(ObjectName(vec![
+                Ident::with_quote(quote, "CATALOG"),
+                Ident::with_quote(quote, "my_schema")
+            ])))
+        );
+    }
+    // Test double identifier without quotes
     std::assert_eq!(
         snowflake().verified_stmt("USE mydb.my_schema"),
-        Statement::Use {
-            db_name: Some(Ident::new("mydb")),
-            schema_name: Some(Ident::new("my_schema")),
-            keyword: None
-        }
-    );
-    std::assert_eq!(
-        snowflake().verified_stmt("USE DATABASE mydb"),
-        Statement::Use {
-            db_name: Some(Ident::new("mydb")),
-            schema_name: None,
-            keyword: Some("DATABASE".to_string()),
-        }
-    );
-    std::assert_eq!(
-        snowflake().verified_stmt("USE SCHEMA my_schema"),
-        Statement::Use {
-            db_name: None,
-            schema_name: Some(Ident::new("my_schema")),
-            keyword: Some("SCHEMA".to_string())
-        }
-    );
-    std::assert_eq!(
-        snowflake().verified_stmt("USE SCHEMA mydb.my_schema"),
-        Statement::Use {
-            db_name: Some(Ident::new("mydb")),
-            schema_name: Some(Ident::new("my_schema")),
-            keyword: Some("SCHEMA".to_string())
-        }
-    );
-    std::assert_eq!(
-        snowflake().verified_stmt("USE CATALOG"),
-        Statement::Use {
-            db_name: Some(Ident::new("CATALOG")),
-            schema_name: None,
-            keyword: None
-        }
+        Statement::Use(Use::Object(ObjectName(vec![
+            Ident::new("mydb"),
+            Ident::new("my_schema")
+        ])))
     );
 
-    let invalid_cases = ["USE SCHEMA", "USE DATABASE"];
+    for &quote in &quote_styles {
+        // Test single and double identifier with keyword and different type of quotes
+        std::assert_eq!(
+            snowflake().verified_stmt(&format!("USE DATABASE {0}my_database{0}", quote)),
+            Statement::Use(Use::Database(ObjectName(vec![Ident::with_quote(
+                quote,
+                "my_database".to_string(),
+            )])))
+        );
+        std::assert_eq!(
+            snowflake().verified_stmt(&format!("USE SCHEMA {0}my_schema{0}", quote)),
+            Statement::Use(Use::Schema(ObjectName(vec![Ident::with_quote(
+                quote,
+                "my_schema".to_string(),
+            )])))
+        );
+        std::assert_eq!(
+            snowflake().verified_stmt(&format!("USE SCHEMA {0}CATALOG{0}.{0}my_schema{0}", quote)),
+            Statement::Use(Use::Schema(ObjectName(vec![
+                Ident::with_quote(quote, "CATALOG"),
+                Ident::with_quote(quote, "my_schema")
+            ])))
+        );
+    }
+
+    // Test invalid syntax - missing identifier
+    let invalid_cases = ["USE SCHEMA", "USE DATABASE", "USE WAREHOUSE"];
     for sql in &invalid_cases {
         std::assert_eq!(
             snowflake().parse_sql_statements(sql).unwrap_err(),


### PR DESCRIPTION
I'd like to add support for different syntaxes of the `USE` statement, used to set a default DATABASE/SCHEMA for set of queries.

Some implementations are calling their top level structure `CATALOG` (e.g. [Databricks](https://docs.databricks.com/en/data-governance/unity-catalog/index.html#object-hierarchy-in-the-metastore), [Trino](https://trino.io/docs/current/overview/concepts.html#catalog)), but most of them stick to `DATABASE` so I assumed that we should stick to naming: `top-level container = DATABASE`, `lower-level container = SCHEMA`. For the full identifier we end up with: `DATABASE.SCHEMA.TABLE`.

In some implementations `DATABASE` and `SCHEMA` are aliases, but usually these implementations have a two-layer structure (`DATABASE.TABLE`, without `SCHEMA`) - in that case we should keep `DATABASE` as `DATABASE` and leave `SCHEMA` empty.

There are different syntaxes of USE statement across dialects, but I implemented it like:
(use syntax => resolved db and schema names)
1. `USE x;` -> `DATABASE=x; SCHEMA=null;` (Databricks is adjusted to `DATABASE=null; SCHEMA=x;`)
2. `USE x.y;` -> `DATABASE=x; SCHEMA=y;`
3. `USE DATABASE x;` -> `DATABASE=x; SCHEMA=null;` (Databricks is adjusted to `DATABASE=null; SCHEMA=x;` In Databricks `DATABASE` is an alias for `SCHEMA` and they both mean lower level structure while the top level structure is called `CATALOG`)
4. `USE SCHEMA y;` -> `DATABASE=null; SCHEMA=y;`
5. `USE SCHEMA x.y;` -> `DATABASE=x; SCHEMA=y;` (Snowflake specific syntax, SCHEMA keyword is optional and should not influence the parsing of fully qualified name)
6. `USE CATALOG x;` -> `DATABASE=x; SCHEMA=null;` (Databricks-specific keyword: `CATALOG`)
7. `USE DEFAULT;` -> `DATABASE=null; SCHEMA=null;`  (Hive specific, means going back to default database set - we don't know what it is just by looking at the query.)

Docs about USE statement in different dialects:
- [MySQL 8.4 USE](https://dev.mysql.com/doc/refman/8.4/en/use.html)
- [MySQL 5.7 USE](https://dev.mysql.com/doc/refman/5.7/en/use.html)
- [Snowflake USE SCHEMA](https://docs.snowflake.com/en/sql-reference/sql/use-schema)
- [Snowflake USE DATABASE](https://docs.snowflake.com/en/sql-reference/sql/use-database)
- [SQL Server USE](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/use-transact-sql?view=sql-server-ver16)
- [ClickHouse USE](https://clickhouse.com/docs/en/sql-reference/statements/use)
- [DuckDB USE](https://duckdb.org/docs/sql/statements/use.html)
- [Hive USE](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-UseDatabase)
- [Databricks USE CATALOG](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-use-catalog.html)
- [Databricks USE SCHEMA](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-use-schema.html)
- [Databricks USE DATABASE](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-usedb.html)

Some comments:
- Bigquery, PostgreSQL, Redshift, SQLite do not allow USE statements;

