### PR TITLE
MySQL: Parse bitwise shift left/right operators

### DIFF
--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -43,6 +43,10 @@ impl Dialect for DuckDbDialect {
         true
     }
 
+    fn supports_bitwise_shift_operators(&self) -> bool {
+        true
+    }
+
     fn supports_named_fn_args_with_eq_operator(&self) -> bool {
         true
     }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -132,6 +132,10 @@ impl Dialect for GenericDialect {
         true
     }
 
+    fn supports_bitwise_shift_operators(&self) -> bool {
+        true
+    }
+
     fn supports_comment_on(&self) -> bool {
         true
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -894,6 +894,11 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports `<<` and `>>` shift operators.
+    fn supports_bitwise_shift_operators(&self) -> bool {
+        false
+    }
+
     /// Returns true if the dialect supports nested comments
     /// e.g. `/* /* nested */ */`
     fn supports_nested_comments(&self) -> bool {

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -84,6 +84,10 @@ impl Dialect for MySqlDialect {
         true
     }
 
+    fn supports_bitwise_shift_operators(&self) -> bool {
+        true
+    }
+
     fn parse_infix(
         &self,
         parser: &mut crate::parser::Parser,

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -199,6 +199,10 @@ impl Dialect for PostgreSqlDialect {
         true
     }
 
+    fn supports_bitwise_shift_operators(&self) -> bool {
+        true
+    }
+
     /// see <https://www.postgresql.org/docs/current/sql-comment.html>
     fn supports_comment_on(&self) -> bool {
         true

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -120,6 +120,10 @@ impl Dialect for RedshiftSqlDialect {
         true
     }
 
+    fn supports_bitwise_shift_operators(&self) -> bool {
+        true
+    }
+
     fn supports_array_typedef_with_brackets(&self) -> bool {
         true
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3485,10 +3485,10 @@ impl<'a> Parser<'a> {
             Token::DuckIntDiv if dialect_is!(dialect is DuckDbDialect | GenericDialect) => {
                 Some(BinaryOperator::DuckIntegerDivide)
             }
-            Token::ShiftLeft if dialect_is!(dialect is PostgreSqlDialect | DuckDbDialect | GenericDialect | RedshiftSqlDialect | MySqlDialect) => {
+            Token::ShiftLeft if dialect.supports_bitwise_shift_operators() => {
                 Some(BinaryOperator::PGBitwiseShiftLeft)
             }
-            Token::ShiftRight if dialect_is!(dialect is PostgreSqlDialect | DuckDbDialect | GenericDialect | RedshiftSqlDialect | MySqlDialect) => {
+            Token::ShiftRight if dialect.supports_bitwise_shift_operators() => {
                 Some(BinaryOperator::PGBitwiseShiftRight)
             }
             Token::Sharp if dialect_is!(dialect is PostgreSqlDialect | RedshiftSqlDialect) => {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2370,6 +2370,29 @@ fn parse_bitwise_ops() {
 }
 
 #[test]
+fn parse_bitwise_shift_ops() {
+    let dialects = all_dialects_where(|d| d.supports_bitwise_shift_operators());
+    let sql = "SELECT 1 << 2, 3 >> 4";
+    let select = dialects.verified_only_select(sql);
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::BinaryOp {
+            left: Box::new(Expr::Value((number("1")).with_empty_span())),
+            op: BinaryOperator::PGBitwiseShiftLeft,
+            right: Box::new(Expr::Value((number("2")).with_empty_span())),
+        }),
+        select.projection[0]
+    );
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::BinaryOp {
+            left: Box::new(Expr::Value((number("3")).with_empty_span())),
+            op: BinaryOperator::PGBitwiseShiftRight,
+            right: Box::new(Expr::Value((number("4")).with_empty_span())),
+        }),
+        select.projection[1]
+    );
+}
+
+#[test]
 fn parse_binary_any() {
     let select = verified_only_select("SELECT a = ANY(b)");
     assert_eq!(

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3766,28 +3766,6 @@ fn parse_logical_xor() {
 }
 
 #[test]
-fn parse_bitwise_shift_ops() {
-    let sql = "SELECT 1 << 2, 8 >> 3";
-    let select = mysql().verified_only_select(sql);
-    assert_eq!(
-        SelectItem::UnnamedExpr(Expr::BinaryOp {
-            left: Box::new(Expr::Value((number("1")).with_empty_span())),
-            op: BinaryOperator::PGBitwiseShiftLeft,
-            right: Box::new(Expr::Value((number("2")).with_empty_span())),
-        }),
-        select.projection[0]
-    );
-    assert_eq!(
-        SelectItem::UnnamedExpr(Expr::BinaryOp {
-            left: Box::new(Expr::Value((number("8")).with_empty_span())),
-            op: BinaryOperator::PGBitwiseShiftRight,
-            right: Box::new(Expr::Value((number("3")).with_empty_span())),
-        }),
-        select.projection[1]
-    );
-}
-
-#[test]
 fn parse_bitstring_literal() {
     let select = mysql_and_generic().verified_only_select("SELECT B'111'");
     assert_eq!(


### PR DESCRIPTION
According to the [docs], MySQL supports `<<` and `>>` operators. They are currently named `PGBitwiseShiftLeft` and `PGBitwiseShiftRight`, respectively, so the name is a bit misleading, but doesn't see worth changing at the moment.

[docs]: https://dev.mysql.com/doc/refman/8.4/en/bit-functions.html