### PR TITLE
fix: Set the current folder as a "primary" for the `find` command

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -124,7 +124,7 @@ test_source_distribution() {
   cargo build
   cargo test --all-features
 
-  if ( find -iname 'Cargo.toml' | xargs grep SNAPSHOT ); then
+  if ( find . -iname 'Cargo.toml' | xargs grep SNAPSHOT ); then
     echo "Cargo.toml version should not contain SNAPSHOT for releases"
     exit 1
   fi


### PR DESCRIPTION
While testing the 0.60,0 RC2 release I noticed the following at the end of the logs:
```
find -iname Cargo.toml
find: illegal option -- i
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
```

The reason is the missing `.` before the arguments. 
https://github.com/martin-g/datafusion-sqlparser-rs/blob/5a3b63bf419ff80e6acdb0b3bbdbcf664083f1d5/dev/release/verify-release-candidate.sh#L75 does it correctly