### PR TITLE
Preserve optional `AS` keyword in aliases

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1902,7 +1902,7 @@ impl fmt::Display for TableFactor {
                     write!(f, " {sample}")?;
                 }
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 if !index_hints.is_empty() {
                     write!(f, " {}", display_separated(index_hints, " "))?;
@@ -1932,7 +1932,7 @@ impl fmt::Display for TableFactor {
                 NewLine.fmt(f)?;
                 f.write_str(")")?;
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -1948,14 +1948,14 @@ impl fmt::Display for TableFactor {
                 write!(f, "{name}")?;
                 write!(f, "({})", display_comma_separated(args))?;
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
             TableFactor::TableFunction { expr, alias } => {
                 write!(f, "TABLE({expr})")?;
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -1973,13 +1973,13 @@ impl fmt::Display for TableFactor {
                 }
 
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 if *with_offset {
                     write!(f, " WITH OFFSET")?;
                 }
                 if let Some(alias) = with_offset_alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -1995,7 +1995,7 @@ impl fmt::Display for TableFactor {
                     columns = display_comma_separated(columns)
                 )?;
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -2014,7 +2014,7 @@ impl fmt::Display for TableFactor {
                     write!(f, " WITH ({})", display_comma_separated(columns))?;
                 }
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -2024,7 +2024,7 @@ impl fmt::Display for TableFactor {
             } => {
                 write!(f, "({table_with_joins})")?;
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -2051,8 +2051,8 @@ impl fmt::Display for TableFactor {
                     write!(f, " DEFAULT ON NULL ({expr})")?;
                 }
                 write!(f, ")")?;
-                if alias.is_some() {
-                    write!(f, " AS {}", alias.as_ref().unwrap())?;
+                if let Some(alias) = alias {
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -2075,8 +2075,8 @@ impl fmt::Display for TableFactor {
                     name,
                     display_comma_separated(columns)
                 )?;
-                if alias.is_some() {
-                    write!(f, " AS {}", alias.as_ref().unwrap())?;
+                if let Some(alias) = alias {
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -2109,8 +2109,8 @@ impl fmt::Display for TableFactor {
                 }
                 write!(f, "PATTERN ({pattern}) ")?;
                 write!(f, "DEFINE {})", display_comma_separated(symbols))?;
-                if alias.is_some() {
-                    write!(f, " AS {}", alias.as_ref().unwrap())?;
+                if let Some(alias) = alias {
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -2135,7 +2135,7 @@ impl fmt::Display for TableFactor {
                     columns = display_comma_separated(columns)
                 )?;
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }
@@ -2168,7 +2168,7 @@ impl fmt::Display for TableFactor {
                 write!(f, ")")?;
 
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
 
                 Ok(())
@@ -2181,13 +2181,17 @@ impl fmt::Display for TableFactor {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct TableAlias {
+    /// Tells whether the alias was introduced with an explicit, preceding "AS"
+    /// keyword, e.g. `AS name`. Typically, the keyword is preceding the name
+    /// (e.g. `.. FROM table AS t ..`).
+    pub explicit: bool,
     pub name: Ident,
     pub columns: Vec<TableAliasColumnDef>,
 }
 
 impl fmt::Display for TableAlias {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.name)?;
+        write!(f, "{}{}", if self.explicit { "AS " } else { "" }, self.name)?;
         if !self.columns.is_empty() {
             write!(f, " ({})", display_comma_separated(&self.columns))?;
         }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -15,10 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::ast::{
-    ddl::AlterSchema, query::SelectItemQualifiedWildcardKind, AlterSchemaOperation, AlterTable,
-    ColumnOptions, CreateOperator, CreateOperatorClass, CreateOperatorFamily, CreateView,
-    ExportData, Owner, TypedString,
+use crate::{
+    ast::{
+        ddl::AlterSchema, query::SelectItemQualifiedWildcardKind, AlterSchemaOperation, AlterTable,
+        ColumnOptions, CreateOperator, CreateOperatorClass, CreateOperatorFamily, CreateView,
+        ExportData, Owner, TypedString,
+    },
+    tokenizer::TokenWithSpan,
 };
 use core::iter;
 
@@ -94,6 +97,12 @@ pub trait Spanned {
     ///
     /// [`Location`]: crate::tokenizer::Location
     fn span(&self) -> Span;
+}
+
+impl Spanned for TokenWithSpan {
+    fn span(&self) -> Span {
+        self.span
+    }
 }
 
 impl Spanned for Query {
@@ -2079,9 +2088,12 @@ impl Spanned for FunctionArgExpr {
 
 impl Spanned for TableAlias {
     fn span(&self) -> Span {
-        let TableAlias { name, columns } = self;
-
-        union_spans(iter::once(name.span).chain(columns.iter().map(|i| i.span())))
+        let TableAlias {
+            explicit: _,
+            name,
+            columns,
+        } = self;
+        union_spans(core::iter::once(name.span).chain(columns.iter().map(Spanned::span)))
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11140,10 +11140,15 @@ impl<'a> Parser<'a> {
         fn validator(explicit: bool, kw: &Keyword, parser: &mut Parser) -> bool {
             parser.dialect.is_table_factor_alias(explicit, kw, parser)
         }
+        let explicit = self.peek_keyword(Keyword::AS);
         match self.parse_optional_alias_inner(None, validator)? {
             Some(name) => {
                 let columns = self.parse_table_alias_column_defs()?;
-                Ok(Some(TableAlias { name, columns }))
+                Ok(Some(TableAlias {
+                    explicit,
+                    name,
+                    columns,
+                }))
             }
             None => Ok(None),
         }
@@ -12775,6 +12780,7 @@ impl<'a> Parser<'a> {
             let closing_paren_token = self.expect_token(&Token::RParen)?;
 
             let alias = TableAlias {
+                explicit: false,
                 name,
                 columns: vec![],
             };
@@ -12801,7 +12807,11 @@ impl<'a> Parser<'a> {
             let query = self.parse_query()?;
             let closing_paren_token = self.expect_token(&Token::RParen)?;
 
-            let alias = TableAlias { name, columns };
+            let alias = TableAlias {
+                explicit: false,
+                name,
+                columns,
+            };
             Cte {
                 alias,
                 query,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -368,8 +368,9 @@ pub fn single_quoted_string(s: impl Into<String>) -> Value {
     Value::SingleQuotedString(s.into())
 }
 
-pub fn table_alias(name: impl Into<String>) -> Option<TableAlias> {
+pub fn table_alias(explicit: bool, name: impl Into<String>) -> Option<TableAlias> {
     Some(TableAlias {
+        explicit,
         name: Ident::new(name),
         columns: vec![],
     })
@@ -405,13 +406,14 @@ pub fn table_from_name(name: ObjectName) -> TableFactor {
     }
 }
 
-pub fn table_with_alias(name: impl Into<String>, alias: impl Into<String>) -> TableFactor {
+pub fn table_with_alias(
+    name: impl Into<String>,
+    with_as_keyword: bool,
+    alias: impl Into<String>,
+) -> TableFactor {
     TableFactor::Table {
         name: ObjectName::from(vec![Ident::new(name)]),
-        alias: Some(TableAlias {
-            name: Ident::new(alias),
-            columns: vec![],
-        }),
+        alias: table_alias(with_as_keyword, alias),
         args: None,
         with_hints: vec![],
         version: None,

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1690,7 +1690,7 @@ fn parse_table_identifiers() {
 fn parse_hyphenated_table_identifiers() {
     bigquery().one_statement_parses_to(
         "select * from foo-bar f join baz-qux b on f.id = b.id",
-        "SELECT * FROM foo-bar AS f JOIN baz-qux AS b ON f.id = b.id",
+        "SELECT * FROM foo-bar f JOIN baz-qux b ON f.id = b.id",
     );
 
     assert_eq!(
@@ -1766,7 +1766,7 @@ fn parse_join_constraint_unnest_alias() {
         .joins,
         vec![Join {
             relation: TableFactor::UNNEST {
-                alias: table_alias("f"),
+                alias: table_alias(true, "f"),
                 array_exprs: vec![Expr::CompoundIdentifier(vec![
                     Ident::new("t1"),
                     Ident::new("a")
@@ -1841,10 +1841,7 @@ fn parse_merge() {
             assert_eq!(
                 TableFactor::Table {
                     name: ObjectName::from(vec![Ident::new("inventory")]),
-                    alias: Some(TableAlias {
-                        name: Ident::new("T"),
-                        columns: vec![],
-                    }),
+                    alias: table_alias(true, "T"),
                     args: Default::default(),
                     with_hints: Default::default(),
                     version: Default::default(),
@@ -1859,10 +1856,7 @@ fn parse_merge() {
             assert_eq!(
                 TableFactor::Table {
                     name: ObjectName::from(vec![Ident::new("newArrivals")]),
-                    alias: Some(TableAlias {
-                        name: Ident::new("S"),
-                        columns: vec![],
-                    }),
+                    alias: table_alias(true, "S"),
                     args: Default::default(),
                     with_hints: Default::default(),
                     version: Default::default(),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -2638,10 +2638,7 @@ fn parse_update_with_joins() {
                 TableWithJoins {
                     relation: TableFactor::Table {
                         name: ObjectName::from(vec![Ident::new("orders")]),
-                        alias: Some(TableAlias {
-                            name: Ident::new("o"),
-                            columns: vec![]
-                        }),
+                        alias: table_alias(true, "o"),
                         args: None,
                         with_hints: vec![],
                         version: None,
@@ -2654,10 +2651,7 @@ fn parse_update_with_joins() {
                     joins: vec![Join {
                         relation: TableFactor::Table {
                             name: ObjectName::from(vec![Ident::new("customers")]),
-                            alias: Some(TableAlias {
-                                name: Ident::new("c"),
-                                columns: vec![]
-                            }),
+                            alias: table_alias(true, "c"),
                             args: None,
                             with_hints: vec![],
                             version: None,
@@ -3716,10 +3710,7 @@ fn parse_json_table() {
                     on_error: Some(JsonTableColumnErrorHandling::Null),
                 }),
             ],
-            alias: Some(TableAlias {
-                name: Ident::new("t"),
-                columns: vec![],
-            }),
+            alias: table_alias(true, "t"),
         }
     );
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5109,7 +5109,7 @@ fn parse_join_constraint_unnest_alias() {
         .joins,
         vec![Join {
             relation: TableFactor::UNNEST {
-                alias: table_alias("f"),
+                alias: table_alias(true, "f"),
                 array_exprs: vec![Expr::CompoundIdentifier(vec![
                     Ident::new("t1"),
                     Ident::new("a")

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1197,17 +1197,17 @@ fn test_single_table_in_parenthesis() {
 fn test_single_table_in_parenthesis_with_alias() {
     snowflake_and_generic().one_statement_parses_to(
         "SELECT * FROM (a NATURAL JOIN (b) c )",
-        "SELECT * FROM (a NATURAL JOIN b AS c)",
+        "SELECT * FROM (a NATURAL JOIN b c)",
     );
 
     snowflake_and_generic().one_statement_parses_to(
         "SELECT * FROM (a NATURAL JOIN ((b)) c )",
-        "SELECT * FROM (a NATURAL JOIN b AS c)",
+        "SELECT * FROM (a NATURAL JOIN b c)",
     );
 
     snowflake_and_generic().one_statement_parses_to(
         "SELECT * FROM (a NATURAL JOIN ( (b) c ) )",
-        "SELECT * FROM (a NATURAL JOIN b AS c)",
+        "SELECT * FROM (a NATURAL JOIN b c)",
     );
 
     snowflake_and_generic().one_statement_parses_to(
@@ -1216,8 +1216,12 @@ fn test_single_table_in_parenthesis_with_alias() {
     );
 
     snowflake_and_generic().one_statement_parses_to(
+        "SELECT * FROM (a as alias1 NATURAL JOIN ( (b) c ) )",
+        "SELECT * FROM (a AS alias1 NATURAL JOIN b c)",
+    );
+    snowflake_and_generic().one_statement_parses_to(
         "SELECT * FROM (a alias1 NATURAL JOIN ( (b) c ) )",
-        "SELECT * FROM (a AS alias1 NATURAL JOIN b AS c)",
+        "SELECT * FROM (a alias1 NATURAL JOIN b c)",
     );
 
     snowflake_and_generic().one_statement_parses_to(
@@ -1226,7 +1230,7 @@ fn test_single_table_in_parenthesis_with_alias() {
     );
 
     snowflake_and_generic().one_statement_parses_to(
-        "SELECT * FROM (a NATURAL JOIN b) c",
+        "SELECT * FROM (a NATURAL JOIN b) AS c",
         "SELECT * FROM (a NATURAL JOIN b) AS c",
     );
 
@@ -3051,9 +3055,9 @@ fn asof_joins() {
     assert_eq!(
         query.from[0],
         TableWithJoins {
-            relation: table_with_alias("trades_unixtime", "tu"),
+            relation: table_with_alias("trades_unixtime", true, "tu"),
             joins: vec![Join {
-                relation: table_with_alias("quotes_unixtime", "qu"),
+                relation: table_with_alias("quotes_unixtime", true, "qu"),
                 global: false,
                 join_operator: JoinOperator::AsOf {
                     match_condition: Expr::BinaryOp {
@@ -3644,10 +3648,37 @@ fn test_sql_keywords_as_table_aliases() {
         "OPEN",
     ];
 
+    fn assert_implicit_alias(mut select: Select, canonical_with_explicit_alias: &str) {
+        if let TableFactor::Table { alias, .. } = &mut select
+            .from
+            .get_mut(0)
+            .as_mut()
+            .expect("missing FROM")
+            .relation
+        {
+            let alias = alias.as_mut().expect("missing ALIAS");
+            assert!(!alias.explicit);
+            alias.explicit = true;
+            assert_eq!(&format!("{select}"), canonical_with_explicit_alias);
+        } else {
+            panic!("unexpected FROM <table-factor>");
+        }
+    }
+
+    fn assert_no_alias(select: Select) {
+        if let TableFactor::Table { alias, .. } =
+            &select.from.first().expect("missing FROM").relation
+        {
+            assert_eq!(alias, &None);
+        } else {
+            panic!("unexpected FROM <table-factor>");
+        }
+    }
+
     for kw in unreserved_kws {
         snowflake().verified_stmt(&format!("SELECT * FROM tbl AS {kw}"));
-        snowflake().one_statement_parses_to(
-            &format!("SELECT * FROM tbl {kw}"),
+        assert_implicit_alias(
+            snowflake().verified_only_select(&format!("SELECT * FROM tbl {kw}")),
             &format!("SELECT * FROM tbl AS {kw}"),
         );
     }
@@ -3663,13 +3694,17 @@ fn test_sql_keywords_as_table_aliases() {
     }
 
     // LIMIT is alias
-    snowflake().one_statement_parses_to("SELECT * FROM tbl LIMIT", "SELECT * FROM tbl AS LIMIT");
+    assert_implicit_alias(
+        snowflake().verified_only_select("SELECT * FROM tbl LIMIT"),
+        "SELECT * FROM tbl AS LIMIT",
+    );
+
     // LIMIT is not an alias
-    snowflake().verified_stmt("SELECT * FROM tbl LIMIT 1");
-    snowflake().verified_stmt("SELECT * FROM tbl LIMIT $1");
-    snowflake().verified_stmt("SELECT * FROM tbl LIMIT ''");
-    snowflake().verified_stmt("SELECT * FROM tbl LIMIT NULL");
-    snowflake().verified_stmt("SELECT * FROM tbl LIMIT $$$$");
+    assert_no_alias(snowflake().verified_only_select("SELECT * FROM tbl LIMIT 1"));
+    assert_no_alias(snowflake().verified_only_select("SELECT * FROM tbl LIMIT $1"));
+    assert_no_alias(snowflake().verified_only_select("SELECT * FROM tbl LIMIT ''"));
+    assert_no_alias(snowflake().verified_only_select("SELECT * FROM tbl LIMIT NULL"));
+    assert_no_alias(snowflake().verified_only_select("SELECT * FROM tbl LIMIT $$$$"));
 }
 
 #[test]
@@ -3911,14 +3946,7 @@ fn test_nested_join_without_parentheses() {
                 table_with_joins: Box::new(TableWithJoins {
                     relation: TableFactor::Table {
                         name: ObjectName::from(vec![Ident::new("customers".to_string())]),
-                        alias: Some(TableAlias {
-                            name: Ident {
-                                value: "c".to_string(),
-                                quote_style: None,
-                                span: Span::empty(),
-                            },
-                            columns: vec![],
-                        }),
+                        alias: table_alias(true, "c"),
                         args: None,
                         with_hints: vec![],
                         version: None,
@@ -3931,14 +3959,7 @@ fn test_nested_join_without_parentheses() {
                     joins: vec![Join {
                         relation: TableFactor::Table {
                             name: ObjectName::from(vec![Ident::new("products".to_string())]),
-                            alias: Some(TableAlias {
-                                name: Ident {
-                                    value: "p".to_string(),
-                                    quote_style: None,
-                                    span: Span::empty(),
-                                },
-                                columns: vec![],
-                            }),
+                            alias: table_alias(true, "p"),
                             args: None,
                             with_hints: vec![],
                             version: None,
@@ -3992,14 +4013,7 @@ fn test_nested_join_without_parentheses() {
                 table_with_joins: Box::new(TableWithJoins {
                     relation: TableFactor::Table {
                         name: ObjectName::from(vec![Ident::new("customers".to_string())]),
-                        alias: Some(TableAlias {
-                            name: Ident {
-                                value: "c".to_string(),
-                                quote_style: None,
-                                span: Span::empty(),
-                            },
-                            columns: vec![],
-                        }),
+                        alias: table_alias(true, "c"),
                         args: None,
                         with_hints: vec![],
                         version: None,
@@ -4012,14 +4026,7 @@ fn test_nested_join_without_parentheses() {
                     joins: vec![Join {
                         relation: TableFactor::Table {
                             name: ObjectName::from(vec![Ident::new("products".to_string())]),
-                            alias: Some(TableAlias {
-                                name: Ident {
-                                    value: "p".to_string(),
-                                    quote_style: None,
-                                    span: Span::empty(),
-                                },
-                                columns: vec![],
-                            }),
+                            alias: table_alias(true, "p"),
                             args: None,
                             with_hints: vec![],
                             version: None,
@@ -4073,14 +4080,7 @@ fn test_nested_join_without_parentheses() {
                 table_with_joins: Box::new(TableWithJoins {
                     relation: TableFactor::Table {
                         name: ObjectName::from(vec![Ident::new("customers".to_string())]),
-                        alias: Some(TableAlias {
-                            name: Ident {
-                                value: "c".to_string(),
-                                quote_style: None,
-                                span: Span::empty(),
-                            },
-                            columns: vec![],
-                        }),
+                        alias: table_alias(true, "c"),
                         args: None,
                         with_hints: vec![],
                         version: None,
@@ -4093,14 +4093,7 @@ fn test_nested_join_without_parentheses() {
                     joins: vec![Join {
                         relation: TableFactor::Table {
                             name: ObjectName::from(vec![Ident::new("products".to_string())]),
-                            alias: Some(TableAlias {
-                                name: Ident {
-                                    value: "p".to_string(),
-                                    quote_style: None,
-                                    span: Span::empty(),
-                                },
-                                columns: vec![],
-                            }),
+                            alias: table_alias(true, "p"),
                             args: None,
                             with_hints: vec![],
                             version: None,
@@ -4154,14 +4147,7 @@ fn test_nested_join_without_parentheses() {
                 table_with_joins: Box::new(TableWithJoins {
                     relation: TableFactor::Table {
                         name: ObjectName::from(vec![Ident::new("customers".to_string())]),
-                        alias: Some(TableAlias {
-                            name: Ident {
-                                value: "c".to_string(),
-                                quote_style: None,
-                                span: Span::empty(),
-                            },
-                            columns: vec![],
-                        }),
+                        alias: table_alias(true, "c"),
                         args: None,
                         with_hints: vec![],
                         version: None,
@@ -4174,14 +4160,7 @@ fn test_nested_join_without_parentheses() {
                     joins: vec![Join {
                         relation: TableFactor::Table {
                             name: ObjectName::from(vec![Ident::new("products".to_string())]),
-                            alias: Some(TableAlias {
-                                name: Ident {
-                                    value: "p".to_string(),
-                                    quote_style: None,
-                                    span: Span::empty(),
-                                },
-                                columns: vec![],
-                            }),
+                            alias: table_alias(true, "p"),
                             args: None,
                             with_hints: vec![],
                             version: None,
@@ -4235,14 +4214,7 @@ fn test_nested_join_without_parentheses() {
                 table_with_joins: Box::new(TableWithJoins {
                     relation: TableFactor::Table {
                         name: ObjectName::from(vec![Ident::new("customers".to_string())]),
-                        alias: Some(TableAlias {
-                            name: Ident {
-                                value: "c".to_string(),
-                                quote_style: None,
-                                span: Span::empty(),
-                            },
-                            columns: vec![],
-                        }),
+                        alias: table_alias(true, "c"),
                         args: None,
                         with_hints: vec![],
                         version: None,
@@ -4255,14 +4227,7 @@ fn test_nested_join_without_parentheses() {
                     joins: vec![Join {
                         relation: TableFactor::Table {
                             name: ObjectName::from(vec![Ident::new("products".to_string())]),
-                            alias: Some(TableAlias {
-                                name: Ident {
-                                    value: "p".to_string(),
-                                    quote_style: None,
-                                    span: Span::empty(),
-                                },
-                                columns: vec![],
-                            }),
+                            alias: table_alias(true, "p"),
                             args: None,
                             with_hints: vec![],
                             version: None,


### PR DESCRIPTION
Right now `sqlparser-rs` injects the `AS` keyword in front of alias names unconditionally. As reported by #1875 or #1784 this leads to problems on Oracle databases.  This patch preserves the original absence / presence  of the keyword (implicit/explicit aliases) in "table-factor" position when rendered via `Display`.

1. Some more effort could be invested to apply the same behaviour for select-items (ie. projections in queries) and/or further nodes of the AST with an alias for which `AS` is optional.  To unify the implementation within the parser and for clients, representing aliases could then be exposed not as pure `Ident`s but maybe as something as:

```rust
struct Alias {
  explicit: bool,
  name: Ident,
}

impl Deref for Alias {
  type Target = Ident;
  ...
}

impl From<Alias> for Ident {
  ...
}
```

2. The parser _could_ be instructed / configured (either by `ParserOptions` or through a `Dialect` setting) to always produce "explicit" alias tokens. This would then always produce the "AS" keyword when render via `Display`. Ideally, there would be a `VisitorMut::visit_(mut_)alias` and clients could just apply their own setting easily. But this would be rather a nice-to-have.

3. Initially, I started out with an `pub as_keyword: Option<TokenWithSpan>` (to preserves the optional token's span) instead of the now proposed `pub explicit: bool`, but that blew up the size of `TableAlias` from 88bytes to 176bytes :/

4. I'd greatly appreciate a critical look since my know-how regarding different DBs is quite limited. I hope I've not broken any of the existing dialects and also hope this PR helps "preserving the syntax round trip".
