### PR TITLE
Fix identifier starts with `$` should be regarded as a placeholder in SQLite

### DIFF
--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -41,7 +41,6 @@ impl Dialect for SQLiteDialect {
         ch.is_ascii_lowercase()
             || ch.is_ascii_uppercase()
             || ch == '_'
-            || ch == '$'
             || ('\u{007f}'..='\u{ffff}').contains(&ch)
     }
 

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -20,6 +20,7 @@ mod test_utils;
 use test_utils::*;
 
 use sqlparser::ast::SelectItem::UnnamedExpr;
+use sqlparser::ast::Value::Placeholder;
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, SQLiteDialect};
 use sqlparser::parser::{ParserError, ParserOptions};
@@ -468,6 +469,22 @@ fn parse_start_transaction_with_modifier() {
         ParserError::ParserError("Expected: end of statement, found: EXCLUSIVE".to_string()),
         res.unwrap_err(),
     );
+}
+
+#[test]
+fn test_dollar_identifier_as_placeholder() {
+    // This relates to the discussion in issue #291. The `$id` should be treated as a placeholder,
+    // not as an identifier in SQLite dialect.
+    //
+    // Reference: https://www.sqlite.org/lang_expr.html#varparam
+    match sqlite().verified_expr("id = $id") {
+        Expr::BinaryOp { op, left, right } => {
+            assert_eq!(op, BinaryOperator::Eq);
+            assert_eq!(left, Box::new(Expr::Identifier(Ident::new("id"))));
+            assert_eq!(right, Box::new(Expr::Value(Placeholder("$id".to_string()))));
+        }
+        _ => unreachable!(),
+    }
 }
 
 fn sqlite() -> TestedDialects {


### PR DESCRIPTION
Currently, `$var` would be parsed as an identifier instead of a placeholder in SQLite dialect, which is unexpected from the SQLite's documentation: https://www.sqlite.org/lang_expr.html#varparam.

This relates to the issue comment: https://github.com/sqlparser-rs/sqlparser-rs/issues/291#issuecomment-2309797948