### PR TITLE
Allow to use ON CLUSTER cluster_name in TRUNCATE syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2172,6 +2172,11 @@ pub enum Statement {
         /// Postgres-specific option
         /// [ CASCADE | RESTRICT ]
         cascade: Option<TruncateCascadeOption>,
+        /// ClickHouse-specific option
+        /// [ ON CLUSTER cluster_name ]
+        ///
+        /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/truncate/)
+        on_cluster: Option<Ident>,
     },
     /// ```sql
     /// MSCK
@@ -3293,6 +3298,7 @@ impl fmt::Display for Statement {
                 only,
                 identity,
                 cascade,
+                on_cluster,
             } => {
                 let table = if *table { "TABLE " } else { "" };
                 let only = if *only { "ONLY " } else { "" };
@@ -3320,6 +3326,9 @@ impl fmt::Display for Statement {
                     if !parts.is_empty() {
                         write!(f, " PARTITION ({})", display_comma_separated(parts))?;
                     }
+                }
+                if let Some(on_cluster) = on_cluster {
+                    write!(f, " ON CLUSTER {on_cluster}")?;
                 }
                 Ok(())
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -708,6 +708,8 @@ impl<'a> Parser<'a> {
             };
         };
 
+        let on_cluster = self.parse_optional_on_cluster()?;
+
         Ok(Statement::Truncate {
             table_names,
             partitions,
@@ -715,6 +717,7 @@ impl<'a> Parser<'a> {
             only,
             identity,
             cascade,
+            on_cluster,
         })
     }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3990,6 +3990,7 @@ fn parse_truncate() {
             only: false,
             identity: None,
             cascade: None,
+            on_cluster: None,
         },
         truncate
     );
@@ -4012,7 +4013,8 @@ fn parse_truncate_with_options() {
             table: true,
             only: true,
             identity: Some(TruncateIdentityOption::Restart),
-            cascade: Some(TruncateCascadeOption::Cascade)
+            cascade: Some(TruncateCascadeOption::Cascade),
+            on_cluster: None,
         },
         truncate
     );
@@ -4043,7 +4045,8 @@ fn parse_truncate_with_table_list() {
             table: true,
             only: false,
             identity: Some(TruncateIdentityOption::Restart),
-            cascade: Some(TruncateCascadeOption::Cascade)
+            cascade: Some(TruncateCascadeOption::Cascade),
+            on_cluster: None,
         },
         truncate
     );


### PR DESCRIPTION
See https://clickhouse.com/docs/en/sql-reference/statements/truncate#truncate-table