### PR TITLE
Add a note discouraging new use of `dialect_of` macro

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -60,6 +60,13 @@ use alloc::boxed::Box;
 
 /// Convenience check if a [`Parser`] uses a certain dialect.
 ///
+/// Note: when possible please the new style, adding a method to the [`Dialect`]
+/// trait rather than using this macro.
+///
+/// The benefits of adding a method on `Dialect` over this macro are:
+/// 1. user defined [`Dialect`]s can customize the parsing behavior
+/// 2. The differences between dialects can be clearly documented in the trait
+///
 /// `dialect_of!(parser Is SQLiteDialect |  GenericDialect)` evaluates
 /// to `true` if `parser.dialect` is one of the [`Dialect`]s specified.
 macro_rules! dialect_of {


### PR DESCRIPTION
@samuelcolvin  has brought up the idea of standardizing on one pattern for different Dialect parsing behavior

I don't have the ambition to try and change the existing code, but we can encourage new contributions to follow the preferred behavior with some comments. 

cc @iffyio @tobyhede and @lovasoa 