### PR TITLE
Added TIMESTAMP_NTZ type support with precision to Snowflake dialect

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -375,7 +375,7 @@ pub enum DataType {
     /// Databricks timestamp without time zone. See [1].
     ///
     /// [1]: https://docs.databricks.com/aws/en/sql/language-manual/data-types/timestamp-ntz-type
-    TimestampNtz,
+    TimestampNtz(Option<u64>),
     /// Interval type.
     Interval {
         /// [PostgreSQL] fields specification like `INTERVAL YEAR TO MONTH`.
@@ -676,7 +676,9 @@ impl fmt::Display for DataType {
             DataType::Timestamp(precision, timezone_info) => {
                 format_datetime_precision_and_tz(f, "TIMESTAMP", precision, timezone_info)
             }
-            DataType::TimestampNtz => write!(f, "TIMESTAMP_NTZ"),
+            DataType::TimestampNtz(precision) => {
+                format_type_with_optional_length(f, "TIMESTAMP_NTZ", precision, false)
+            }
             DataType::Datetime64(precision, timezone) => {
                 format_clickhouse_datetime_precision_and_timezone(
                     f,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10542,7 +10542,9 @@ impl<'a> Parser<'a> {
                     self.parse_optional_precision()?,
                     TimezoneInfo::Tz,
                 )),
-                Keyword::TIMESTAMP_NTZ => Ok(DataType::TimestampNtz),
+                Keyword::TIMESTAMP_NTZ => {
+                    Ok(DataType::TimestampNtz(self.parse_optional_precision()?))
+                }
                 Keyword::TIME => {
                     let precision = self.parse_optional_precision()?;
                     let tz = if self.parse_keyword(Keyword::WITH) {

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -328,7 +328,7 @@ fn data_type_timestamp_ntz() {
     assert_eq!(
         databricks().verified_expr("TIMESTAMP_NTZ '2025-03-29T18:52:00'"),
         Expr::TypedString(TypedString {
-            data_type: DataType::TimestampNtz,
+            data_type: DataType::TimestampNtz(None),
             value: ValueWithSpan {
                 value: Value::SingleQuotedString("2025-03-29T18:52:00".to_owned()),
                 span: Span::empty(),
@@ -345,7 +345,7 @@ fn data_type_timestamp_ntz() {
             expr: Box::new(Expr::Nested(Box::new(Expr::Identifier(
                 "created_at".into()
             )))),
-            data_type: DataType::TimestampNtz,
+            data_type: DataType::TimestampNtz(None),
             format: None
         }
     );
@@ -357,7 +357,7 @@ fn data_type_timestamp_ntz() {
                 columns,
                 vec![ColumnDef {
                     name: "x".into(),
-                    data_type: DataType::TimestampNtz,
+                    data_type: DataType::TimestampNtz(None),
                     options: vec![],
                 }]
             );

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -4639,6 +4639,21 @@ fn test_create_database() {
 }
 
 #[test]
+fn test_timestamp_ntz_with_precision() {
+    snowflake().verified_stmt("SELECT CAST('2024-01-01 01:00:00' AS TIMESTAMP_NTZ(1))");
+    snowflake().verified_stmt("SELECT CAST('2024-01-01 01:00:00' AS TIMESTAMP_NTZ(9))");
+
+    let select =
+        snowflake().verified_only_select("SELECT CAST('2024-01-01 01:00:00' AS TIMESTAMP_NTZ(9))");
+    match expr_from_projection(only(&select.projection)) {
+        Expr::Cast { data_type, .. } => {
+            assert_eq!(*data_type, DataType::TimestampNtz(Some(9)));
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn test_drop_constraints() {
     snowflake().verified_stmt("ALTER TABLE tbl DROP PRIMARY KEY");
     snowflake().verified_stmt("ALTER TABLE tbl DROP FOREIGN KEY k1");


### PR DESCRIPTION
Adding support for optional precision for `TIMESTAMP_NTZ` type in snowflake. Example: `TIMESTAMP_NTZ(9)`
It's supported in spec: https://docs.snowflake.com/en/sql-reference/data-types-datetime
Specifically
```
All timestamp variations, as well as the TIMESTAMP alias, support an optional precision parameter for
fractional seconds (for example, TIMESTAMP(3)). Timestamp precision can range from 0 (seconds) 
to 9 (nanoseconds). The default precision is 9.
```
Example of sql:
```sql
SELECT CAST(TO_CHAR(CURRENT_DATE, 'YYYY-MM-DD')||' 01:00:00' AS TIMESTAMP_NTZ(9))
```