### PR TITLE
Attach a span to most common errors describing the problematic token

### DIFF
--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -2516,7 +2516,7 @@ pub mod tests {
                         span,
                     })) => {
                         assert_eq!(":fooBar", s);
-                        assert_eq!(&Span::new((3, 3).into(), (3, 10).into()), span);
+                        assert_eq!(&Span::new((3, 3), (3, 10)), span);
                     }
                     _ => panic!("expected unnamed expression; got {col:?}"),
                 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -574,8 +574,11 @@ impl Span {
     const EMPTY: Span = Self::empty();
 
     /// Create a new span from a start and end [`Location`]
-    pub fn new(start: Location, end: Location) -> Span {
-        Span { start, end }
+    pub fn new(start: impl Into<Location>, end: impl Into<Location>) -> Span {
+        Span {
+            start: start.into(),
+            end: end.into(),
+        }
     }
 
     /// Returns an empty span `(0, 0) -> (0, 0)`

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -295,13 +295,13 @@ fn parse_begin() {
         bigquery()
             .parse_sql_statements("BEGIN SELECT 1; SELECT 2 END")
             .unwrap_err(),
-        ParserError::ParserError("Expected: ;, found: END".to_string())
+        ParserError::SpannedParserError("Expected: ;, found: END".to_string(), Span::empty())
     );
     assert_eq!(
         bigquery()
             .parse_sql_statements("BEGIN SELECT 1; EXCEPTION WHEN ERROR THEN SELECT 2 END")
             .unwrap_err(),
-        ParserError::ParserError("Expected: ;, found: END".to_string())
+        ParserError::SpannedParserError("Expected: ;, found: END".to_string(), Span::empty())
     );
 }
 
@@ -2011,7 +2011,7 @@ fn parse_merge_invalid_statements() {
     ] {
         let res = dialects.parse_sql_statements(sql);
         assert_eq!(
-            ParserError::ParserError(err_msg.to_string()),
+            ParserError::SpannedParserError(err_msg.to_string(), Span::empty()),
             res.unwrap_err()
         );
     }
@@ -2135,13 +2135,19 @@ fn parse_big_query_declare() {
 
     let error_sql = "DECLARE x";
     assert_eq!(
-        ParserError::ParserError("Expected: a data type name, found: EOF".to_owned()),
+        ParserError::SpannedParserError(
+            "Expected: a data type name, found: EOF".to_owned(),
+            Span::empty()
+        ),
         bigquery().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE x 42";
     assert_eq!(
-        ParserError::ParserError("Expected: a data type name, found: 42".to_owned()),
+        ParserError::SpannedParserError(
+            "Expected: a data type name, found: 42".to_owned(),
+            Span::empty()
+        ),
         bigquery().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -2345,7 +2351,7 @@ fn test_bigquery_create_function() {
     ];
     for (sql, error) in error_sqls {
         assert_eq!(
-            ParserError::ParserError(error.to_owned()),
+            ParserError::SpannedParserError(error.to_owned(), Span::empty()),
             bigquery().parse_sql_statements(sql).unwrap_err()
         );
     }
@@ -2375,7 +2381,7 @@ fn test_bigquery_trim() {
     // missing comma separation
     let error_sql = "SELECT TRIM('xyz' 'a')";
     assert_eq!(
-        ParserError::ParserError("Expected: ), found: 'a'".to_owned()),
+        ParserError::SpannedParserError("Expected: ), found: 'a'".to_owned(), Span::empty()),
         bigquery().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -2538,7 +2544,7 @@ fn test_struct_trailing_and_nested_bracket() {
 
     // Bad case with missing closing bracket
     assert_eq!(
-        ParserError::ParserError("Expected: >, found: )".to_owned()),
+        ParserError::SpannedParserError("Expected: >, found: )".to_owned(), Span::empty()),
         bigquery()
             .parse_sql_statements("CREATE TABLE my_table(f1 STRUCT<a STRING, b INT64)")
             .unwrap_err()
@@ -2546,8 +2552,9 @@ fn test_struct_trailing_and_nested_bracket() {
 
     // Bad case with redundant closing bracket
     assert_eq!(
-        ParserError::ParserError(
-            "unmatched > after parsing data type STRUCT<a STRING, b INT64>)".to_owned()
+        ParserError::SpannedParserError(
+            "unmatched > after parsing data type STRUCT<a STRING, b INT64>".to_owned(),
+            Span::empty()
         ),
         bigquery()
             .parse_sql_statements("CREATE TABLE my_table(f1 STRUCT<a STRING, b INT64>>)")
@@ -2556,8 +2563,9 @@ fn test_struct_trailing_and_nested_bracket() {
 
     // Base case with redundant closing bracket in nested struct
     assert_eq!(
-        ParserError::ParserError(
-            "Expected: ',' or ')' after column definition, found: >".to_owned()
+        ParserError::SpannedParserError(
+            "Expected: ',' or ')' after column definition, found: >".to_owned(),
+            Span::empty()
         ),
         bigquery()
             .parse_sql_statements("CREATE TABLE my_table(f1 STRUCT<a STRUCT<b INT>>>, c INT64)")
@@ -2569,7 +2577,7 @@ fn test_struct_trailing_and_nested_bracket() {
         bigquery_and_generic()
             .parse_sql_statements(sql)
             .unwrap_err(),
-        ParserError::ParserError("unmatched > in STRUCT literal".to_string())
+        ParserError::SpannedParserError("unmatched > in STRUCT literal".to_string(), Span::empty())
     );
 
     let sql = "SELECT STRUCT<STRUCT<INT64>>>(NULL)";
@@ -2577,7 +2585,7 @@ fn test_struct_trailing_and_nested_bracket() {
         bigquery_and_generic()
             .parse_sql_statements(sql)
             .unwrap_err(),
-        ParserError::ParserError("Expected: (, found: >".to_string())
+        ParserError::SpannedParserError("Expected: (, found: >".to_string(), Span::empty())
     );
 
     let sql = "CREATE TABLE table (x STRUCT<STRUCT<INT64>>>)";
@@ -2585,8 +2593,9 @@ fn test_struct_trailing_and_nested_bracket() {
         bigquery_and_generic()
             .parse_sql_statements(sql)
             .unwrap_err(),
-        ParserError::ParserError(
-            "Expected: ',' or ')' after column definition, found: >".to_string()
+        ParserError::SpannedParserError(
+            "Expected: ',' or ')' after column definition, found: >".to_string(),
+            Span::empty()
         )
     );
 }

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -32,7 +32,7 @@ use sqlparser::ast::Value::Boolean;
 use sqlparser::ast::*;
 use sqlparser::dialect::ClickHouseDialect;
 use sqlparser::dialect::GenericDialect;
-use sqlparser::parser::ParserError::ParserError;
+use sqlparser::parser::ParserError;
 
 #[test]
 fn parse_map_access_expr() {
@@ -289,13 +289,19 @@ fn parse_alter_table_attach_and_detach_partition() {
             clickhouse_and_generic()
                 .parse_sql_statements(format!("ALTER TABLE t0 {operation} PARTITION").as_str())
                 .unwrap_err(),
-            ParserError("Expected: an expression, found: EOF".to_string())
+            ParserError::SpannedParserError(
+                "Expected: an expression, found: EOF".to_string(),
+                Span::empty()
+            )
         );
         assert_eq!(
             clickhouse_and_generic()
                 .parse_sql_statements(format!("ALTER TABLE t0 {operation} PART").as_str())
                 .unwrap_err(),
-            ParserError("Expected: an expression, found: EOF".to_string())
+            ParserError::SpannedParserError(
+                "Expected: an expression, found: EOF".to_string(),
+                Span::empty()
+            )
         );
     }
 }
@@ -358,19 +364,22 @@ fn parse_alter_table_add_projection() {
         clickhouse_and_generic()
             .parse_sql_statements("ALTER TABLE t0 ADD PROJECTION my_name")
             .unwrap_err(),
-        ParserError("Expected: (, found: EOF".to_string())
+        ParserError::SpannedParserError("Expected: (, found: EOF".to_string(), Span::empty())
     );
     assert_eq!(
         clickhouse_and_generic()
             .parse_sql_statements("ALTER TABLE t0 ADD PROJECTION my_name ()")
             .unwrap_err(),
-        ParserError("Expected: SELECT, found: )".to_string())
+        ParserError::SpannedParserError("Expected: SELECT, found: )".to_string(), Span::empty())
     );
     assert_eq!(
         clickhouse_and_generic()
             .parse_sql_statements("ALTER TABLE t0 ADD PROJECTION my_name (SELECT)")
             .unwrap_err(),
-        ParserError("Expected: an expression, found: )".to_string())
+        ParserError::SpannedParserError(
+            "Expected: an expression, found: )".to_string(),
+            Span::empty()
+        )
     );
 }
 
@@ -400,7 +409,10 @@ fn parse_alter_table_drop_projection() {
         clickhouse_and_generic()
             .parse_sql_statements("ALTER TABLE t0 DROP PROJECTION")
             .unwrap_err(),
-        ParserError("Expected: identifier, found: EOF".to_string())
+        ParserError::SpannedParserError(
+            "Expected: identifier, found: EOF".to_string(),
+            Span::empty()
+        )
     );
 }
 
@@ -447,7 +459,10 @@ fn parse_alter_table_clear_and_materialize_projection() {
             clickhouse_and_generic()
                 .parse_sql_statements(format!("ALTER TABLE t0 {keyword} PROJECTION",).as_str())
                 .unwrap_err(),
-            ParserError("Expected: identifier, found: EOF".to_string())
+            ParserError::SpannedParserError(
+                "Expected: identifier, found: EOF".to_string(),
+                Span::empty()
+            )
         );
 
         assert_eq!(
@@ -456,7 +471,10 @@ fn parse_alter_table_clear_and_materialize_projection() {
                     format!("ALTER TABLE t0 {keyword} PROJECTION my_name IN PARTITION",).as_str()
                 )
                 .unwrap_err(),
-            ParserError("Expected: identifier, found: EOF".to_string())
+            ParserError::SpannedParserError(
+                "Expected: identifier, found: EOF".to_string(),
+                Span::empty()
+            )
         );
 
         assert_eq!(
@@ -465,7 +483,10 @@ fn parse_alter_table_clear_and_materialize_projection() {
                     format!("ALTER TABLE t0 {keyword} PROJECTION my_name IN",).as_str()
                 )
                 .unwrap_err(),
-            ParserError("Expected: end of statement, found: IN".to_string())
+            ParserError::SpannedParserError(
+                "Expected: end of statement, found: IN".to_string(),
+                Span::empty()
+            )
         );
     }
 }
@@ -513,19 +534,28 @@ fn parse_optimize_table() {
         clickhouse_and_generic()
             .parse_sql_statements("OPTIMIZE TABLE t0 DEDUPLICATE BY")
             .unwrap_err(),
-        ParserError("Expected: an expression, found: EOF".to_string())
+        ParserError::SpannedParserError(
+            "Expected: an expression, found: EOF".to_string(),
+            Span::empty()
+        )
     );
     assert_eq!(
         clickhouse_and_generic()
             .parse_sql_statements("OPTIMIZE TABLE t0 PARTITION")
             .unwrap_err(),
-        ParserError("Expected: an expression, found: EOF".to_string())
+        ParserError::SpannedParserError(
+            "Expected: an expression, found: EOF".to_string(),
+            Span::empty()
+        )
     );
     assert_eq!(
         clickhouse_and_generic()
             .parse_sql_statements("OPTIMIZE TABLE t0 PARTITION ID")
             .unwrap_err(),
-        ParserError("Expected: identifier, found: EOF".to_string())
+        ParserError::SpannedParserError(
+            "Expected: identifier, found: EOF".to_string(),
+            Span::empty()
+        )
     );
 }
 
@@ -1063,7 +1093,7 @@ fn parse_settings_in_query() {
             clickhouse_and_generic()
                 .parse_sql_statements(sql)
                 .unwrap_err(),
-            ParserError(error_msg.to_string())
+            ParserError::SpannedParserError(error_msg.to_string(), Span::empty())
         );
     }
 }
@@ -1568,7 +1598,10 @@ fn parse_freeze_and_unfreeze_partition() {
             clickhouse_and_generic()
                 .parse_sql_statements(format!("ALTER TABLE t0 {operation_name} PARTITION").as_str())
                 .unwrap_err(),
-            ParserError("Expected: an expression, found: EOF".to_string())
+            ParserError::SpannedParserError(
+                "Expected: an expression, found: EOF".to_string(),
+                Span::empty()
+            )
         );
         assert_eq!(
             clickhouse_and_generic()
@@ -1576,7 +1609,10 @@ fn parse_freeze_and_unfreeze_partition() {
                     format!("ALTER TABLE t0 {operation_name} PARTITION p0 WITH").as_str()
                 )
                 .unwrap_err(),
-            ParserError("Expected: NAME, found: EOF".to_string())
+            ParserError::SpannedParserError(
+                "Expected: NAME, found: EOF".to_string(),
+                Span::empty()
+            )
         );
         assert_eq!(
             clickhouse_and_generic()
@@ -1584,7 +1620,10 @@ fn parse_freeze_and_unfreeze_partition() {
                     format!("ALTER TABLE t0 {operation_name} PARTITION p0 WITH NAME").as_str()
                 )
                 .unwrap_err(),
-            ParserError("Expected: identifier, found: EOF".to_string())
+            ParserError::SpannedParserError(
+                "Expected: identifier, found: EOF".to_string(),
+                Span::empty()
+            )
         );
     }
 }

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -82,7 +82,7 @@ fn test_databricks_exists() {
     let res = databricks().parse_sql_statements("SELECT EXISTS (");
     assert_eq!(
         // TODO: improve this error message...
-        ParserError::ParserError("Expected: an expression, found: EOF".to_string()),
+        ParserError::SpannedParserError("Expected: an expression, found: EOF".to_string(), Span::empty()),
         res.unwrap_err(),
     );
 }
@@ -280,7 +280,7 @@ fn parse_use() {
     for sql in &invalid_cases {
         assert_eq!(
             databricks().parse_sql_statements(sql).unwrap_err(),
-            ParserError::ParserError("Expected: identifier, found: EOF".to_string()),
+            ParserError::SpannedParserError("Expected: identifier, found: EOF".to_string(), Span::empty()),
         );
     }
 }

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -865,7 +865,7 @@ fn test_duckdb_trim() {
     // missing comma separation
     let error_sql = "SELECT TRIM('xyz' 'a')";
     assert_eq!(
-        ParserError::ParserError("Expected: ), found: 'a'".to_owned()),
+        ParserError::SpannedParserError("Expected: ), found: 'a'".to_owned(), Span::empty()),
         duckdb().parse_sql_statements(error_sql).unwrap_err()
     );
 }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -367,7 +367,7 @@ fn parse_create_function() {
         END\
     ";
     assert_eq!(
-        ParserError::ParserError("Unparsable function body".to_owned()),
+        ParserError::SpannedParserError("Unparsable function body".to_owned(), Span::empty()),
         ms().parse_sql_statements(create_multi_statement_tvf_without_table_definition)
             .unwrap_err()
     );
@@ -379,8 +379,9 @@ fn parse_create_function() {
         RETURN 'hi'\
     ";
     assert_eq!(
-        ParserError::ParserError(
-            "Expected a subquery (or bare SELECT statement) after RETURN".to_owned()
+        ParserError::SpannedParserError(
+            "Expected a subquery (or bare SELECT statement) after RETURN".to_owned(),
+            Span::empty(),
         ),
         ms().parse_sql_statements(create_inline_tvf_without_subquery_or_bare_select)
             .unwrap_err()
@@ -1334,7 +1335,7 @@ fn parse_convert() {
 
     let error_sql = "SELECT CONVERT(INT, 'foo',) FROM T";
     assert_eq!(
-        ParserError::ParserError("Expected: an expression, found: )".to_owned()),
+        ParserError::SpannedParserError("Expected: an expression, found: )".to_owned(), Span::empty()),
         ms().parse_sql_statements(error_sql).unwrap_err()
     );
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1321,7 +1321,7 @@ fn parse_create_table_both_options_and_as_query() {
         r"CREATE TABLE foo (id INT(11)) ENGINE = InnoDB AS SELECT 1 DEFAULT CHARSET = utf8mb3";
     assert!(matches!(
         mysql_and_generic().parse_sql_statements(sql),
-        Err(ParserError::ParserError(_))
+        Err(ParserError::SpannedParserError(_, _))
     ));
 }
 
@@ -2125,7 +2125,7 @@ fn parse_insert_as() {
     let sql = r"INSERT INTO `table` (`date`) VALUES ('2024-01-01') AS `alias` ()";
     assert!(matches!(
         mysql_and_generic().parse_sql_statements(sql),
-        Err(ParserError::ParserError(_))
+        Err(ParserError::SpannedParserError(_, _))
     ));
 
     let sql = r"INSERT INTO `table` (`id`, `date`) VALUES (1, '2024-01-01') AS `alias` (`mek_id`, `mek_date`)";

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -307,7 +307,7 @@ fn parse_create_sequence() {
 
     assert!(matches!(
         pg().parse_sql_statements("CREATE SEQUENCE foo INCREMENT 1 NO MINVALUE NO"),
-        Err(ParserError::ParserError(_))
+        Err(ParserError::SpannedParserError(_, _))
     ));
 }
 
@@ -806,7 +806,7 @@ fn parse_alter_table_alter_column_add_generated() {
         "ALTER TABLE t ALTER COLUMN id ADD GENERATED ( INCREMENT 1 MINVALUE 1 )",
     );
     assert_eq!(
-        ParserError::ParserError("Expected: AS, found: (".to_string()),
+        ParserError::SpannedParserError("Expected: AS, found: (".to_string(), Span::empty()),
         res.unwrap_err()
     );
 
@@ -814,14 +814,14 @@ fn parse_alter_table_alter_column_add_generated() {
         "ALTER TABLE t ALTER COLUMN id ADD GENERATED AS IDENTITY ( INCREMENT )",
     );
     assert_eq!(
-        ParserError::ParserError("Expected: a value, found: )".to_string()),
+        ParserError::SpannedParserError("Expected: a value, found: )".to_string(), Span::empty()),
         res.unwrap_err()
     );
 
     let res =
         pg().parse_sql_statements("ALTER TABLE t ALTER COLUMN id ADD GENERATED AS IDENTITY (");
     assert_eq!(
-        ParserError::ParserError("Expected: ), found: EOF".to_string()),
+        ParserError::SpannedParserError("Expected: ), found: EOF".to_string(), Span::empty()),
         res.unwrap_err()
     );
 }
@@ -930,7 +930,10 @@ fn parse_alter_table_owner_to() {
 
     let res = pg().parse_sql_statements("ALTER TABLE tab OWNER TO CREATE FOO");
     assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: FOO".to_string()),
+        ParserError::SpannedParserError(
+            "Expected: end of statement, found: FOO".to_string(),
+            Span::empty()
+        ),
         res.unwrap_err()
     );
 
@@ -961,25 +964,37 @@ fn parse_create_table_if_not_exists() {
 fn parse_bad_if_not_exists() {
     let res = pg().parse_sql_statements("CREATE TABLE NOT EXISTS uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: EXISTS".to_string()),
+        ParserError::SpannedParserError(
+            "Expected: end of statement, found: EXISTS".to_string(),
+            Span::empty()
+        ),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF EXISTS uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: EXISTS".to_string()),
+        ParserError::SpannedParserError(
+            "Expected: end of statement, found: EXISTS".to_string(),
+            Span::empty()
+        ),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: uk_cities".to_string()),
+        ParserError::SpannedParserError(
+            "Expected: end of statement, found: uk_cities".to_string(),
+            Span::empty()
+        ),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF NOT uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: NOT".to_string()),
+        ParserError::SpannedParserError(
+            "Expected: end of statement, found: NOT".to_string(),
+            Span::empty()
+        ),
         res.unwrap_err()
     );
 }
@@ -1534,22 +1549,25 @@ fn parse_set() {
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET"),
-        Err(ParserError::ParserError(
-            "Expected: identifier, found: EOF".to_string()
+        Err(ParserError::SpannedParserError(
+            "Expected: identifier, found: EOF".to_string(),
+            Span::empty(),
         )),
     );
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET a b"),
-        Err(ParserError::ParserError(
-            "Expected: equals sign or TO, found: b".to_string()
+        Err(ParserError::SpannedParserError(
+            "Expected: equals sign or TO, found: b".to_string(),
+            Span::empty(),
         )),
     );
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET a ="),
-        Err(ParserError::ParserError(
-            "Expected: variable value, found: EOF".to_string()
+        Err(ParserError::SpannedParserError(
+            "Expected: variable value, found: EOF".to_string(),
+            Span::empty(),
         )),
     );
 }
@@ -2830,7 +2848,7 @@ fn parse_create_table_with_inherits() {
 fn parse_create_table_with_empty_inherits_fails() {
     assert!(matches!(
         pg().parse_sql_statements("CREATE TABLE child_table (child_column INT) INHERITS ()"),
-        Err(ParserError::ParserError(_))
+        Err(ParserError::SpannedParserError(_, _))
     ));
 }
 
@@ -4731,13 +4749,19 @@ fn parse_drop_procedure() {
 
     let res = pg().parse_sql_statements("DROP PROCEDURE testproc DROP");
     assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: DROP".to_string()),
+        ParserError::SpannedParserError(
+            "Expected: end of statement, found: DROP".to_string(),
+            Span::empty()
+        ),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("DROP PROCEDURE testproc SET NULL");
     assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: SET".to_string()),
+        ParserError::SpannedParserError(
+            "Expected: end of statement, found: SET".to_string(),
+            Span::empty()
+        ),
         res.unwrap_err()
     );
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -423,15 +423,17 @@ fn test_snowflake_create_global_table() {
 fn test_snowflake_create_invalid_local_global_table() {
     assert_eq!(
         snowflake().parse_sql_statements("CREATE LOCAL GLOBAL TABLE my_table (a INT)"),
-        Err(ParserError::ParserError(
-            "Expected: an SQL statement, found: LOCAL".to_string()
+        Err(ParserError::SpannedParserError(
+            "Expected: an SQL statement, found: LOCAL".to_string(),
+            Span::empty(),
         ))
     );
 
     assert_eq!(
         snowflake().parse_sql_statements("CREATE GLOBAL LOCAL TABLE my_table (a INT)"),
-        Err(ParserError::ParserError(
-            "Expected: an SQL statement, found: GLOBAL".to_string()
+        Err(ParserError::SpannedParserError(
+            "Expected: an SQL statement, found: GLOBAL".to_string(),
+            Span::empty(),
         ))
     );
 }
@@ -440,22 +442,25 @@ fn test_snowflake_create_invalid_local_global_table() {
 fn test_snowflake_create_invalid_temporal_table() {
     assert_eq!(
         snowflake().parse_sql_statements("CREATE TEMP TEMPORARY TABLE my_table (a INT)"),
-        Err(ParserError::ParserError(
-            "Expected: an object type after CREATE, found: TEMPORARY".to_string()
+        Err(ParserError::SpannedParserError(
+            "Expected: an object type after CREATE, found: TEMPORARY".to_string(),
+            Span::empty(),
         ))
     );
 
     assert_eq!(
         snowflake().parse_sql_statements("CREATE TEMP VOLATILE TABLE my_table (a INT)"),
-        Err(ParserError::ParserError(
-            "Expected: an object type after CREATE, found: VOLATILE".to_string()
+        Err(ParserError::SpannedParserError(
+            "Expected: an object type after CREATE, found: VOLATILE".to_string(),
+            Span::empty(),
         ))
     );
 
     assert_eq!(
         snowflake().parse_sql_statements("CREATE TEMP TRANSIENT TABLE my_table (a INT)"),
-        Err(ParserError::ParserError(
-            "Expected: an object type after CREATE, found: TRANSIENT".to_string()
+        Err(ParserError::SpannedParserError(
+            "Expected: an object type after CREATE, found: TRANSIENT".to_string(),
+            Span::empty(),
         ))
     );
 }
@@ -1845,13 +1850,13 @@ fn parse_snowflake_declare_cursor() {
 
     let error_sql = "DECLARE c1 CURSOR SELECT id FROM invoices";
     assert_eq!(
-        ParserError::ParserError("Expected: FOR, found: SELECT".to_owned()),
+        ParserError::SpannedParserError("Expected: FOR, found: SELECT".to_owned(), Span::empty()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE c1 CURSOR res";
     assert_eq!(
-        ParserError::ParserError("Expected: FOR, found: res".to_owned()),
+        ParserError::SpannedParserError("Expected: FOR, found: res".to_owned(), Span::empty()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -1899,13 +1904,19 @@ fn parse_snowflake_declare_result_set() {
 
     let error_sql = "DECLARE res RESULTSET DEFAULT";
     assert_eq!(
-        ParserError::ParserError("Expected: an expression, found: EOF".to_owned()),
+        ParserError::SpannedParserError(
+            "Expected: an expression, found: EOF".to_owned(),
+            Span::empty()
+        ),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE res RESULTSET :=";
     assert_eq!(
-        ParserError::ParserError("Expected: an expression, found: EOF".to_owned()),
+        ParserError::SpannedParserError(
+            "Expected: an expression, found: EOF".to_owned(),
+            Span::empty()
+        ),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -1991,19 +2002,28 @@ fn parse_snowflake_declare_variable() {
 
     let error_sql = "DECLARE profit INT 2";
     assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: 2".to_owned()),
+        ParserError::SpannedParserError(
+            "Expected: end of statement, found: 2".to_owned(),
+            Span::empty()
+        ),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE profit INT DEFAULT";
     assert_eq!(
-        ParserError::ParserError("Expected: an expression, found: EOF".to_owned()),
+        ParserError::SpannedParserError(
+            "Expected: an expression, found: EOF".to_owned(),
+            Span::empty()
+        ),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 
     let error_sql = "DECLARE profit DEFAULT";
     assert_eq!(
-        ParserError::ParserError("Expected: an expression, found: EOF".to_owned()),
+        ParserError::SpannedParserError(
+            "Expected: an expression, found: EOF".to_owned(),
+            Span::empty()
+        ),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -2038,7 +2058,10 @@ fn parse_snowflake_declare_multi_statements() {
 
     let error_sql = "DECLARE profit DEFAULT 42 c1 CURSOR FOR res;";
     assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: c1".to_owned()),
+        ParserError::SpannedParserError(
+            "Expected: end of statement, found: c1".to_owned(),
+            Span::empty()
+        ),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -2763,7 +2786,7 @@ fn test_snowflake_trim() {
     // missing comma separation
     let error_sql = "SELECT TRIM('xyz' 'a')";
     assert_eq!(
-        ParserError::ParserError("Expected: ), found: 'a'".to_owned()),
+        ParserError::SpannedParserError("Expected: ), found: 'a'".to_owned(), Span::empty()),
         snowflake().parse_sql_statements(error_sql).unwrap_err()
     );
 }
@@ -3247,7 +3270,10 @@ fn parse_use() {
     for sql in &invalid_cases {
         assert_eq!(
             snowflake().parse_sql_statements(sql).unwrap_err(),
-            ParserError::ParserError("Expected: identifier, found: EOF".to_string()),
+            ParserError::SpannedParserError(
+                "Expected: identifier, found: EOF".to_string(),
+                Span::empty()
+            ),
         );
     }
 

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -30,7 +30,7 @@ use sqlparser::ast::Value::Placeholder;
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, SQLiteDialect};
 use sqlparser::parser::{ParserError, ParserOptions};
-use sqlparser::tokenizer::Token;
+use sqlparser::tokenizer::{Span, Token};
 
 #[test]
 fn pragma_no_value() {
@@ -356,9 +356,10 @@ fn test_parse_create_table_on_conflict_col_err() {
         .unwrap_err();
     assert_eq!(
         err,
-        ParserError::ParserError(
+        ParserError::SpannedParserError(
             "Expected: one of ROLLBACK or ABORT or FAIL or IGNORE or REPLACE, found: BOH"
-                .to_string()
+                .to_string(),
+            Span::empty()
         )
     );
 }


### PR DESCRIPTION
This PR adds a new type of parser error, `SpannedParserError`, which includes the span of the token which raised the error.
In terms of simply displaying the error via `to_string` or `Display`, nothing has changed, but if the error is handled by a more complicated system it can get the actual span of the error- to for example underline the relevant part of the statement in red or otherwise highlight it.

This new type of error has been implemented for most parser errors, specifically all errors raised via `parser_err!` plus a few extra.