### PR TITLE
Fix `codestyle` CI check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,11 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Rust Toolchain
         uses: ./.github/actions/setup-builder
-        with:
-          # Note that `nightly` is required for `license_template_path`, as
-          # it's an unstable feature.
-          rust-version: nightly
-      - run: cargo +nightly fmt -- --check --config-path <(echo 'license_template_path = "HEADER"')
+      - run: cargo fmt -- --check 
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
For reasons I don't understand and can't replicate,  https://github.com/sqlparser-rs/sqlparser-rs/pull/1437 caused CI on main to start failing the `codestyle` CI check. 

Here is an example failure:  https://github.com/sqlparser-rs/sqlparser-rs/actions/runs/10971828683/job/30467402220

```
Run cargo +nightly fmt -- --check --config-path <(echo 'license_template_path = "HEADER"')
No such file or directory (os error 2)
Error: Process completed with exit code 1.
```


That PR did pass the codestyle check ([CI run here](https://github.com/sqlparser-rs/sqlparser-rs/actions/runs/10948764051/job/30400522612?pr=1437)) 🤷 

