### PR TITLE
MS SQL Server: add support for IDENTITY column option

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1050,6 +1050,20 @@ impl fmt::Display for ColumnOptionDef {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct IdentityProperty {
+    pub seed: Expr,
+    pub increment: Expr,
+}
+
+impl fmt::Display for IdentityProperty {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}, {}", self.seed, self.increment)
+    }
+}
+
 /// `ColumnOption`s are modifiers that follow a column definition in a `CREATE
 /// TABLE` statement.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1126,7 +1140,7 @@ pub enum ColumnOption {
     /// IDENTITY [ (seed , increment) ]
     /// ```
     /// [MS SQL Server]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property
-    Identity(Option<SqlOption>),
+    Identity(Option<IdentityProperty>),
 }
 
 impl fmt::Display for ColumnOption {

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1120,6 +1120,13 @@ pub enum ColumnOption {
     /// [1]: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#view_column_option_list
     /// [2]: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#column_option_list
     Options(Vec<SqlOption>),
+    /// MS SQL Server specific: Creates an identity column in a table.
+    /// Syntax
+    /// ```sql
+    /// IDENTITY [ (seed , increment) ]
+    /// ```
+    /// [MS SQL Server]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property
+    Identity(Option<SqlOption>),
 }
 
 impl fmt::Display for ColumnOption {
@@ -1220,6 +1227,13 @@ impl fmt::Display for ColumnOption {
             }
             Options(options) => {
                 write!(f, "OPTIONS({})", display_comma_separated(options))
+            }
+            Identity(parameters) => {
+                write!(f, "IDENTITY")?;
+                if let Some(parameters) = parameters {
+                    write!(f, "({parameters})")?;
+                }
+                Ok(())
             }
         }
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -36,8 +36,8 @@ pub use self::dcl::{AlterRoleOperation, ResetConfig, RoleOption, SetConfigValue,
 pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterTableOperation, ClusteredBy, ColumnDef,
     ColumnOption, ColumnOptionDef, ConstraintCharacteristics, Deduplicate, DeferrableInitial,
-    GeneratedAs, GeneratedExpressionMode, IndexOption, IndexType, KeyOrIndexDisplay, Owner,
-    Partition, ProcedureParam, ReferentialAction, TableConstraint,
+    GeneratedAs, GeneratedExpressionMode, IdentityProperty, IndexOption, IndexType,
+    KeyOrIndexDisplay, Owner, Partition, ProcedureParam, ReferentialAction, TableConstraint,
     UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation, ViewColumnDef,
 };
 pub use self::dml::{CreateIndex, CreateTable, Delete, Insert};
@@ -5818,13 +5818,6 @@ pub enum SqlOption {
         range_direction: Option<PartitionRangeDirection>,
         for_values: Vec<Expr>,
     },
-    /// MS SQL Server specific: Optional parameters of identity column
-    /// E.g.
-    ///
-    ///   IDENTITY(1, 2)
-    ///
-    /// [MS SQL Server]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property
-    Identity { seed: Value, increment: Value },
 }
 
 impl fmt::Display for SqlOption {
@@ -5855,9 +5848,6 @@ impl fmt::Display for SqlOption {
                     direction,
                     display_comma_separated(for_values)
                 )
-            }
-            SqlOption::Identity { seed, increment } => {
-                write!(f, "{}, {}", seed, increment)
             }
         }
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -5818,6 +5818,13 @@ pub enum SqlOption {
         range_direction: Option<PartitionRangeDirection>,
         for_values: Vec<Expr>,
     },
+    /// MS SQL Server specific: Optional parameters of identity column
+    /// E.g.
+    ///
+    ///   IDENTITY(1, 2)
+    ///
+    /// [MS SQL Server]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property
+    Identity { seed: Value, increment: Value },
 }
 
 impl fmt::Display for SqlOption {
@@ -5848,6 +5855,9 @@ impl fmt::Display for SqlOption {
                     direction,
                     display_comma_separated(for_values)
                 )
+            }
+            SqlOption::Identity { seed, increment } => {
+                write!(f, "{}, {}", seed, increment)
             }
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6043,6 +6043,20 @@ impl<'a> Parser<'a> {
             && dialect_of!(self is MySqlDialect | SQLiteDialect | DuckDbDialect | GenericDialect)
         {
             self.parse_optional_column_option_as()
+        } else if self.parse_keyword(Keyword::IDENTITY)
+            && dialect_of!(self is MsSqlDialect | GenericDialect)
+        {
+            let parameters = if self.expect_token(&Token::LParen).is_ok() {
+                let seed = self.parse_number_value()?;
+                self.expect_token(&Token::Comma)?;
+                let increment = self.parse_number_value()?;
+                self.expect_token(&Token::RParen)?;
+
+                Some(SqlOption::Identity { seed, increment })
+            } else {
+                None
+            };
+            Ok(Some(ColumnOption::Identity(parameters)))
         } else {
             Ok(None)
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6046,17 +6046,17 @@ impl<'a> Parser<'a> {
         } else if self.parse_keyword(Keyword::IDENTITY)
             && dialect_of!(self is MsSqlDialect | GenericDialect)
         {
-            let parameters = if self.expect_token(&Token::LParen).is_ok() {
-                let seed = self.parse_number_value()?;
+            let property = if self.consume_token(&Token::LParen) {
+                let seed = self.parse_number()?;
                 self.expect_token(&Token::Comma)?;
-                let increment = self.parse_number_value()?;
+                let increment = self.parse_number()?;
                 self.expect_token(&Token::RParen)?;
 
-                Some(SqlOption::Identity { seed, increment })
+                Some(IdentityProperty { seed, increment })
             } else {
                 None
             };
-            Ok(Some(ColumnOption::Identity(parameters)))
+            Ok(Some(ColumnOption::Identity(property)))
         } else {
             Ok(None)
         }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -912,7 +912,7 @@ fn parse_create_table_with_invalid_options() {
 fn parse_create_table_with_identity_column() {
     let with_column_options = [
         (
-            r#"CREATE TABLE [mytable] ([columnA] INT IDENTITY NOT NULL)"#,
+            r#"CREATE TABLE mytable (columnA INT IDENTITY NOT NULL)"#,
             vec![
                 ColumnOptionDef {
                     name: None,
@@ -925,7 +925,7 @@ fn parse_create_table_with_identity_column() {
             ],
         ),
         (
-            r#"CREATE TABLE [mytable] ([columnA] INT IDENTITY(1, 1) NOT NULL)"#,
+            r#"CREATE TABLE mytable (columnA INT IDENTITY(1, 1) NOT NULL)"#,
             vec![
                 ColumnOptionDef {
                     name: None,
@@ -953,7 +953,7 @@ fn parse_create_table_with_identity_column() {
 
     for (sql, column_options) in with_column_options {
         assert_eq!(
-            ms().verified_stmt(sql),
+            ms_and_generic().verified_stmt(sql),
             Statement::CreateTable(CreateTable {
                 or_replace: false,
                 temporary: false,
@@ -964,12 +964,12 @@ fn parse_create_table_with_identity_column() {
                 volatile: false,
                 name: ObjectName(vec![Ident {
                     value: "mytable".to_string(),
-                    quote_style: Some('['),
+                    quote_style: None,
                 },],),
                 columns: vec![ColumnDef {
                     name: Ident {
                         value: "columnA".to_string(),
-                        quote_style: Some('['),
+                        quote_style: None,
                     },
                     data_type: Int(None,),
                     collation: None,

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -930,14 +930,17 @@ fn parse_create_table_with_identity_column() {
                 ColumnOptionDef {
                     name: None,
                     #[cfg(not(feature = "bigdecimal"))]
-                    option: ColumnOption::Identity(Some(SqlOption::Identity {
-                        seed: Value::Number("1".to_string(), false),
-                        increment: Value::Number("1".to_string(), false),
+                    option: ColumnOption::Identity(Some(IdentityProperty {
+                        seed: Expr::Value(Value::Number("1".to_string(), false)),
+                        increment: Expr::Value(Value::Number("1".to_string(), false)),
                     })),
                     #[cfg(feature = "bigdecimal")]
-                    option: ColumnOption::Identity(Some(SqlOption::Identity {
-                        seed: Value::Number(bigdecimal::BigDecimal::from(1), false),
-                        increment: Value::Number(bigdecimal::BigDecimal::from(1), false),
+                    option: ColumnOption::Identity(Some(IdentityProperty {
+                        seed: Expr::Value(Value::Number(bigdecimal::BigDecimal::from(1), false)),
+                        increment: Expr::Value(Value::Number(
+                            bigdecimal::BigDecimal::from(1),
+                            false,
+                        )),
                     })),
                 },
                 ColumnOptionDef {


### PR DESCRIPTION
This PR implements support [IDENTITY](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property?view=sql-server-ver16) column option of T-SQL (MS SQL Server). Example:

```
CREATE TABLE [dbo].[table_name]
(
  [columnA] int IDENTITY(1,1) NOT NULL,
  [columnB] nvarchar(255) NULL
)
```