### PR TITLE
Fix parsing of negative values

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7274,7 +7274,7 @@ impl<'a> Parser<'a> {
                 let placeholder = tok.to_string() + &ident.value;
                 Ok(Value::Placeholder(placeholder))
             }
-            tok @ Token::Minus => {
+            tok @ Token::Minus | tok @ Token::Plus => {
                 let next_token = self.next_token();
                 match next_token.token {
                     Token::Number(n, l) => Ok(Value::Number(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7277,10 +7277,16 @@ impl<'a> Parser<'a> {
             tok @ Token::Minus | tok @ Token::Plus => {
                 let next_token = self.next_token();
                 match next_token.token {
-                    Token::Number(n, l) => Ok(Value::Number(
-                        Self::parse::<String>(tok.to_string() + &n, location)?,
-                        l,
-                    )),
+                    Token::Number(n, l) => {
+                        if tok == Token::Minus {
+                            Ok(Value::Number(
+                                Self::parse(tok.to_string() + &n, location)?,
+                                l,
+                            ))
+                        } else {
+                            Ok(Value::Number(Self::parse(n, location)?, l))
+                        }
+                    }
                     _ => self.expected("number", next_token),
                 }
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7298,7 +7298,7 @@ impl<'a> Parser<'a> {
 
     /// Parse a numeric literal as an expression. Returns a [`Expr::UnaryOp`] if the number is signed,
     /// otherwise returns a [`Expr::Value`]
-    pub fn parse_number_value_with_sign(&mut self) -> Result<Expr, ParserError> {
+    pub fn parse_number(&mut self) -> Result<Expr, ParserError> {
         let next_token = self.next_token();
         match next_token.token {
             Token::Plus => Ok(Expr::UnaryOp {
@@ -11629,30 +11629,20 @@ impl<'a> Parser<'a> {
         //[ INCREMENT [ BY ] increment ]
         if self.parse_keywords(&[Keyword::INCREMENT]) {
             if self.parse_keywords(&[Keyword::BY]) {
-                sequence_options.push(SequenceOptions::IncrementBy(
-                    self.parse_number_value_with_sign()?,
-                    true,
-                ));
+                sequence_options.push(SequenceOptions::IncrementBy(self.parse_number()?, true));
             } else {
-                sequence_options.push(SequenceOptions::IncrementBy(
-                    self.parse_number_value_with_sign()?,
-                    false,
-                ));
+                sequence_options.push(SequenceOptions::IncrementBy(self.parse_number()?, false));
             }
         }
         //[ MINVALUE minvalue | NO MINVALUE ]
         if self.parse_keyword(Keyword::MINVALUE) {
-            sequence_options.push(SequenceOptions::MinValue(Some(
-                self.parse_number_value_with_sign()?,
-            )));
+            sequence_options.push(SequenceOptions::MinValue(Some(self.parse_number()?)));
         } else if self.parse_keywords(&[Keyword::NO, Keyword::MINVALUE]) {
             sequence_options.push(SequenceOptions::MinValue(None));
         }
         //[ MAXVALUE maxvalue | NO MAXVALUE ]
         if self.parse_keywords(&[Keyword::MAXVALUE]) {
-            sequence_options.push(SequenceOptions::MaxValue(Some(
-                self.parse_number_value_with_sign()?,
-            )));
+            sequence_options.push(SequenceOptions::MaxValue(Some(self.parse_number()?)));
         } else if self.parse_keywords(&[Keyword::NO, Keyword::MAXVALUE]) {
             sequence_options.push(SequenceOptions::MaxValue(None));
         }
@@ -11660,20 +11650,14 @@ impl<'a> Parser<'a> {
         //[ START [ WITH ] start ]
         if self.parse_keywords(&[Keyword::START]) {
             if self.parse_keywords(&[Keyword::WITH]) {
-                sequence_options.push(SequenceOptions::StartWith(
-                    self.parse_number_value_with_sign()?,
-                    true,
-                ));
+                sequence_options.push(SequenceOptions::StartWith(self.parse_number()?, true));
             } else {
-                sequence_options.push(SequenceOptions::StartWith(
-                    self.parse_number_value_with_sign()?,
-                    false,
-                ));
+                sequence_options.push(SequenceOptions::StartWith(self.parse_number()?, false));
             }
         }
         //[ CACHE cache ]
         if self.parse_keywords(&[Keyword::CACHE]) {
-            sequence_options.push(SequenceOptions::Cache(self.parse_number_value_with_sign()?));
+            sequence_options.push(SequenceOptions::Cache(self.parse_number()?));
         }
         // [ [ NO ] CYCLE ]
         if self.parse_keywords(&[Keyword::NO, Keyword::CYCLE]) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7274,6 +7274,16 @@ impl<'a> Parser<'a> {
                 let placeholder = tok.to_string() + &ident.value;
                 Ok(Value::Placeholder(placeholder))
             }
+            tok @ Token::Minus => {
+                let next_token = self.next_token();
+                match next_token.token {
+                    Token::Number(n, l) => Ok(Value::Number(
+                        Self::parse::<String>(tok.to_string() + &n, location)?,
+                        l,
+                    )),
+                    _ => self.expected("number", next_token),
+                }
+            }
             unexpected => self.expected(
                 "a value",
                 TokenWithLocation {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2820,6 +2820,29 @@ fn parse_window_function_null_treatment_arg() {
 }
 
 #[test]
+fn parse_signed_value() {
+    let sql1 = "CREATE SEQUENCE name1
+    AS BIGINT
+    INCREMENT   -15
+    MINVALUE - 2000  MAXVALUE -50
+    START WITH -   60";
+    one_statement_parses_to(
+        sql1,
+        "CREATE SEQUENCE name1 AS BIGINT INCREMENT -15 MINVALUE -2000 MAXVALUE -50 START WITH -60",
+    );
+
+    let sql2 = "CREATE SEQUENCE name2
+    AS BIGINT
+    INCREMENT   +10
+    MINVALUE + 30  MAXVALUE +5000
+    START WITH +   45";
+    one_statement_parses_to(
+        sql2,
+        "CREATE SEQUENCE name2 AS BIGINT INCREMENT +10 MINVALUE +30 MAXVALUE +5000 START WITH +45",
+    );
+}
+
+#[test]
 fn parse_create_table() {
     let sql = "CREATE TABLE uk_cities (\
                name VARCHAR(100) NOT NULL,\

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2840,6 +2840,15 @@ fn parse_signed_value() {
         sql2,
         "CREATE SEQUENCE name2 AS BIGINT INCREMENT 10 MINVALUE 30 MAXVALUE 5000 START WITH 45",
     );
+
+    let sql3 = "CREATE SEQUENCE name3 INCREMENT -10 MINVALUE -1000 MAXVALUE 1 START -100;";
+    one_statement_parses_to(
+        sql3,
+        "CREATE SEQUENCE name3 INCREMENT -10 MINVALUE -1000 MAXVALUE 1 START -100",
+    );
+
+    let sql4 = "SELECT -1";
+    one_statement_parses_to(sql4, "SELECT -1");
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2838,7 +2838,7 @@ fn parse_signed_value() {
     START WITH +   45";
     one_statement_parses_to(
         sql2,
-        "CREATE SEQUENCE name2 AS BIGINT INCREMENT +10 MINVALUE +30 MAXVALUE +5000 START WITH +45",
+        "CREATE SEQUENCE name2 AS BIGINT INCREMENT 10 MINVALUE 30 MAXVALUE 5000 START WITH 45",
     );
 }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2820,35 +2820,15 @@ fn parse_window_function_null_treatment_arg() {
 }
 
 #[test]
-fn parse_signed_value() {
-    let sql1 = "CREATE SEQUENCE name1
-    AS BIGINT
-    INCREMENT   -15
-    MINVALUE - 2000  MAXVALUE -50
-    START WITH -   60";
-    one_statement_parses_to(
-        sql1,
-        "CREATE SEQUENCE name1 AS BIGINT INCREMENT -15 MINVALUE -2000 MAXVALUE -50 START WITH -60",
-    );
+fn parse_negative_value() {
+    let sql1 = "SELECT -1";
+    one_statement_parses_to(sql1, "SELECT -1");
 
-    let sql2 = "CREATE SEQUENCE name2
-    AS BIGINT
-    INCREMENT   +10
-    MINVALUE + 30  MAXVALUE +5000
-    START WITH +   45";
+    let sql2 = "CREATE SEQUENCE name INCREMENT -10 MINVALUE -1000 MAXVALUE 15 START -100;";
     one_statement_parses_to(
         sql2,
-        "CREATE SEQUENCE name2 AS BIGINT INCREMENT 10 MINVALUE 30 MAXVALUE 5000 START WITH 45",
+        "CREATE SEQUENCE name INCREMENT -10 MINVALUE -1000 MAXVALUE 15 START -100",
     );
-
-    let sql3 = "CREATE SEQUENCE name3 INCREMENT -10 MINVALUE -1000 MAXVALUE 1 START -100;";
-    one_statement_parses_to(
-        sql3,
-        "CREATE SEQUENCE name3 INCREMENT -10 MINVALUE -1000 MAXVALUE 1 START -100",
-    );
-
-    let sql4 = "SELECT -1";
-    one_statement_parses_to(sql4, "SELECT -1");
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -277,6 +277,26 @@ fn parse_create_sequence() {
         "CREATE TEMPORARY SEQUENCE IF NOT EXISTS name3 INCREMENT 1 NO MINVALUE MAXVALUE 20 OWNED BY NONE",
     );
 
+    let sql7 = "CREATE SEQUENCE name4
+    AS BIGINT
+    INCREMENT   -15
+    MINVALUE - 2000  MAXVALUE -50
+    START WITH -   60";
+    pg().one_statement_parses_to(
+        sql7,
+        "CREATE SEQUENCE name4 AS BIGINT INCREMENT -15 MINVALUE -2000 MAXVALUE -50 START WITH -60",
+    );
+
+    let sql8 = "CREATE SEQUENCE name5
+    AS BIGINT
+    INCREMENT   +10
+    MINVALUE + 30  MAXVALUE +5000
+    START WITH +   45";
+    pg().one_statement_parses_to(
+        sql8,
+        "CREATE SEQUENCE name5 AS BIGINT INCREMENT +10 MINVALUE +30 MAXVALUE +5000 START WITH +45",
+    );
+
     assert!(matches!(
         pg().parse_sql_statements("CREATE SEQUENCE foo INCREMENT 1 NO MINVALUE NO"),
         Err(ParserError::ParserError(_))

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -277,6 +277,16 @@ fn parse_create_sequence() {
         "CREATE TEMPORARY SEQUENCE IF NOT EXISTS name3 INCREMENT 1 NO MINVALUE MAXVALUE 20 OWNED BY NONE",
     );
 
+    let sql7 = "CREATE SEQUENCE name4
+    AS BIGINT
+    INCREMENT   -10
+    MINVALUE - 2000  MAXVALUE -5
+    START WITH -   20";
+    pg().one_statement_parses_to(
+        sql7,
+        "CREATE SEQUENCE name4 AS BIGINT INCREMENT -10 MINVALUE -2000 MAXVALUE -5 START WITH -20",
+    );
+
     assert!(matches!(
         pg().parse_sql_statements("CREATE SEQUENCE foo INCREMENT 1 NO MINVALUE NO"),
         Err(ParserError::ParserError(_))

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -277,16 +277,6 @@ fn parse_create_sequence() {
         "CREATE TEMPORARY SEQUENCE IF NOT EXISTS name3 INCREMENT 1 NO MINVALUE MAXVALUE 20 OWNED BY NONE",
     );
 
-    let sql7 = "CREATE SEQUENCE name4
-    AS BIGINT
-    INCREMENT   -10
-    MINVALUE - 2000  MAXVALUE -5
-    START WITH -   20";
-    pg().one_statement_parses_to(
-        sql7,
-        "CREATE SEQUENCE name4 AS BIGINT INCREMENT -10 MINVALUE -2000 MAXVALUE -5 START WITH -20",
-    );
-
     assert!(matches!(
         pg().parse_sql_statements("CREATE SEQUENCE foo INCREMENT 1 NO MINVALUE NO"),
         Err(ParserError::ParserError(_))


### PR DESCRIPTION
Currently, when passing negative numbers, the sql parser returns an error. While the PostgreSQL syntax allows you to specify negative values ​​when creating a sequence.

**Example:**
```
CREATE SEQUENCE seq START -100 INCREMENT -10 MINVALUE -1000 MAXVALUE 1;
```

**Error text:**
```
ParserError("Expected: a value, found: -")
```

**Link to PostgreSQL documentation**:
https://www.postgresql.org/docs/current/sql-createsequence.html