### PR TITLE
fix interval precedence for interval expressions

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -31,7 +31,7 @@ Usage:
 $ cargo run --example cli FILENAME.sql [--dialectname]
 
 To print the parse results as JSON:
-$ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
+$ cargo run --features json_example --example cli FILENAME.sql [--dialectname]
 
 "#,
     );

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -482,6 +482,7 @@ pub trait Dialect: Debug + Any {
             Precedence::UnaryNot => 15,
             Precedence::And => 10,
             Precedence::Or => 5,
+            Precedence::Interval => 4,
         }
     }
 
@@ -522,6 +523,7 @@ pub enum Precedence {
     UnaryNot,
     And,
     Or,
+    Interval,
 }
 
 impl dyn Dialect {

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -482,7 +482,7 @@ pub trait Dialect: Debug + Any {
             Precedence::UnaryNot => 15,
             Precedence::And => 10,
             Precedence::Or => 5,
-            Precedence::Interval => 4,
+            Precedence::Interval => self.prec_unknown(),
         }
     }
 

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -21,6 +21,8 @@ use crate::tokenizer::Token;
 #[derive(Debug)]
 pub struct PostgreSqlDialect {}
 
+// matches <https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE>
+const INTERVAL_COLON_PREC: u8 = 150;
 const DOUBLE_COLON_PREC: u8 = 140;
 const BRACKET_PREC: u8 = 130;
 const COLLATE_PREC: u8 = 120;
@@ -136,6 +138,7 @@ impl Dialect for PostgreSqlDialect {
 
     fn prec_value(&self, prec: Precedence) -> u8 {
         match prec {
+            Precedence::Interval => INTERVAL_COLON_PREC,
             Precedence::DoubleColon => DOUBLE_COLON_PREC,
             Precedence::AtTz => AT_TZ_PREC,
             Precedence::MulDivModOp => MUL_DIV_MOD_OP_PREC,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -897,7 +897,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_interval_expr(&mut self) -> Result<Expr, ParserError> {
-        let precedence = self.dialect.prec_unknown();
+        let precedence = self.dialect.prec_value(Precedence::Interval);
         let mut expr = self.parse_prefix()?;
 
         loop {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4954,8 +4954,10 @@ fn parse_interval() {
         expr_from_projection(only(&select.projection)),
     );
 
+
     let sql = "SELECT INTERVAL 1 + 1 DAY";
-    let select = verified_only_select(sql);
+    let all_except_pg = all_dialects_except(|d| d.is::<PostgreSqlDialect>());
+    let select = all_except_pg.verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
             value: Box::new(Expr::BinaryOp {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4954,7 +4954,6 @@ fn parse_interval() {
         expr_from_projection(only(&select.projection)),
     );
 
-
     let sql = "SELECT INTERVAL 1 + 1 DAY";
     let all_except_pg = all_dialects_except(|d| d.is::<PostgreSqlDialect>());
     let select = all_except_pg.verified_only_select(sql);

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4952,43 +4952,47 @@ fn test_unicode_string_literal() {
 #[test]
 fn interval_precedence_gt() {
     let expr = pg().verified_expr("INTERVAL '1 second' > x");
-    assert_eq!(expr, Expr::BinaryOp {
-        left: Box::new(Expr::Interval(
-            Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString("1 second".to_string()))),
+    assert_eq!(
+        expr,
+        Expr::BinaryOp {
+            left: Box::new(Expr::Interval(Interval {
+                value: Box::new(Expr::Value(Value::SingleQuotedString(
+                    "1 second".to_string()
+                ))),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
                 fractional_seconds_precision: None,
-            },
-        )),
-        op: BinaryOperator::Gt,
-        right: Box::new(Expr::Identifier(
-            Ident {
+            },)),
+            op: BinaryOperator::Gt,
+            right: Box::new(Expr::Identifier(Ident {
                 value: "x".to_string(),
                 quote_style: None,
-            },
-        )),
-    })
+            })),
+        }
+    )
 }
 
 #[test]
 fn interval_precedence_double_colon() {
     let expr = pg().verified_expr("INTERVAL '1 second'::TEXT");
-    assert_eq!(expr, Expr::Cast {
-        kind: CastKind::DoubleColon,
-        expr: Box::new(Expr::Interval(
-            Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString("1 second".to_string()))),
+    assert_eq!(
+        expr,
+        Expr::Cast {
+            kind: CastKind::DoubleColon,
+            expr: Box::new(Expr::Interval(Interval {
+                value: Box::new(Expr::Value(Value::SingleQuotedString(
+                    "1 second".to_string()
+                ))),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
                 fractional_seconds_precision: None,
-            },
-        )),
-        data_type: DataType::Text,
-        format: None,
-    })
+            })),
+            data_type: DataType::Text,
+            format: None,
+        }
+    )
 }
 
 fn check_arrow_precedence(sql: &str, arrow_operator: BinaryOperator) {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4949,6 +4949,48 @@ fn test_unicode_string_literal() {
     }
 }
 
+#[test]
+fn interval_precedence_gt() {
+    let expr = pg().verified_expr("INTERVAL '1 second' > x");
+    assert_eq!(expr, Expr::BinaryOp {
+        left: Box::new(Expr::Interval(
+            Interval {
+                value: Box::new(Expr::Value(Value::SingleQuotedString("1 second".to_string()))),
+                leading_field: None,
+                leading_precision: None,
+                last_field: None,
+                fractional_seconds_precision: None,
+            },
+        )),
+        op: BinaryOperator::Gt,
+        right: Box::new(Expr::Identifier(
+            Ident {
+                value: "x".to_string(),
+                quote_style: None,
+            },
+        )),
+    })
+}
+
+#[test]
+fn interval_precedence_double_colon() {
+    let expr = pg().verified_expr("INTERVAL '1 second'::TEXT");
+    assert_eq!(expr, Expr::Cast {
+        kind: CastKind::DoubleColon,
+        expr: Box::new(Expr::Interval(
+            Interval {
+                value: Box::new(Expr::Value(Value::SingleQuotedString("1 second".to_string()))),
+                leading_field: None,
+                leading_precision: None,
+                last_field: None,
+                fractional_seconds_precision: None,
+            },
+        )),
+        data_type: DataType::Text,
+        format: None,
+    })
+}
+
 fn check_arrow_precedence(sql: &str, arrow_operator: BinaryOperator) {
     assert_eq!(
         pg().verified_expr(sql),


### PR DESCRIPTION
I'm not sure this is exactly the right solution, but it's definitely closer to correct for PostgreSQL.