### PR TITLE
Support `DISTINCT AS { STRUCT | VALUE }` for BigQuery

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -3338,11 +3338,8 @@ impl fmt::Display for OpenJsonTableColumn {
 }
 
 /// BigQuery supports ValueTables which have 2 modes:
-/// `SELECT AS STRUCT`
-/// `SELECT AS VALUE`
-///
-/// They can be combined with `[ { ALL | DISTINCT } ]`, e.g.
-/// `SELECT DISTINCT AS STRUCT`
+/// `SELECT [ALL | DISTINCT] AS STRUCT`
+/// `SELECT [ALL | DISTINCT] AS VALUE`
 ///
 /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#value_tables>
 /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_list>


### PR DESCRIPTION
According to the query syntax at
https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_list you can combine `[ { ALL | DISTINCT } ]` with `[ AS { STRUCT | VALUE } ]`:

```sh
SELECT
  [ WITH differential_privacy_clause ]
  [ { ALL | DISTINCT } ]
  [ AS { STRUCT | VALUE } ]
  select_list
```

This adds support to parse `DISTINCT` or `ALL` as the first keyword after `SELECT` and adds two new variants to the `ValueTableMode` if defined.