### PR TITLE
Add support of `ADD PROJECTION` syntax for ClickHouse

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -48,7 +48,7 @@ pub use self::query::{
     InterpolateExpr, Join, JoinConstraint, JoinOperator, JsonTableColumn,
     JsonTableColumnErrorHandling, LateralView, LockClause, LockType, MatchRecognizePattern,
     MatchRecognizeSymbol, Measure, NamedWindowDefinition, NamedWindowExpr, NonBlock, Offset,
-    OffsetRows, OrderBy, OrderByExpr, PivotValueSource, Query, RenameSelectItem,
+    OffsetRows, OrderBy, OrderByExpr, PivotValueSource, ProjectionSelect, Query, RenameSelectItem,
     RepetitionQuantifier, ReplaceSelectElement, ReplaceSelectItem, RowsPerMatch, Select,
     SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, Setting, SymbolDefinition, Table,
     TableAlias, TableFactor, TableFunctionArgs, TableVersion, TableWithJoins, Top, TopQuantity,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -576,6 +576,7 @@ define_keywords!(
     PRIVILEGES,
     PROCEDURE,
     PROGRAM,
+    PROJECTION,
     PURGE,
     QUALIFY,
     QUARTER,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6437,6 +6437,16 @@ impl<'a> Parser<'a> {
             order_by,
         })
     }
+    pub fn parse_alter_table_add_projection(&mut self) -> Result<AlterTableOperation, ParserError> {
+        let if_not_exists = self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
+        let name = self.parse_identifier(false)?;
+        let query = self.parse_projection_select()?;
+        Ok(AlterTableOperation::AddProjection {
+            if_not_exists,
+            name,
+            select: query,
+        })
+    }
 
     pub fn parse_alter_table_operation(&mut self) -> Result<AlterTableOperation, ParserError> {
         let operation = if self.parse_keyword(Keyword::ADD) {
@@ -6445,15 +6455,7 @@ impl<'a> Parser<'a> {
             } else if dialect_of!(self is ClickHouseDialect|GenericDialect)
                 && self.parse_keyword(Keyword::PROJECTION)
             {
-                let if_not_exists =
-                    self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
-                let name = self.parse_identifier(false)?;
-                let query = self.parse_projection_select()?;
-                AlterTableOperation::AddProjection {
-                    if_not_exists,
-                    name,
-                    select: query,
-                }
+                return self.parse_alter_table_add_projection();
             } else {
                 let if_not_exists =
                     self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);


### PR DESCRIPTION
ClickHouse supports using the projections mechanism to optimize query execution, and allow to use `ALTER TABLE` to manipulate its projection behavior.

For the documentation, please refer to:

https://clickhouse.com/docs/en/sql-reference/statements/alter/projection#add-projection