### PR TITLE
MySQL: Support comma-separated `CREATE TABLE` options

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -590,7 +590,7 @@ pub trait Dialect: Debug + Any {
         false
     }
 
-    /// Returne true if the dialect supports specifying multiple options
+    /// Return true if the dialect supports specifying multiple options
     /// in a `CREATE TABLE` statement for the structure of the new table. For example:
     /// `CREATE TABLE t (a INT, b INT) AS SELECT 1 AS b, 2 AS a`
     fn supports_create_table_multi_schema_info_sources(&self) -> bool {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7708,6 +7708,9 @@ impl<'a> Parser<'a> {
 
         while let Some(option) = self.parse_plain_option()? {
             options.push(option);
+            // Some dialects support comma-separated options; it shouldn't introduce ambiguity to
+            // consume it for all dialects.
+            let _ = self.consume_token(&Token::Comma);
         }
 
         Ok(options)

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1362,6 +1362,13 @@ fn parse_create_table_gencol() {
 }
 
 #[test]
+fn parse_create_table_options_comma_separated() {
+    let sql = "CREATE TABLE t (x INT) DEFAULT CHARSET = utf8mb4, ENGINE = InnoDB , AUTO_INCREMENT 1 DATA DIRECTORY '/var/lib/mysql/data'";
+    let canonical = "CREATE TABLE t (x INT) DEFAULT CHARSET = utf8mb4 ENGINE = InnoDB AUTO_INCREMENT = 1 DATA DIRECTORY = '/var/lib/mysql/data'";
+    mysql_and_generic().one_statement_parses_to(sql, canonical);
+}
+
+#[test]
 fn parse_quote_identifiers() {
     let sql = "CREATE TABLE `PRIMARY` (`BEGIN` INT PRIMARY KEY)";
     match mysql().verified_stmt(sql) {


### PR DESCRIPTION
In [MySQL], options for `CREATE TABLE` following the body can be optionally separated by commas. I'm not aware of any cases where this affects parsing (e.g. eliminating ambiguity or anything), so we just optionally eat comma tokens after each option is parsed.

[MySQL]: https://dev.mysql.com/doc/refman/8.4/en/create-table.html