### PR TITLE
Fixing location for extrenal tables

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2803,7 +2803,9 @@ impl fmt::Display for CreateTable {
             if let Some(file_format) = self.file_format {
                 write!(f, " STORED AS {file_format}")?;
             }
-            write!(f, " LOCATION '{}'", self.location.as_ref().unwrap())?;
+            if let Some(location) = &self.location {
+                write!(f, " LOCATION '{location}'")?;
+            }
         }
 
         match &self.table_options {

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -34,10 +34,12 @@ fn parse_table_create() {
     let sql = r#"CREATE TABLE IF NOT EXISTS db.table (a BIGINT, b STRING, c TIMESTAMP) PARTITIONED BY (d STRING, e TIMESTAMP) STORED AS ORC LOCATION 's3://...' TBLPROPERTIES ("prop" = "2", "asdf" = '1234', 'asdf' = "1234", "asdf" = 2)"#;
     let iof = r#"CREATE TABLE IF NOT EXISTS db.table (a BIGINT, b STRING, c TIMESTAMP) PARTITIONED BY (d STRING, e TIMESTAMP) STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat' OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat' LOCATION 's3://...'"#;
     let serdeproperties = r#"CREATE EXTERNAL TABLE IF NOT EXISTS db.table (a STRING, b STRING, c STRING) PARTITIONED BY (d STRING, e STRING) ROW FORMAT SERDE 'org.apache.hadoop.hive.serde.config' WITH SERDEPROPERTIES ('prop_a' = 'a', 'prop_b' = 'b') STORED AS TEXTFILE LOCATION 's3://...' TBLPROPERTIES ('prop_c' = 'c')"#;
+    let externaltable = r#"CREATE EXTERNAL TABLE t (c INT)"#;
 
     hive().verified_stmt(sql);
     hive().verified_stmt(iof);
     hive().verified_stmt(serdeproperties);
+    hive().verified_stmt(externaltable);
 }
 
 #[test]


### PR DESCRIPTION
Location isn't required for external tables for hive. Example of query:
```
CREATE EXTERNAL TABLE my_table (
    c INT
)
```
Spec:
https://hive.apache.org/docs/latest/language/languagemanual-ddl/?utm_source=chatgpt.com#external-tables

It says: `The EXTERNAL keyword lets you create a table and provide a LOCATION so that Hive does not use a default location`. It's not very clear, but if location is not specified, it will provide default location.
