### PR TITLE
GenericDialect: support colon operator for JsonAccess

### DIFF
--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -160,6 +160,15 @@ impl Dialect for MsSqlDialect {
             None
         }
     }
+
+    fn get_next_precedence(&self, parser: &Parser) -> Option<Result<u8, ParserError>> {
+        let token = parser.peek_token();
+        match token.token {
+            // lowest prec to prevent it from turning into a binary op
+            Token::Colon => Some(Ok(self.prec_unknown())),
+            _ => None,
+        }
+    }
 }
 
 impl MsSqlDialect {

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -136,6 +136,8 @@ impl Dialect for PostgreSqlDialect {
             | Token::ShiftRight
             | Token::ShiftLeft
             | Token::CustomBinaryOperator(_) => Some(Ok(PG_OTHER_PREC)),
+            // lowest prec to prevent it from turning into a binary op
+            Token::Colon => Some(Ok(self.prec_unknown())),
             _ => None,
         }
     }
@@ -159,6 +161,7 @@ impl Dialect for PostgreSqlDialect {
             Precedence::Ampersand => PG_OTHER_PREC,
             Precedence::Caret => CARET_PREC,
             Precedence::Pipe => PG_OTHER_PREC,
+            Precedence::Colon => PG_OTHER_PREC,
             Precedence::Between => BETWEEN_LIKE_PREC,
             Precedence::Eq => EQ_PREC,
             Precedence::Like => BETWEEN_LIKE_PREC,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3921,7 +3921,7 @@ impl<'a> Parser<'a> {
                 expr: Box::new(expr),
             })
         } else if Token::LBracket == *tok && self.dialect.supports_partiql()
-            || (dialect_of!(self is SnowflakeDialect | GenericDialect) && Token::Colon == *tok)
+            || (Token::Colon == *tok)
         {
             self.prev_token();
             self.parse_json_access(expr)
@@ -3957,7 +3957,8 @@ impl<'a> Parser<'a> {
         let lower_bound = if self.consume_token(&Token::Colon) {
             None
         } else {
-            Some(self.parse_expr()?)
+            // parse expr until we hit a colon (or any token with lower precedence)
+            Some(self.parse_subexpr(self.dialect.prec_value(Precedence::Colon))?)
         };
 
         // check for end
@@ -3985,7 +3986,8 @@ impl<'a> Parser<'a> {
                 stride: None,
             });
         } else {
-            Some(self.parse_expr()?)
+            // parse expr until we hit a colon (or any token with lower precedence)
+            Some(self.parse_subexpr(self.dialect.prec_value(Precedence::Colon))?)
         };
 
         // check for end


### PR DESCRIPTION
- Port JsonAccess colon operator from Snowflake to Generic dialect
- This will be used in variant data type support in Datafusion
- see discussion in https://github.com/datafusion-contrib/datafusion-variant/issues/2