### PR TITLE
Support `CREATE SEQUENCE` options in any order

### DIFF
--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -309,6 +309,15 @@ fn parse_create_sequence() {
         pg().parse_sql_statements("CREATE SEQUENCE foo INCREMENT 1 NO MINVALUE NO"),
         Err(ParserError::ParserError(_))
     ));
+
+    let sql9 = "CREATE SEQUENCE name6
+    AS INTEGER
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1";
+    pg().one_statement_parses_to(sql9, "CREATE SEQUENCE name6 AS INTEGER START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1");
 }
 
 #[test]


### PR DESCRIPTION
This changes the parsing of the `CREATE SEQUENCE` options to allow the individual options to appear in any order.

The reason I'm opening this pull request is that the Postgres `pg_dump` utility dumps `CREATE SEQUENCE` statements like this:

```sql
CREATE SEQUENCE name6
AS INTEGER
START WITH 1
INCREMENT BY 1
NO MINVALUE
NO MAXVALUE
CACHE 1
```

Where the `START WITH 1` appears before the `INCREMENT BY 1`, Postgres allows this but the parser did not.

There should not be any noticable performance impact I think. I did run the benchmarks and did not see any impact.