### PR TITLE
fix: Fix stack overflow in parse_subexpr

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -874,12 +874,12 @@ impl<'a> Parser<'a> {
 
     /// Parse a new expression.
     pub fn parse_expr(&mut self) -> Result<Expr, ParserError> {
-        let _guard = self.recursion_counter.try_decrease()?;
         self.parse_subexpr(self.dialect.prec_unknown())
     }
 
     /// Parse tokens until the precedence changes.
     pub fn parse_subexpr(&mut self, precedence: u8) -> Result<Expr, ParserError> {
+        let _guard = self.recursion_counter.try_decrease()?;
         debug!("parsing expr");
         let mut expr = self.parse_prefix()?;
         debug!("prefix: {:?}", expr);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8809,6 +8809,13 @@ fn parse_deeply_nested_parens_hits_recursion_limits() {
 }
 
 #[test]
+fn parse_deeply_nested_unary_op_hits_recursion_limits() {
+    let sql = format!("SELECT {}", "+".repeat(1000));
+    let res = parse_sql_statements(&sql);
+    assert_eq!(ParserError::RecursionLimitExceeded, res.unwrap_err());
+}
+
+#[test]
 fn parse_deeply_nested_expr_hits_recursion_limits() {
     let dialect = GenericDialect {};
 


### PR DESCRIPTION
This patch moves the guard from parse_expr to parse_subexpr. This helps
prevent us from overflowing the stack in more cases. Also added a test case for where the current code has a stackoverflow. The test cases is a expression contains a repeated +(unary plus) leading to a stackoverflow.

Found by running the fuzzer.