### PR TITLE
minor: Add `dabricks` dialect to `dialect_from_str`

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -587,6 +587,7 @@ pub fn dialect_from_str(dialect_name: impl AsRef<str>) -> Option<Box<dyn Dialect
         "bigquery" => Some(Box::new(BigQueryDialect)),
         "ansi" => Some(Box::new(AnsiDialect {})),
         "duckdb" => Some(Box::new(DuckDbDialect {})),
+        "databricks" => Some(Box::new(DatabricksDialect {})),
         _ => None,
     }
 }


### PR DESCRIPTION
Databricks dialect is missing in `dialect_from_str` function