### PR TITLE
Fix Hive table comment should be after table column definitions

### DIFF
--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -226,6 +226,13 @@ impl Display for CreateTable {
             // PostgreSQL allows `CREATE TABLE t ();`, but requires empty parens
             write!(f, " ()")?;
         }
+
+        // Hive table comment should be after column definitions, please refer to:
+        // [Hive](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-CreateTable)
+        if let Some(CommentDef::AfterColumnDefsWithoutEq(comment)) = &self.comment {
+            write!(f, " COMMENT '{comment}'")?;
+        }
+
         // Only for SQLite
         if self.without_rowid {
             write!(f, " WITHOUT ROWID")?;
@@ -336,6 +343,8 @@ impl Display for CreateTable {
                 CommentDef::WithoutEq(comment) => {
                     write!(f, " COMMENT '{comment}'")?;
                 }
+                // For CommentDef::AfterColumnDefsWithoutEq will be displayed after column definition
+                CommentDef::AfterColumnDefsWithoutEq(_) => (),
             }
         }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -6807,12 +6807,18 @@ pub enum CommentDef {
     /// Does not include `=` when printing the comment, as `COMMENT 'comment'`
     WithEq(String),
     WithoutEq(String),
+    // For Hive dialect, the table comment is after the column definitions without `=`,
+    // so we need to add an extra variant to allow to identify this case when displaying.
+    // [Hive](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-CreateTable)
+    AfterColumnDefsWithoutEq(String),
 }
 
 impl Display for CommentDef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CommentDef::WithEq(comment) | CommentDef::WithoutEq(comment) => write!(f, "{comment}"),
+            CommentDef::WithEq(comment)
+            | CommentDef::WithoutEq(comment)
+            | CommentDef::AfterColumnDefsWithoutEq(comment) => write!(f, "{comment}"),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5735,18 +5735,14 @@ impl<'a> Parser<'a> {
         let strict = self.parse_keyword(Keyword::STRICT);
 
         // Excludes Hive dialect here since it has been handled after table column definitions.
-        if !dialect_of!(self is HiveDialect) {
-            comment = if self.parse_keyword(Keyword::COMMENT) {
-                let _ = self.consume_token(&Token::Eq);
-                let next_token = self.next_token();
-                match next_token.token {
-                    Token::SingleQuotedString(str) => Some(CommentDef::WithoutEq(str)),
-                    _ => self.expected("comment", next_token)?,
-                }
-            } else {
-                None
-            };
-        }
+        if !dialect_of!(self is HiveDialect) && self.parse_keyword(Keyword::COMMENT) {
+            let _ = self.consume_token(&Token::Eq);
+            let next_token = self.next_token();
+            comment = match next_token.token {
+                Token::SingleQuotedString(str) => Some(CommentDef::WithoutEq(str)),
+                _ => self.expected("comment", next_token)?,
+            }
+        };
 
         // Parse optional `AS ( query )`
         let query = if self.parse_keyword(Keyword::AS) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5734,7 +5734,7 @@ impl<'a> Parser<'a> {
 
         let strict = self.parse_keyword(Keyword::STRICT);
 
-        // For Hive, the comment is after the table column definitions
+        // Excludes Hive dialect here since it has been handled after table column definitions.
         if !dialect_of!(self is HiveDialect) {
             comment = if self.parse_keyword(Keyword::COMMENT) {
                 let _ = self.consume_token(&Token::Eq);


### PR DESCRIPTION
For the documentation, please refer to:
https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-CreateTable

This closes #1395