### PR TITLE
Add support for C-style comments

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -176,6 +176,10 @@ impl Dialect for GenericDialect {
         true
     }
 
+    fn supports_multiline_comment_hints(&self) -> bool {
+        true
+    }
+
     fn supports_user_host_grantee(&self) -> bool {
         true
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1086,6 +1086,12 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports optimizer hints in multiline comments
+    /// e.g. `/*!50110 KEY_BLOCK_SIZE = 1024*/`
+    fn supports_multiline_comment_hints(&self) -> bool {
+        false
+    }
+
     /// Returns true if this dialect supports treating the equals operator `=` within a `SelectItem`
     /// as an alias assignment operator, rather than a boolean expression.
     /// For example: the following statements are equivalent for such a dialect:

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -88,6 +88,11 @@ impl Dialect for MySqlDialect {
         true
     }
 
+    /// see <https://dev.mysql.com/doc/refman/8.4/en/comments.html>
+    fn supports_multiline_comment_hints(&self) -> bool {
+        true
+    }
+
     fn parse_infix(
         &self,
         parser: &mut crate::parser::Parser,


### PR DESCRIPTION
This commit adds support for C-style comments supported by MySQL. It parses and consumes the optional version number after the `!` character.