### PR TITLE
Add support for postgres TRUNCATE syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2013,11 +2013,12 @@ pub enum Statement {
     Truncate {
         #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
         table_name: ObjectName,
+        table_names: Vec<ObjectName>,
         partitions: Option<Vec<Expr>>,
         /// TABLE - optional keyword;
         table: bool,
         /// Postgres-specific option
-        /// TRUNCATE [ TABLE ] [ ONLY ] name
+        /// [ TRUNCATE TABLE ONLY ]
         only: bool,
         /// Postgres-specific option
         /// [ RESTART IDENTITY | CONTINUE IDENTITY ]
@@ -3140,7 +3141,8 @@ impl fmt::Display for Statement {
                 Ok(())
             }
             Statement::Truncate {
-                table_name,
+                table_name: _,
+                table_names,
                 partitions,
                 table,
                 only,
@@ -3149,7 +3151,15 @@ impl fmt::Display for Statement {
             } => {
                 let table = if *table { "TABLE " } else { "" };
                 let only = if *only { "ONLY " } else { "" };
-                write!(f, "TRUNCATE {table}{only}{table_name}")?;
+
+                let table_names = table_names
+                    .iter()
+                    .map(|table_name| table_name.to_string()) // replace `to_string()` with the appropriate method if necessary
+                    .collect::<Vec<String>>()
+                    .join(", ");
+
+                write!(f, "TRUNCATE {table}{only}{table_names}")?;
+
                 if let Some(identity) = identity {
                     match identity {
                         TruncateIdentityOption::Restart => write!(f, " RESTART IDENTITY")?,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2016,6 +2016,15 @@ pub enum Statement {
         partitions: Option<Vec<Expr>>,
         /// TABLE - optional keyword;
         table: bool,
+        /// Postgres-specific option
+        /// TRUNCATE [ TABLE ] [ ONLY ] name
+        only: bool,
+        /// Postgres-specific option
+        /// [ RESTART IDENTITY | CONTINUE IDENTITY ]
+        identity: Option<TruncateIdentityOption>,
+        /// Postgres-specific option
+        /// [ CASCADE | RESTRICT ]
+        cascade: Option<TruncateCascadeOption>,
     },
     /// ```sql
     /// MSCK
@@ -3134,9 +3143,26 @@ impl fmt::Display for Statement {
                 table_name,
                 partitions,
                 table,
+                only,
+                identity,
+                cascade,
             } => {
                 let table = if *table { "TABLE " } else { "" };
-                write!(f, "TRUNCATE {table}{table_name}")?;
+                let only = if *only { "ONLY " } else { "" };
+                write!(f, "TRUNCATE {table}{only}{table_name}")?;
+                if let Some(identity) = identity {
+                    match identity {
+                        TruncateIdentityOption::Restart => write!(f, " RESTART IDENTITY")?,
+                        TruncateIdentityOption::Continue => write!(f, " CONTINUE IDENTITY")?,
+                    }
+                }
+                if let Some(cascade) = cascade {
+                    match cascade {
+                        TruncateCascadeOption::Cascade => write!(f, " CASCADE")?,
+                        TruncateCascadeOption::Restrict => write!(f, " RESTRICT")?,
+                    }
+                }
+
                 if let Some(ref parts) = partitions {
                     if !parts.is_empty() {
                         write!(f, " PARTITION ({})", display_comma_separated(parts))?;
@@ -4585,6 +4611,26 @@ impl fmt::Display for SequenceOptions {
             }
         }
     }
+}
+
+/// PostgreSQL identity option for TRUNCATE table
+/// [ RESTART IDENTITY | CONTINUE IDENTITY ]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum TruncateIdentityOption {
+    Restart,
+    Continue,
+}
+
+/// PostgreSQL cascade option for TRUNCATE table
+/// [ CASCADE | RESTRICT ]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum TruncateCascadeOption {
+    Cascade,
+    Restrict,
 }
 
 /// Can use to describe options in  create sequence or table column type identity

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1761,6 +1761,9 @@ pub struct OrderByExpr {
     pub asc: Option<bool>,
     /// Optional `NULLS FIRST` or `NULLS LAST`
     pub nulls_first: Option<bool>,
+    /// Optional: `USING``operator
+    /// Supported by [PostgreSQL syntax]: <https://www.postgresql.org/docs/current/sql-select.html>
+    pub using: Option<BinaryOperator>,
     /// Optional: `WITH FILL`
     /// Supported by [ClickHouse syntax]: <https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#order-by-expr-with-fill-modifier>
     pub with_fill: Option<WithFill>,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -175,6 +175,7 @@ define_keywords!(
     CONNECTION,
     CONSTRAINT,
     CONTAINS,
+    CONTINUE,
     CONVERT,
     COPY,
     COPY_OPTIONS,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -682,7 +682,11 @@ impl<'a> Parser<'a> {
     pub fn parse_truncate(&mut self) -> Result<Statement, ParserError> {
         let table = self.parse_keyword(Keyword::TABLE);
         let only = self.parse_keyword(Keyword::ONLY);
-        let table_name = self.parse_object_name(false)?;
+
+        let table_names = self.parse_comma_separated(|p| p.parse_object_name(false))?;
+
+        // Unwrap is safe - the preceding parse  fails if there is not at least one table name
+        let table_name = table_names.first().unwrap().clone();
 
         let mut partitions = None;
         if self.parse_keyword(Keyword::PARTITION) {
@@ -709,6 +713,7 @@ impl<'a> Parser<'a> {
 
         Ok(Statement::Truncate {
             table_name,
+            table_names,
             partitions,
             table,
             only,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -681,17 +681,39 @@ impl<'a> Parser<'a> {
 
     pub fn parse_truncate(&mut self) -> Result<Statement, ParserError> {
         let table = self.parse_keyword(Keyword::TABLE);
+        let only = self.parse_keyword(Keyword::ONLY);
         let table_name = self.parse_object_name(false)?;
+
         let mut partitions = None;
         if self.parse_keyword(Keyword::PARTITION) {
             self.expect_token(&Token::LParen)?;
             partitions = Some(self.parse_comma_separated(Parser::parse_expr)?);
             self.expect_token(&Token::RParen)?;
         }
+
+        let identity = if self.parse_keywords(&[Keyword::RESTART, Keyword::IDENTITY]) {
+            Some(TruncateIdentityOption::Restart)
+        } else if self.parse_keywords(&[Keyword::CONTINUE, Keyword::IDENTITY]) {
+            Some(TruncateIdentityOption::Continue)
+        } else {
+            None
+        };
+
+        let cascade = if self.parse_keyword(Keyword::CASCADE) {
+            Some(TruncateCascadeOption::Cascade)
+        } else if self.parse_keyword(Keyword::RESTRICT) {
+            Some(TruncateCascadeOption::Restrict)
+        } else {
+            None
+        };
+
         Ok(Statement::Truncate {
             table_name,
             partitions,
             table,
+            only,
+            identity,
+            cascade,
         })
     }
 


### PR DESCRIPTION

Correctly parses the following pg options:
```
ONLY
RESTART IDENTITY | CONTINUE IDENTITY 
CASCADE | RESTRICT 
```

And supports providing a list of table names 
```
TRUNCATE table_a, table_b, table_c
```

