### PR TITLE
Keep the COLUMN keyword only if it exists when dropping the column

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -139,6 +139,7 @@ pub enum AlterTableOperation {
     },
     /// `DROP [ COLUMN ] [ IF EXISTS ] <column_name> [ CASCADE ]`
     DropColumn {
+        has_column_keyword: bool,
         column_name: Ident,
         if_exists: bool,
         drop_behavior: Option<DropBehavior>,
@@ -606,12 +607,14 @@ impl fmt::Display for AlterTableOperation {
             AlterTableOperation::DropPrimaryKey => write!(f, "DROP PRIMARY KEY"),
             AlterTableOperation::DropForeignKey { name } => write!(f, "DROP FOREIGN KEY {name}"),
             AlterTableOperation::DropColumn {
+                has_column_keyword,
                 column_name,
                 if_exists,
                 drop_behavior,
             } => write!(
                 f,
-                "DROP COLUMN {}{}{}",
+                "DROP {}{}{}{}",
+                if *has_column_keyword { "COLUMN " } else { "" },
                 if *if_exists { "IF EXISTS " } else { "" },
                 column_name,
                 match drop_behavior {

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1090,6 +1090,7 @@ impl Spanned for AlterTableOperation {
                 drop_behavior: _,
             } => name.span,
             AlterTableOperation::DropColumn {
+                has_column_keyword: _,
                 column_name,
                 if_exists: _,
                 drop_behavior: _,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8608,11 +8608,12 @@ impl<'a> Parser<'a> {
             } else if self.parse_keywords(&[Keyword::CLUSTERING, Keyword::KEY]) {
                 AlterTableOperation::DropClusteringKey
             } else {
-                let _ = self.parse_keyword(Keyword::COLUMN); // [ COLUMN ]
+                let has_column_keyword = self.parse_keyword(Keyword::COLUMN); // [ COLUMN ]
                 let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
                 let column_name = self.parse_identifier()?;
                 let drop_behavior = self.parse_optional_drop_behavior();
                 AlterTableOperation::DropColumn {
+                    has_column_keyword,
                     column_name,
                     if_exists,
                     drop_behavior,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4926,17 +4926,18 @@ fn parse_alter_table_drop_column() {
     check_one("DROP COLUMN IF EXISTS is_active CASCADE");
     check_one("DROP COLUMN IF EXISTS is_active RESTRICT");
     one_statement_parses_to(
-        "ALTER TABLE tab DROP IF EXISTS is_active CASCADE",
+        "ALTER TABLE tab DROP COLUMN IF EXISTS is_active CASCADE",
         "ALTER TABLE tab DROP COLUMN IF EXISTS is_active CASCADE",
     );
     one_statement_parses_to(
         "ALTER TABLE tab DROP is_active CASCADE",
-        "ALTER TABLE tab DROP COLUMN is_active CASCADE",
+        "ALTER TABLE tab DROP is_active CASCADE",
     );
 
     fn check_one(constraint_text: &str) {
         match alter_table_op(verified_stmt(&format!("ALTER TABLE tab {constraint_text}"))) {
             AlterTableOperation::DropColumn {
+                has_column_keyword: true,
                 column_name,
                 if_exists,
                 drop_behavior,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -2801,6 +2801,7 @@ fn parse_alter_table_with_algorithm() {
                 operations,
                 vec![
                     AlterTableOperation::DropColumn {
+                        has_column_keyword: true,
                         column_name: Ident::new("password_digest"),
                         if_exists: false,
                         drop_behavior: None,
@@ -2848,6 +2849,7 @@ fn parse_alter_table_with_lock() {
                 operations,
                 vec![
                     AlterTableOperation::DropColumn {
+                        has_column_keyword: true,
                         column_name: Ident::new("password_digest"),
                         if_exists: false,
                         drop_behavior: None,


### PR DESCRIPTION
This closes #1859.