### PR TITLE
PostgreSQL: Support schema-qualified operator classes in CREATE INDEX

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -61,7 +61,7 @@ use crate::tokenizer::{Span, Token};
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct IndexColumn {
     pub column: OrderByExpr,
-    pub operator_class: Option<Ident>,
+    pub operator_class: Option<ObjectName>,
 }
 
 impl From<Ident> for IndexColumn {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -16892,10 +16892,10 @@ impl<'a> Parser<'a> {
     fn parse_order_by_expr_inner(
         &mut self,
         with_operator_class: bool,
-    ) -> Result<(OrderByExpr, Option<Ident>), ParserError> {
+    ) -> Result<(OrderByExpr, Option<ObjectName>), ParserError> {
         let expr = self.parse_expr()?;
 
-        let operator_class: Option<Ident> = if with_operator_class {
+        let operator_class: Option<ObjectName> = if with_operator_class {
             // We check that if non of the following keywords are present, then we parse an
             // identifier as operator class.
             if self
@@ -16904,7 +16904,7 @@ impl<'a> Parser<'a> {
             {
                 None
             } else {
-                self.maybe_parse(|parser| parser.parse_identifier())?
+                self.maybe_parse(|parser| parser.parse_object_name(false))?
             }
         } else {
             None


### PR DESCRIPTION
This PR adds support for schema-qualified operator classes in PostgreSQL `CREATE INDEX` statements. Previously, the parser only accepted simple identifiers for operator classes (e.g., `vector_cosine_ops`). With this change, schema-qualified names are now supported (e.g., `public.vector_cosine_ops`).

The following SQL is now correctly parsed:
```sql
CREATE INDEX my_index ON my_table USING HNSW (embedding public.vector_cosine_ops);
```