### PR TITLE
Immutable parser (Tokenize borrow strings cont)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2790,7 +2790,7 @@ impl fmt::Display for Declare {
 }
 
 /// Sql options of a `CREATE TABLE` statement.
-#[derive(Debug, Default, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum CreateTableOptions {

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -2407,7 +2407,7 @@ pub mod tests {
     #[test]
     fn test_join() {
         let dialect = &GenericDialect;
-        let mut test = SpanTest::new(
+        let test = SpanTest::new(
             dialect,
             "SELECT id, name FROM users LEFT JOIN companies ON users.company_id = companies.id",
         );
@@ -2432,7 +2432,7 @@ pub mod tests {
     #[test]
     pub fn test_union() {
         let dialect = &GenericDialect;
-        let mut test = SpanTest::new(
+        let test = SpanTest::new(
             dialect,
             "SELECT a FROM postgres.public.source UNION SELECT a FROM postgres.public.source",
         );
@@ -2449,7 +2449,7 @@ pub mod tests {
     #[test]
     pub fn test_subquery() {
         let dialect = &GenericDialect;
-        let mut test = SpanTest::new(
+        let test = SpanTest::new(
             dialect,
             "SELECT a FROM (SELECT a FROM postgres.public.source) AS b",
         );
@@ -2474,7 +2474,7 @@ pub mod tests {
     #[test]
     pub fn test_cte() {
         let dialect = &GenericDialect;
-        let mut test = SpanTest::new(dialect, "WITH cte_outer AS (SELECT a FROM postgres.public.source), cte_ignored AS (SELECT a FROM cte_outer), cte_inner AS (SELECT a FROM cte_outer) SELECT a FROM cte_inner");
+        let test = SpanTest::new(dialect, "WITH cte_outer AS (SELECT a FROM postgres.public.source), cte_ignored AS (SELECT a FROM cte_outer), cte_inner AS (SELECT a FROM cte_outer) SELECT a FROM cte_inner");
 
         let query = test.0.parse_query().unwrap();
 
@@ -2486,7 +2486,7 @@ pub mod tests {
     #[test]
     pub fn test_snowflake_lateral_flatten() {
         let dialect = &SnowflakeDialect;
-        let mut test = SpanTest::new(dialect, "SELECT FLATTENED.VALUE:field::TEXT AS FIELD FROM SNOWFLAKE.SCHEMA.SOURCE AS S, LATERAL FLATTEN(INPUT => S.JSON_ARRAY) AS FLATTENED");
+        let test = SpanTest::new(dialect, "SELECT FLATTENED.VALUE:field::TEXT AS FIELD FROM SNOWFLAKE.SCHEMA.SOURCE AS S, LATERAL FLATTEN(INPUT => S.JSON_ARRAY) AS FLATTENED");
 
         let query = test.0.parse_select().unwrap();
 
@@ -2498,7 +2498,7 @@ pub mod tests {
     #[test]
     pub fn test_wildcard_from_cte() {
         let dialect = &GenericDialect;
-        let mut test = SpanTest::new(
+        let test = SpanTest::new(
             dialect,
             "WITH cte AS (SELECT a FROM postgres.public.source) SELECT cte.* FROM cte",
         );
@@ -2524,7 +2524,7 @@ pub mod tests {
     #[test]
     fn test_case_expr_span() {
         let dialect = &GenericDialect;
-        let mut test = SpanTest::new(dialect, "CASE 1 WHEN 2 THEN 3 ELSE 4 END");
+        let test = SpanTest::new(dialect, "CASE 1 WHEN 2 THEN 3 ELSE 4 END");
         let expr = test.0.parse_expr().unwrap();
         let expr_span = expr.span();
         assert_eq!(

--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -46,7 +46,7 @@ const RESERVED_FOR_COLUMN_ALIAS: &[Keyword] = &[
 pub struct BigQueryDialect;
 
 impl Dialect for BigQueryDialect {
-    fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+    fn parse_statement(&self, parser: &Parser) -> Option<Result<Statement, ParserError>> {
         if parser.parse_keyword(Keyword::BEGIN) {
             if parser.peek_keyword(Keyword::TRANSACTION)
                 || parser.peek_token_ref().token == Token::SemiColon
@@ -145,7 +145,7 @@ impl Dialect for BigQueryDialect {
         true
     }
 
-    fn is_column_alias(&self, kw: &Keyword, _parser: &mut Parser) -> bool {
+    fn is_column_alias(&self, kw: &Keyword, _parser: &Parser) -> bool {
         !RESERVED_FOR_COLUMN_ALIAS.contains(kw)
     }
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -466,7 +466,7 @@ pub trait Dialect: Debug + Any {
     }
 
     /// Dialect-specific prefix parser override
-    fn parse_prefix(&self, _parser: &mut Parser) -> Option<Result<Expr, ParserError>> {
+    fn parse_prefix(&self, _parser: &Parser) -> Option<Result<Expr, ParserError>> {
         // return None to fall back to the default behavior
         None
     }
@@ -615,7 +615,7 @@ pub trait Dialect: Debug + Any {
     /// If `None` is returned, falls back to the default behavior.
     fn parse_infix(
         &self,
-        _parser: &mut Parser,
+        _parser: &Parser,
         _expr: &Expr,
         _precedence: u8,
     ) -> Option<Result<Expr, ParserError>> {
@@ -778,7 +778,7 @@ pub trait Dialect: Debug + Any {
     /// This method is called to parse the next statement.
     ///
     /// If `None` is returned, falls back to the default behavior.
-    fn parse_statement(&self, _parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+    fn parse_statement(&self, _parser: &Parser) -> Option<Result<Statement, ParserError>> {
         // return None to fall back to the default behavior
         None
     }
@@ -790,7 +790,7 @@ pub trait Dialect: Debug + Any {
     /// If `None` is returned, falls back to the default behavior.
     fn parse_column_option(
         &self,
-        _parser: &mut Parser,
+        _parser: &Parser,
     ) -> Result<Option<Result<Option<ColumnOption>, ParserError>>, ParserError> {
         // return None to fall back to the default behavior
         Ok(None)
@@ -1021,33 +1021,33 @@ pub trait Dialect: Debug + Any {
 
     /// Returns true if the specified keyword should be parsed as a column identifier.
     /// See [keywords::RESERVED_FOR_COLUMN_ALIAS]
-    fn is_column_alias(&self, kw: &Keyword, _parser: &mut Parser) -> bool {
+    fn is_column_alias(&self, kw: &Keyword, _parser: &Parser) -> bool {
         !keywords::RESERVED_FOR_COLUMN_ALIAS.contains(kw)
     }
 
     /// Returns true if the specified keyword should be parsed as a select item alias.
     /// When explicit is true, the keyword is preceded by an `AS` word. Parser is provided
     /// to enable looking ahead if needed.
-    fn is_select_item_alias(&self, explicit: bool, kw: &Keyword, parser: &mut Parser) -> bool {
+    fn is_select_item_alias(&self, explicit: bool, kw: &Keyword, parser: &Parser) -> bool {
         explicit || self.is_column_alias(kw, parser)
     }
 
     /// Returns true if the specified keyword should be parsed as a table factor identifier.
     /// See [keywords::RESERVED_FOR_TABLE_FACTOR]
-    fn is_table_factor(&self, kw: &Keyword, _parser: &mut Parser) -> bool {
+    fn is_table_factor(&self, kw: &Keyword, _parser: &Parser) -> bool {
         !keywords::RESERVED_FOR_TABLE_FACTOR.contains(kw)
     }
 
     /// Returns true if the specified keyword should be parsed as a table factor alias.
     /// See [keywords::RESERVED_FOR_TABLE_ALIAS]
-    fn is_table_alias(&self, kw: &Keyword, _parser: &mut Parser) -> bool {
+    fn is_table_alias(&self, kw: &Keyword, _parser: &Parser) -> bool {
         !keywords::RESERVED_FOR_TABLE_ALIAS.contains(kw)
     }
 
     /// Returns true if the specified keyword should be parsed as a table factor alias.
     /// When explicit is true, the keyword is preceded by an `AS` word. Parser is provided
     /// to enable looking ahead if needed.
-    fn is_table_factor_alias(&self, explicit: bool, kw: &Keyword, parser: &mut Parser) -> bool {
+    fn is_table_factor_alias(&self, explicit: bool, kw: &Keyword, parser: &Parser) -> bool {
         explicit || self.is_table_alias(kw, parser)
     }
 
@@ -1400,14 +1400,14 @@ mod tests {
 
             fn parse_prefix(
                 &self,
-                parser: &mut sqlparser::parser::Parser,
+                parser: &sqlparser::parser::Parser,
             ) -> Option<Result<Expr, sqlparser::parser::ParserError>> {
                 self.0.parse_prefix(parser)
             }
 
             fn parse_infix(
                 &self,
-                parser: &mut sqlparser::parser::Parser,
+                parser: &sqlparser::parser::Parser,
                 expr: &Expr,
                 precedence: u8,
             ) -> Option<Result<Expr, sqlparser::parser::ParserError>> {
@@ -1423,7 +1423,7 @@ mod tests {
 
             fn parse_statement(
                 &self,
-                parser: &mut sqlparser::parser::Parser,
+                parser: &sqlparser::parser::Parser,
             ) -> Option<Result<Statement, sqlparser::parser::ParserError>> {
                 self.0.parse_statement(parser)
             }

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -128,11 +128,11 @@ impl Dialect for MsSqlDialect {
         &[GranteesType::Public]
     }
 
-    fn is_column_alias(&self, kw: &Keyword, _parser: &mut Parser) -> bool {
+    fn is_column_alias(&self, kw: &Keyword, _parser: &Parser) -> bool {
         !keywords::RESERVED_FOR_COLUMN_ALIAS.contains(kw) && !RESERVED_FOR_COLUMN_ALIAS.contains(kw)
     }
 
-    fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+    fn parse_statement(&self, parser: &Parser) -> Option<Result<Statement, ParserError>> {
         if parser.peek_keyword(Keyword::IF) {
             Some(self.parse_if_stmt(parser))
         } else if parser.parse_keywords(&[Keyword::CREATE, Keyword::TRIGGER]) {
@@ -157,7 +157,7 @@ impl MsSqlDialect {
     /// [ ELSE
     ///     { sql_statement | statement_block } ]
     /// ```
-    fn parse_if_stmt(&self, parser: &mut Parser) -> Result<Statement, ParserError> {
+    fn parse_if_stmt(&self, parser: &Parser) -> Result<Statement, ParserError> {
         let if_token = parser.expect_keyword(Keyword::IF)?;
 
         let condition = parser.parse_expr()?;
@@ -240,7 +240,7 @@ impl MsSqlDialect {
     /// [MsSql]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql
     fn parse_create_trigger(
         &self,
-        parser: &mut Parser,
+        parser: &Parser,
         or_alter: bool,
     ) -> Result<Statement, ParserError> {
         let name = parser.parse_object_name(false)?;
@@ -279,7 +279,7 @@ impl MsSqlDialect {
     /// Stops parsing when reaching EOF or the given keyword.
     fn parse_statement_list(
         &self,
-        parser: &mut Parser,
+        parser: &Parser,
         terminal_keyword: Option<Keyword>,
     ) -> Result<Vec<Statement>, ParserError> {
         let mut stmts = Vec::new();

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -86,7 +86,7 @@ impl Dialect for MySqlDialect {
 
     fn parse_infix(
         &self,
-        parser: &mut crate::parser::Parser,
+        parser: &crate::parser::Parser,
         expr: &crate::ast::Expr,
         _precedence: u8,
     ) -> Option<Result<crate::ast::Expr, ParserError>> {
@@ -102,7 +102,7 @@ impl Dialect for MySqlDialect {
         }
     }
 
-    fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+    fn parse_statement(&self, parser: &Parser) -> Option<Result<Statement, ParserError>> {
         if parser.parse_keywords(&[Keyword::LOCK, Keyword::TABLES]) {
             Some(parse_lock_tables(parser))
         } else if parser.parse_keywords(&[Keyword::UNLOCK, Keyword::TABLES]) {
@@ -134,7 +134,7 @@ impl Dialect for MySqlDialect {
         true
     }
 
-    fn is_table_factor_alias(&self, explicit: bool, kw: &Keyword, _parser: &mut Parser) -> bool {
+    fn is_table_factor_alias(&self, explicit: bool, kw: &Keyword, _parser: &Parser) -> bool {
         explicit
             || (!keywords::RESERVED_FOR_TABLE_ALIAS.contains(kw)
                 && !RESERVED_FOR_TABLE_ALIAS_MYSQL.contains(kw))
@@ -171,13 +171,13 @@ impl Dialect for MySqlDialect {
 
 /// `LOCK TABLES`
 /// <https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html>
-fn parse_lock_tables(parser: &mut Parser) -> Result<Statement, ParserError> {
+fn parse_lock_tables(parser: &Parser) -> Result<Statement, ParserError> {
     let tables = parser.parse_comma_separated(parse_lock_table)?;
     Ok(Statement::LockTables { tables })
 }
 
 // tbl_name [[AS] alias] lock_type
-fn parse_lock_table(parser: &mut Parser) -> Result<LockTable, ParserError> {
+fn parse_lock_table(parser: &Parser) -> Result<LockTable, ParserError> {
     let table = parser.parse_identifier()?;
     let alias =
         parser.parse_optional_alias(&[Keyword::READ, Keyword::WRITE, Keyword::LOW_PRIORITY])?;
@@ -191,7 +191,7 @@ fn parse_lock_table(parser: &mut Parser) -> Result<LockTable, ParserError> {
 }
 
 // READ [LOCAL] | [LOW_PRIORITY] WRITE
-fn parse_lock_tables_type(parser: &mut Parser) -> Result<LockTableType, ParserError> {
+fn parse_lock_tables_type(parser: &Parser) -> Result<LockTableType, ParserError> {
     if parser.parse_keyword(Keyword::READ) {
         if parser.parse_keyword(Keyword::LOCAL) {
             Ok(LockTableType::Read { local: true })
@@ -211,6 +211,6 @@ fn parse_lock_tables_type(parser: &mut Parser) -> Result<LockTableType, ParserEr
 
 /// UNLOCK TABLES
 /// <https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html>
-fn parse_unlock_tables(_parser: &mut Parser) -> Result<Statement, ParserError> {
+fn parse_unlock_tables(_parser: &Parser) -> Result<Statement, ParserError> {
     Ok(Statement::UnlockTables)
 }

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -65,7 +65,7 @@ impl Dialect for SQLiteDialect {
         self.is_identifier_start(ch) || ch.is_ascii_digit()
     }
 
-    fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+    fn parse_statement(&self, parser: &Parser) -> Option<Result<Statement, ParserError>> {
         if parser.parse_keyword(Keyword::REPLACE) {
             parser.prev_token();
             Some(parser.parse_insert(parser.get_current_token().clone()))
@@ -76,7 +76,7 @@ impl Dialect for SQLiteDialect {
 
     fn parse_infix(
         &self,
-        parser: &mut crate::parser::Parser,
+        parser: &crate::parser::Parser,
         expr: &crate::ast::Expr,
         _precedence: u8,
     ) -> Option<Result<crate::ast::Expr, ParserError>> {

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 impl Parser<'_> {
-    pub fn parse_alter_role(&mut self) -> Result<Statement, ParserError> {
+    pub fn parse_alter_role(&self) -> Result<Statement, ParserError> {
         if dialect_of!(self is PostgreSqlDialect) {
             return self.parse_pg_alter_role();
         } else if dialect_of!(self is MsSqlDialect) {
@@ -53,7 +53,7 @@ impl Parser<'_> {
     /// ```
     ///
     /// [PostgreSQL](https://www.postgresql.org/docs/current/sql-alterpolicy.html)
-    pub fn parse_alter_policy(&mut self) -> Result<Statement, ParserError> {
+    pub fn parse_alter_policy(&self) -> Result<Statement, ParserError> {
         let name = self.parse_identifier()?;
         self.expect_keyword_is(Keyword::ON)?;
         let table_name = self.parse_object_name(false)?;
@@ -110,7 +110,7 @@ impl Parser<'_> {
     ///
     /// ALTER CONNECTOR connector_name SET OWNER [USER|ROLE] user_or_role;
     /// ```
-    pub fn parse_alter_connector(&mut self) -> Result<Statement, ParserError> {
+    pub fn parse_alter_connector(&self) -> Result<Statement, ParserError> {
         let name = self.parse_identifier()?;
         self.expect_keyword_is(Keyword::SET)?;
 
@@ -147,7 +147,7 @@ impl Parser<'_> {
     /// ```sql
     /// ALTER USER [ IF EXISTS ] [ <name> ] [ OPTIONS ]
     /// ```
-    pub fn parse_alter_user(&mut self) -> Result<Statement, ParserError> {
+    pub fn parse_alter_user(&self) -> Result<Statement, ParserError> {
         let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
         let name = self.parse_identifier()?;
         let rename_to = if self.parse_keywords(&[Keyword::RENAME, Keyword::TO]) {
@@ -314,7 +314,7 @@ impl Parser<'_> {
         }))
     }
 
-    fn parse_mfa_method(&mut self) -> Result<MfaMethodKind, ParserError> {
+    fn parse_mfa_method(&self) -> Result<MfaMethodKind, ParserError> {
         if self.parse_keyword(Keyword::PASSKEY) {
             Ok(MfaMethodKind::PassKey)
         } else if self.parse_keyword(Keyword::TOTP) {
@@ -326,7 +326,7 @@ impl Parser<'_> {
         }
     }
 
-    fn parse_mssql_alter_role(&mut self) -> Result<Statement, ParserError> {
+    fn parse_mssql_alter_role(&self) -> Result<Statement, ParserError> {
         let role_name = self.parse_identifier()?;
 
         let operation = if self.parse_keywords(&[Keyword::ADD, Keyword::MEMBER]) {
@@ -352,7 +352,7 @@ impl Parser<'_> {
         })
     }
 
-    fn parse_pg_alter_role(&mut self) -> Result<Statement, ParserError> {
+    fn parse_pg_alter_role(&self) -> Result<Statement, ParserError> {
         let role_name = self.parse_identifier()?;
 
         // [ IN DATABASE _`database_name`_ ]
@@ -436,7 +436,7 @@ impl Parser<'_> {
         })
     }
 
-    fn parse_pg_role_option(&mut self) -> Result<RoleOption, ParserError> {
+    fn parse_pg_role_option(&self) -> Result<RoleOption, ParserError> {
         let option = match self.parse_one_of_keywords(&[
             Keyword::BYPASSRLS,
             Keyword::NOBYPASSRLS,

--- a/tests/sqlparser_custom_dialect.rs
+++ b/tests/sqlparser_custom_dialect.rs
@@ -39,7 +39,7 @@ fn custom_prefix_parser() -> Result<(), ParserError> {
             is_identifier_part(ch)
         }
 
-        fn parse_prefix(&self, parser: &mut Parser) -> Option<Result<Expr, ParserError>> {
+        fn parse_prefix(&self, parser: &Parser) -> Option<Result<Expr, ParserError>> {
             if parser.consume_token(&Token::Number("1".to_string(), false)) {
                 Some(Ok(Expr::Value(Value::Null.with_empty_span())))
             } else {
@@ -72,7 +72,7 @@ fn custom_infix_parser() -> Result<(), ParserError> {
 
         fn parse_infix(
             &self,
-            parser: &mut Parser,
+            parser: &Parser,
             expr: &Expr,
             _precedence: u8,
         ) -> Option<Result<Expr, ParserError>> {
@@ -110,7 +110,7 @@ fn custom_statement_parser() -> Result<(), ParserError> {
             is_identifier_part(ch)
         }
 
-        fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+        fn parse_statement(&self, parser: &Parser) -> Option<Result<Statement, ParserError>> {
             if parser.parse_keyword(Keyword::SELECT) {
                 for _ in 0..3 {
                     let _ = parser.next_token();

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2213,7 +2213,7 @@ fn parse_mssql_if_else() {
 #[test]
 fn test_mssql_if_else_span() {
     let sql = "IF 1 = 1 SELECT '1' ELSE SELECT '2'";
-    let mut parser = Parser::new(&MsSqlDialect {}).try_with_sql(sql).unwrap();
+    let parser = Parser::new(&MsSqlDialect {}).try_with_sql(sql).unwrap();
     assert_eq!(
         parser.parse_statement().unwrap().span(),
         Span::new(Location::new(1, 1), Location::new(1, sql.len() as u64 + 1))
@@ -2226,7 +2226,7 @@ fn test_mssql_if_else_multiline_span() {
     let sql_line2 = "SELECT '1'";
     let sql_line3 = "ELSE SELECT '2'";
     let sql = [sql_line1, sql_line2, sql_line3].join("\n");
-    let mut parser = Parser::new(&MsSqlDialect {}).try_with_sql(&sql).unwrap();
+    let parser = Parser::new(&MsSqlDialect {}).try_with_sql(&sql).unwrap();
     assert_eq!(
         parser.parse_statement().unwrap().span(),
         Span::new(


### PR DESCRIPTION
refactor: Make Parser methods immutable using interior mutability

Changed all parsing methods to take `&self` instead of `&mut self`. 
Mutable parser state (token index and parser state) now uses `Cell` 
for interior mutability.

This refactoring is preparation for the borrowed tokenizer work. When 
holding borrowed tokens from the parser (with lifetime tied to `&self`), 
we cannot call methods requiring `&mut self` due to Rust's borrowing 
rules. Using interior mutability resolves this conflict by allowing 
state mutations through shared references. 