### PR TITLE
Run cargo fmt on `derive` crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Rust Toolchain
         uses: ./.github/actions/setup-builder
-      - run: cargo fmt -- --check 
+      - run: cargo fmt --all -- --check
 
   lint:
     runs-on: ubuntu-latest

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -18,7 +18,11 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
-use syn::{parse::{Parse, ParseStream}, parse_macro_input, parse_quote, Attribute, Data, DeriveInput, Fields, GenericParam, Generics, Ident, Index, LitStr, Meta, Token, Type, TypePath};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, parse_quote, Attribute, Data, DeriveInput, Fields, GenericParam, Generics,
+    Ident, Index, LitStr, Meta, Token, Type, TypePath,
+};
 use syn::{Path, PathArguments};
 
 /// Implementation of `[#derive(Visit)]`
@@ -267,7 +271,11 @@ fn visit_children(
 }
 
 fn is_option(ty: &Type) -> bool {
-    if let Type::Path(TypePath { path: Path { segments, .. }, .. }) = ty {
+    if let Type::Path(TypePath {
+        path: Path { segments, .. },
+        ..
+    }) = ty
+    {
         if let Some(segment) = segments.last() {
             if segment.ident == "Option" {
                 if let PathArguments::AngleBracketed(args) = &segment.arguments {


### PR DESCRIPTION
- part of https://github.com/apache/datafusion-sqlparser-rs/issues/1517

While running the release verification script with rc1 the cargo fmt check failed:

```
+ cargo fmt --all -- --check
Diff in /private/var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-sqlparser-rs-0.53.0.XXXXX.7AY3fOIeJZ/apache-datafusion-sqlparser-rs-0.53.0/derive/src/lib.rs:18:
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
-use syn::{parse::{Parse, ParseStream}, parse_macro_input, parse_quote, Attribute, Data, DeriveInput, Fields, GenericParam, Generics, Ident, Index, LitStr, Meta, Token, Type, TypePath};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, parse_quote, Attribute, Data, DeriveInput, Fields, GenericParam, Generics,
+    Ident, Index, LitStr, Meta, Token, Type, TypePath,
+};
 use syn::{Path, PathArguments};

 /// Implementation of `[#derive(Visit)]`
Diff in /private/var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-sqlparser-rs-0.53.0.XXXXX.7AY3fOIeJZ/apache-datafusion-sqlparser-rs-0.53.0/derive/src/lib.rs:267:
 }

 fn is_option(ty: &Type) -> bool {
-    if let Type::Path(TypePath { path: Path { segments, .. }, .. }) = ty {
+    if let Type::Path(TypePath {
+        path: Path { segments, .. },
+        ..
+    }) = ty
+    {
         if let Some(segment) = segments.last() {
             if segment.ident == "Option" {
                 if let PathArguments::AngleBracketed(args) = &segment.arguments {
+ cleanup
+ '[' no = yes ']'
+ echo 'Failed to verify release candidate. See /var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-sqlparser-rs-0.53.0.XXXXX.7AY3fOIeJZ for details.'
Failed to verify release candidate. See /var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-sqlparser-rs-0.53.0.XXXXX.7AY3fOIeJZ for details.
```

This PR updates the CI check to match the verification script and also formats derive