### PR TITLE
feat: add some DELTA keywords

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -491,6 +491,7 @@ define_keywords!(
     INTERSECTION,
     INTERVAL,
     INTO,
+    INVENTORY,
     INVOKER,
     IO,
     IS,


### PR DESCRIPTION
The LITE and INVENTORY keywords are used in the delta [VACUUM](https://docs.databricks.com/aws/en/sql/language-manual/delta-vacuum) command, would be great if we could add it.

The SHALLOW keyword is used in shallow clones of delta tables.