### PR TITLE
Fix verification script for new sqlparser_derive version

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -129,8 +129,10 @@ test_source_distribution() {
     exit 1
   fi
 
+  # Can't test using dry-run because sqlparser depends on sqlparser_derive
+  # see https://github.com/crate-ci/cargo-release/issues/691#issuecomment-2059866021
   # Check that publish works
-  cargo publish --dry-run
+  # cargo publish --dry-run
 }
 
 TEST_SUCCESS=no


### PR DESCRIPTION
- part of https://github.com/apache/datafusion-sqlparser-rs/issues/2045
- closes https://github.com/apache/datafusion-sqlparser-rs/issues/2118

`cargo publish --dry-run` doesn't work when there are multiple crates that are to be published in the same workspace
- https://github.com/crate-ci/cargo-release/issues/691#issuecomment-2059866021

Thus, if we change the version of sqlparser_derive, `cargo publish --dry-run` fails with the 0.60.0 release, as reported in https://github.com/apache/datafusion-sqlparser-rs/issues/2118.

Let's remove the `cargo publish --dry-run` check.  I tested locally and verified that the verification procedure now passes with `0.60.0` rc1
```shell
 ./dev/release/verify-release-candidate.sh 0.60.0 1
```