### PR TITLE
Fix parse_identifiers not taking semicolons into account

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12024,7 +12024,7 @@ impl<'a> Parser<'a> {
                 Token::Word(w) => {
                     idents.push(w.clone().into_ident(self.peek_token_ref().span));
                 }
-                Token::EOF | Token::Eq => break,
+                Token::EOF | Token::Eq | Token::SemiColon => break,
                 _ => {}
             }
             self.advance_token();

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -7914,3 +7914,11 @@ fn parse_create_operator_class() {
         )
         .is_err());
 }
+
+#[test]
+fn parse_identifiers_semicolon_handling() {
+    let statement = "SHOW search_path; SELECT 1";
+    pg_and_generic().statements_parse_to(statement, statement);
+    let statement = "SHOW search_path; SHOW ALL; SHOW ALL";
+    pg_and_generic().statements_parse_to(statement, statement);
+}


### PR DESCRIPTION
Related to: https://github.com/apache/datafusion-sqlparser-rs/issues/1994

The PR fixes the issue with semicolons disappearing when `SHOW` statements are parsed. The test prior to the fix would fail as follows:
```
assertion `left == right` failed
  left: "SHOW search_path; SELECT 1"
 right: "SHOW search_path SELECT"
```

The fix adds a `Semicolon` alongside `EOF` and `Eq` which were the only two tokens that triggered a break in `parse_identifiers`. This should not cause any unintended side effects as semicolons are exclusively used for statement ends.

Additional considerations:
- The `parse_show` test requires `SHOW ALL ALL` to be parsed. This is not valid PostgreSQL syntax according to [postgres 18 docs](https://www.postgresql.org/docs/18/sql-show.html) and was not valid since version 7.1 at least. 
- `parse_identifiers` is seemingly supposed to be very relaxed (as indicated by the above test not failing) and also is used only twice in the code base. The first instance is `SHOW`, the other is the `DROP` that comes after a pipe operator for which the current tests do not need the extra flexibility provided by `parse_identifiers`.

I am willing to make a separate PR for modifying the `parse_show` test to use valid PostgreSQL syntax, I am not familiar enough with the code base to do anything with the latter.
