### PR TITLE
MySQL: Support `CAST(... AS ... ARRAY)` syntax

### DIFF
--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1540,6 +1540,7 @@ impl Spanned for Expr {
                 kind: _,
                 expr,
                 data_type: _,
+                array: _,
                 format: _,
             } => expr.span(),
             Expr::AtTimeZone {
@@ -2801,7 +2802,7 @@ WHERE id = 1
             UPDATE SET target_table.description = source_table.description
 
               WHEN MATCHED AND target_table.x != 'X' THEN   DELETE
-        WHEN NOT MATCHED AND 1 THEN INSERT (product, quantity) ROW 
+        WHEN NOT MATCHED AND 1 THEN INSERT (product, quantity) ROW
         "#;
 
         let r = Parser::parse_sql(&crate::dialect::GenericDialect, sql).unwrap();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1650,6 +1650,7 @@ impl<'a> Parser<'a> {
                         kind: CastKind::Cast,
                         expr: Box::new(parser.parse_expr()?),
                         data_type: DataType::Binary(None),
+                        array: false,
                         format: None,
                     })
                 }
@@ -2655,12 +2656,14 @@ impl<'a> Parser<'a> {
         let expr = self.parse_expr()?;
         self.expect_keyword_is(Keyword::AS)?;
         let data_type = self.parse_data_type()?;
+        let array = self.parse_keyword(Keyword::ARRAY);
         let format = self.parse_optional_cast_format()?;
         self.expect_token(&Token::RParen)?;
         Ok(Expr::Cast {
             kind,
             expr: Box::new(expr),
             data_type,
+            array,
             format,
         })
     }
@@ -3939,6 +3942,7 @@ impl<'a> Parser<'a> {
                 kind: CastKind::DoubleColon,
                 expr: Box::new(expr),
                 data_type: self.parse_data_type()?,
+                array: false,
                 format: None,
             })
         } else if Token::ExclamationMark == *tok && self.dialect.supports_factorial_operator() {
@@ -4179,6 +4183,7 @@ impl<'a> Parser<'a> {
             kind: CastKind::DoubleColon,
             expr: Box::new(expr),
             data_type: self.parse_data_type()?,
+            array: false,
             format: None,
         })
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3027,6 +3027,7 @@ fn parse_cast() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
             data_type: DataType::BigInt(None),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3039,6 +3040,7 @@ fn parse_cast() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
             data_type: DataType::TinyInt(None),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3070,6 +3072,7 @@ fn parse_cast() {
                 length: 50,
                 unit: None,
             })),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3082,6 +3085,7 @@ fn parse_cast() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
             data_type: DataType::Clob(None),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3094,6 +3098,7 @@ fn parse_cast() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
             data_type: DataType::Clob(Some(50)),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3106,6 +3111,7 @@ fn parse_cast() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
             data_type: DataType::Binary(Some(50)),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3118,6 +3124,7 @@ fn parse_cast() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
             data_type: DataType::Varbinary(Some(BinaryLength::IntegerLength { length: 50 })),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3130,6 +3137,7 @@ fn parse_cast() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
             data_type: DataType::Blob(None),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3142,6 +3150,7 @@ fn parse_cast() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
             data_type: DataType::Blob(Some(50)),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3154,6 +3163,7 @@ fn parse_cast() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("details"))),
             data_type: DataType::JSONB,
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -3169,6 +3179,7 @@ fn parse_try_cast() {
             kind: CastKind::TryCast,
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
             data_type: DataType::BigInt(None),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -6505,6 +6516,7 @@ fn interval_disallow_interval_expr_double_colon() {
                 fractional_seconds_precision: None,
             })),
             data_type: DataType::Text,
+            array: false,
             format: None,
         }
     )
@@ -9220,6 +9232,7 @@ fn parse_double_colon_cast_at_timezone() {
                         .with_empty_span()
                 )),
                 data_type: DataType::Timestamp(None, TimezoneInfo::None),
+                array: false,
                 format: None
             }),
             time_zone: Box::new(Expr::Value(
@@ -13352,6 +13365,7 @@ fn test_dictionary_syntax() {
                         (Value::SingleQuotedString("2023-04-01".to_owned())).with_empty_span(),
                     )),
                     data_type: DataType::Timestamp(None, TimezoneInfo::None),
+                    array: false,
                     format: None,
                 }),
             },
@@ -13363,6 +13377,7 @@ fn test_dictionary_syntax() {
                         (Value::SingleQuotedString("2023-04-05".to_owned())).with_empty_span(),
                     )),
                     data_type: DataType::Timestamp(None, TimezoneInfo::None),
+                    array: false,
                     format: None,
                 }),
             },
@@ -13606,6 +13621,7 @@ fn test_extract_seconds_ok() {
                     fields: None,
                     precision: None
                 },
+                array: false,
                 format: None,
             }),
         }
@@ -13634,6 +13650,7 @@ fn test_extract_seconds_ok() {
                         fields: None,
                         precision: None,
                     },
+                    array: false,
                     format: None,
                 }),
             })],
@@ -13691,6 +13708,7 @@ fn test_extract_seconds_single_quote_ok() {
                     fields: None,
                     precision: None
                 },
+                array: false,
                 format: None,
             }),
         }

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -349,6 +349,7 @@ fn data_type_timestamp_ntz() {
                 "created_at".into()
             )))),
             data_type: DataType::TimestampNtz(None),
+            array: false,
             format: None
         }
     );

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -380,6 +380,7 @@ fn test_duckdb_specific_int_types() {
                     Value::Number("123".parse().unwrap(), false).with_empty_span()
                 )),
                 data_type: data_type.clone(),
+                array: false,
                 format: None,
             },
             expr_from_projection(&select.projection[0])

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1706,6 +1706,7 @@ fn parse_execute() {
                             (Value::Number("1337".parse().unwrap(), false)).with_empty_span()
                         )),
                         data_type: DataType::SmallInt(None),
+                        array: false,
                         format: None
                     },
                     alias: None
@@ -1717,6 +1718,7 @@ fn parse_execute() {
                             (Value::Number("7331".parse().unwrap(), false)).with_empty_span()
                         )),
                         data_type: DataType::SmallInt(None),
+                        array: false,
                         format: None
                     },
                     alias: None
@@ -2343,6 +2345,7 @@ fn parse_array_index_expr() {
                     ))),
                     None
                 )),
+                array: false,
                 format: None,
             }))),
             access_chain: vec![
@@ -5573,6 +5576,7 @@ fn parse_at_time_zone() {
                     Value::SingleQuotedString("America/Los_Angeles".to_owned()).with_empty_span(),
                 )),
                 data_type: DataType::Text,
+                array: false,
                 format: None,
             }),
         }),
@@ -6389,6 +6393,7 @@ fn arrow_cast_precedence() {
                     (Value::SingleQuotedString("bar".to_string())).with_empty_span()
                 )),
                 data_type: DataType::Text,
+                array: false,
                 format: None,
             }),
         }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1101,8 +1101,8 @@ fn parse_create_dynamic_table() {
         " EXTERNAL_VOLUME='my_external_volume'",
         " CATALOG='SNOWFLAKE'",
         " BASE_LOCATION='my_iceberg_table'",
-        " TARGET_LAG='20 minutes'", 
-        " WAREHOUSE=mywh",       
+        " TARGET_LAG='20 minutes'",
+        " WAREHOUSE=mywh",
         " AS SELECT product_id, product_name FROM staging_table"
     ));
 
@@ -1250,6 +1250,7 @@ fn parse_array() {
             kind: CastKind::Cast,
             expr: Box::new(Expr::Identifier(Ident::new("a"))),
             data_type: DataType::Array(ArrayElemTypeDef::None),
+            array: false,
             format: None,
         },
         expr_from_projection(only(&select.projection))
@@ -1349,8 +1350,6 @@ fn parse_semi_structured_data_traversal() {
         Expr::JsonAccess {
             value: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                data_type: DataType::Array(ArrayElemTypeDef::None),
-                format: None,
                 expr: Box::new(Expr::JsonAccess {
                     value: Box::new(Expr::Identifier(Ident::new("a"))),
                     path: JsonPath {
@@ -1359,7 +1358,10 @@ fn parse_semi_structured_data_traversal() {
                             quoted: false
                         }]
                     }
-                })
+                }),
+                data_type: DataType::Array(ArrayElemTypeDef::None),
+                array: false,
+                format: None,
             }),
             path: JsonPath {
                 path: vec![JsonPathElem::Bracket {


### PR DESCRIPTION
MySQL has a special case in `CAST` parsing where the type can be followed by `ARRAY`. This is only used for creating multi-valued indexes in InnoDB, so is only allowed in `CREATE TABLE` and other DDL statements when specifying keys. See the [docs].

Given those restrictions, we could be significantly more restrictive in parsing this, e.g. not parsing `ARRAY` unless we are in a key specification. Or, if there was such a thing as a suffix array type definition, we could parse it as a type. But as far as I know, that doesn't exist in any supported SQL dialects, and encountering `ARRAY` here is unambiguous. So it seemed simplest to be permissive and always parse it. The only downside I can see is we are now adding a field to `Expr::Cast`. 

[docs]: https://dev.mysql.com/doc/refman/8.4/en/cast-functions.html#function_cast