### PR TITLE
Add lifetime to token

### DIFF
--- a/src/ast/helpers/attached_token.rs
+++ b/src/ast/helpers/attached_token.rs
@@ -80,7 +80,7 @@ use sqlparser_derive::{Visit, VisitMut};
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
-pub struct AttachedToken(pub TokenWithSpan);
+pub struct AttachedToken(pub TokenWithSpan<'static>);
 
 impl AttachedToken {
     /// Return a new Empty AttachedToken
@@ -123,13 +123,13 @@ impl Hash for AttachedToken {
     }
 }
 
-impl From<TokenWithSpan> for AttachedToken {
-    fn from(value: TokenWithSpan) -> Self {
+impl From<TokenWithSpan<'static>> for AttachedToken {
+    fn from(value: TokenWithSpan<'static>) -> Self {
         AttachedToken(value)
     }
 }
 
-impl From<AttachedToken> for TokenWithSpan {
+impl From<AttachedToken> for TokenWithSpan<'static> {
     fn from(value: AttachedToken) -> Self {
         value.0
     }

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -31,7 +31,7 @@ use log::debug;
 use crate::dialect::{Dialect, Precedence};
 use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
-use crate::tokenizer::Token;
+use crate::tokenizer::BorrowedToken;
 
 /// A [`Dialect`] for [PostgreSQL](https://www.postgresql.org/)
 #[derive(Debug)]
@@ -110,32 +110,32 @@ impl Dialect for PostgreSqlDialect {
         // we only return some custom value here when the behaviour (not merely the numeric value) differs
         // from the default implementation
         match token.token {
-            Token::Word(w)
+            BorrowedToken::Word(w)
                 if w.keyword == Keyword::COLLATE && !parser.in_column_definition_state() =>
             {
                 Some(Ok(COLLATE_PREC))
             }
-            Token::LBracket => Some(Ok(BRACKET_PREC)),
-            Token::Arrow
-            | Token::LongArrow
-            | Token::HashArrow
-            | Token::HashLongArrow
-            | Token::AtArrow
-            | Token::ArrowAt
-            | Token::HashMinus
-            | Token::AtQuestion
-            | Token::AtAt
-            | Token::Question
-            | Token::QuestionAnd
-            | Token::QuestionPipe
-            | Token::ExclamationMark
-            | Token::Overlap
-            | Token::CaretAt
-            | Token::StringConcat
-            | Token::Sharp
-            | Token::ShiftRight
-            | Token::ShiftLeft
-            | Token::CustomBinaryOperator(_) => Some(Ok(PG_OTHER_PREC)),
+            BorrowedToken::LBracket => Some(Ok(BRACKET_PREC)),
+            BorrowedToken::Arrow
+            | BorrowedToken::LongArrow
+            | BorrowedToken::HashArrow
+            | BorrowedToken::HashLongArrow
+            | BorrowedToken::AtArrow
+            | BorrowedToken::ArrowAt
+            | BorrowedToken::HashMinus
+            | BorrowedToken::AtQuestion
+            | BorrowedToken::AtAt
+            | BorrowedToken::Question
+            | BorrowedToken::QuestionAnd
+            | BorrowedToken::QuestionPipe
+            | BorrowedToken::ExclamationMark
+            | BorrowedToken::Overlap
+            | BorrowedToken::CaretAt
+            | BorrowedToken::StringConcat
+            | BorrowedToken::Sharp
+            | BorrowedToken::ShiftRight
+            | BorrowedToken::ShiftLeft
+            | BorrowedToken::CustomBinaryOperator(_) => Some(Ok(PG_OTHER_PREC)),
             _ => None,
         }
     }

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     dialect::{MsSqlDialect, PostgreSqlDialect},
     keywords::Keyword,
-    tokenizer::Token,
+    tokenizer::BorrowedToken,
 };
 
 impl Parser<'_> {
@@ -74,18 +74,18 @@ impl Parser<'_> {
             };
 
             let using = if self.parse_keyword(Keyword::USING) {
-                self.expect_token(&Token::LParen)?;
+                self.expect_token(&BorrowedToken::LParen)?;
                 let expr = self.parse_expr()?;
-                self.expect_token(&Token::RParen)?;
+                self.expect_token(&BorrowedToken::RParen)?;
                 Some(expr)
             } else {
                 None
             };
 
             let with_check = if self.parse_keywords(&[Keyword::WITH, Keyword::CHECK]) {
-                self.expect_token(&Token::LParen)?;
+                self.expect_token(&BorrowedToken::LParen)?;
                 let expr = self.parse_expr()?;
-                self.expect_token(&Token::RParen)?;
+                self.expect_token(&BorrowedToken::RParen)?;
                 Some(expr)
             } else {
                 None
@@ -216,7 +216,7 @@ impl Parser<'_> {
         let add_mfa_method_otp =
             if self.parse_keywords(&[Keyword::ADD, Keyword::MFA, Keyword::METHOD, Keyword::OTP]) {
                 let count = if self.parse_keyword(Keyword::COUNT) {
-                    self.expect_token(&Token::Eq)?;
+                    self.expect_token(&BorrowedToken::Eq)?;
                     Some(self.parse_value()?.into())
                 } else {
                     None
@@ -336,7 +336,7 @@ impl Parser<'_> {
             let member_name = self.parse_identifier()?;
             AlterRoleOperation::DropMember { member_name }
         } else if self.parse_keywords(&[Keyword::WITH, Keyword::NAME]) {
-            if self.consume_token(&Token::Eq) {
+            if self.consume_token(&BorrowedToken::Eq) {
                 let role_name = self.parse_identifier()?;
                 AlterRoleOperation::RenameRole { role_name }
             } else {
@@ -380,7 +380,7 @@ impl Parser<'_> {
                     in_database,
                 }
             // { TO | = } { value | DEFAULT }
-            } else if self.consume_token(&Token::Eq) || self.parse_keyword(Keyword::TO) {
+            } else if self.consume_token(&BorrowedToken::Eq) || self.parse_keyword(Keyword::TO) {
                 if self.parse_keyword(Keyword::DEFAULT) {
                     AlterRoleOperation::Set {
                         config_name,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -126,7 +126,8 @@ impl TestedDialects {
             if let Some(options) = &self.options {
                 tokenizer = tokenizer.with_unescape(options.unescape);
             }
-            let tokens = tokenizer.tokenize()?;
+
+            let tokens = tokenizer.tokenized_owned()?;
             self.new_parser(dialect)
                 .with_tokens(tokens)
                 .parse_statements()

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2045,7 +2045,7 @@ fn parse_pg_returning() {
 fn test_operator(operator: &str, dialect: &TestedDialects, expected: BinaryOperator) {
     let operator_tokens =
         sqlparser::tokenizer::Tokenizer::new(&PostgreSqlDialect {}, &format!("a{operator}b"))
-            .tokenize()
+            .tokenized_owned()
             .unwrap();
     assert_eq!(
         operator_tokens.len(),


### PR DESCRIPTION
his PR adds a lifetime parameter to the Token enum to enable zero-copy tokenization in the future.

  Backward Compatibility:
  To maintain backward compatibility, we renamed Token to BorrowedToken<'a> and introduced Token as a type alias for BorrowedToken<'static>. This allows existing consumers of the library to continue using Token without needing to handle
  lifetimes throughout their code.

  New API:
  This PR also adds a tokenized_owned() method for use cases where consumers prefer to pay the cost of copying in exchange for owned tokens.

  Current State:
  This commit does not yet change the tokenizer's behavior—all string allocations remain in place. The goal of the following commits is to replace String with Cow<'a, str> in as many places as possible, leveraging the Borrowed variant to
  achieve zero-copy tokenization where feasible.
