### PR TITLE
MSSQL: Parse IF/ELSE without semicolon delimiters

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11503,16 +11503,17 @@ impl<'a> Parser<'a> {
 
         let next_token = self.next_token();
         match next_token.token {
-            // By default, if a word is located after the `AS` keyword we consider it an alias
-            // as long as it's not reserved.
+            // Accepts a keyword as an alias if the AS keyword explicitly indicate an alias or if the
+            // caller provided a list of reserved keywords and the keyword is not on that list.
             Token::Word(w)
-                if after_as || reserved_kwds.is_some_and(|x| !x.contains(&w.keyword)) =>
+                if reserved_kwds.is_some()
+                    && (after_as || reserved_kwds.is_some_and(|x| !x.contains(&w.keyword))) =>
             {
                 Ok(Some(w.into_ident(next_token.span)))
             }
-            // This pattern allows for customizing the acceptance of words as aliases based on the caller's
-            // context, such as to what SQL element this word is a potential alias of (select item alias, table name
-            // alias, etc.) or dialect-specific logic that goes beyond a simple list of reserved keywords.
+            // Accepts a keyword as alias based on the caller's context, such as to what SQL element
+            // this word is a potential alias of using the validator call-back. This allows for
+            // dialect-specific logic.
             Token::Word(w) if validator(after_as, &w.keyword, self) => {
                 Ok(Some(w.into_ident(next_token.span)))
             }


### PR DESCRIPTION
When parsing a SQL that doesn't use semicolon delimiters, for example:
```sql
SELECT col FROM tbl
IF x=1
  SELECT 1
ELSE
  SELECT 2
```

The parser needs to identify the `IF` keyword as a new statement instead of an alias for `tbl` and the `ELSE` as part of the conditional statement instead of an alias to `1`. Moreover, MSSQL doesn't support `IF/ELSE` as explicit (after `AS`) or implicit table or column aliases.

Removed the assumption that every keyword after `AS` is an alias, and extended MSSQL to exclude `IF/ELSE` as alias.

