### PR TITLE
 feat: Add dialect-aware SQL serialization with `ToSql` trait for ClickHouse PascalCase types

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -496,6 +496,101 @@ pub enum DataType {
     TsQuery,
 }
 
+use crate::dialect::Dialect;
+
+impl DataType {
+    /// Formats the data type as a SQL string with dialect-specific formatting.
+    ///
+    /// For dialects that require PascalCase type names (like ClickHouse), this method
+    /// outputs types in PascalCase (e.g., `String`, `Int64`, `Nullable`).
+    /// For other dialects, it uses the standard uppercase formatting (e.g., `STRING`, `INT64`).
+    ///
+    /// # Example
+    /// ```
+    /// use sqlparser::ast::DataType;
+    /// use sqlparser::dialect::{ClickHouseDialect, GenericDialect};
+    ///
+    /// let dt = DataType::Int64;
+    ///
+    /// // ClickHouse requires PascalCase
+    /// assert_eq!(dt.to_sql(&ClickHouseDialect {}), "Int64");
+    ///
+    /// // Other dialects use uppercase
+    /// assert_eq!(dt.to_sql(&GenericDialect {}), "INT64");
+    /// ```
+    pub fn to_sql(&self, dialect: &dyn Dialect) -> String {
+        if dialect.requires_pascalcase_types() {
+            self.to_sql_pascalcase()
+        } else {
+            self.to_string()
+        }
+    }
+
+    /// Formats the data type with PascalCase type names (for ClickHouse compatibility).
+    fn to_sql_pascalcase(&self) -> String {
+        match self {
+            // Types that need PascalCase conversion (currently uppercase in Display)
+            DataType::Int8(zerofill) => format_type_pascalcase("Int8", zerofill),
+            DataType::Int64 => "Int64".to_string(),
+            DataType::Float64 => "Float64".to_string(),
+            DataType::String(size) => match size {
+                Some(s) => format!("String({s})"),
+                None => "String".to_string(),
+            },
+            DataType::Bool => "Bool".to_string(),
+            DataType::Boolean => "Boolean".to_string(),
+            DataType::Date => "Date".to_string(),
+            DataType::Datetime(precision) => match precision {
+                Some(p) => format!("DateTime({p})"),
+                None => "DateTime".to_string(),
+            },
+
+            // Container types that need recursive PascalCase formatting
+            DataType::Nullable(inner) => format!("Nullable({})", inner.to_sql_pascalcase()),
+            DataType::LowCardinality(inner) => {
+                format!("LowCardinality({})", inner.to_sql_pascalcase())
+            }
+            DataType::Array(elem) => match elem {
+                ArrayElemTypeDef::None => "Array".to_string(),
+                ArrayElemTypeDef::SquareBracket(t, None) => format!("{}[]", t.to_sql_pascalcase()),
+                ArrayElemTypeDef::SquareBracket(t, Some(size)) => {
+                    format!("{}[{size}]", t.to_sql_pascalcase())
+                }
+                ArrayElemTypeDef::AngleBracket(t) => format!("Array<{}>", t.to_sql_pascalcase()),
+                ArrayElemTypeDef::Parenthesis(t) => format!("Array({})", t.to_sql_pascalcase()),
+            },
+            DataType::Map(key, value) => {
+                format!(
+                    "Map({}, {})",
+                    key.to_sql_pascalcase(),
+                    value.to_sql_pascalcase()
+                )
+            }
+            DataType::Tuple(fields) => {
+                let fields_str: Vec<String> = fields
+                    .iter()
+                    .map(|f| match &f.field_name {
+                        Some(name) => format!("{} {}", name, f.field_type.to_sql_pascalcase()),
+                        None => f.field_type.to_sql_pascalcase(),
+                    })
+                    .collect();
+                format!("Tuple({})", fields_str.join(", "))
+            }
+
+            // All other types use the default Display implementation
+            _ => self.to_string(),
+        }
+    }
+}
+
+/// Helper function to format a type name with optional length in PascalCase
+fn format_type_pascalcase(type_name: &str, len: &Option<u64>) -> String {
+    match len {
+        Some(l) => format!("{type_name}({l})"),
+        None => type_name.to_string(),
+    }
+}
+
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/ast/to_sql.rs
+++ b/src/ast/to_sql.rs
@@ -1,0 +1,171 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Dialect-aware SQL serialization traits and utilities.
+//!
+//! This module provides the [`ToSql`] trait for converting AST nodes to SQL strings
+//! with dialect-specific formatting. This is necessary because some SQL dialects
+//! (like ClickHouse) require specific casing for type names that differs from the
+//! standard uppercase convention.
+//!
+//! # Example
+//!
+//! ```
+//! use sqlparser::ast::ToSql;
+//! use sqlparser::dialect::ClickHouseDialect;
+//! use sqlparser::parser::Parser;
+//!
+//! let sql = "CREATE TABLE t (col String)";
+//! let dialect = ClickHouseDialect {};
+//! let ast = Parser::parse_sql(&dialect, sql).unwrap();
+//!
+//! // Dialect-aware serialization preserves ClickHouse's PascalCase types
+//! let regenerated = ast[0].to_sql(&dialect);
+//! assert!(regenerated.contains("String"));
+//! ```
+//!
+//! # Design Rationale
+//!
+//! The existing `Display` trait implementation cannot be made dialect-aware because
+//! `fmt::Display::fmt` has a fixed signature that doesn't accept dialect context.
+//! Rather than changing `Display` (which would be a breaking change), we introduce
+//! `ToSql` as a separate trait that accepts a `&dyn Dialect` parameter.
+//!
+//! ## Key Design Decisions
+//!
+//! 1. **Coexistence with Display**: `ToSql` and `Display` coexist. `Display` continues
+//!    to provide standard SQL formatting (uppercase types), while `ToSql` enables
+//!    dialect-specific formatting.
+//!
+//! 2. **Macro for Delegation**: Types that don't contain `DataType` fields use the
+//!    [`impl_to_sql_display!`] macro to delegate `ToSql::write_sql` to their `Display`
+//!    implementation. This avoids code duplication (DRY principle).
+//!
+//! 3. **Recursive Propagation**: Types containing `DataType` fields implement `write_sql`
+//!    explicitly, calling `write_sql` recursively on nested types to propagate dialect
+//!    context through the AST tree.
+//!
+//! # Coverage
+//!
+//! The `ToSql` trait is implemented for all major AST types that users are likely to
+//! serialize, including:
+//!
+//! - `Statement`, `Query`, `Select`, `Expr`
+//! - `CreateTable`, `AlterTable`, `CreateView`, `CreateFunction`
+//! - `DataType`, `ColumnDef`, `ViewColumnDef`
+//! - `Function`, `WindowSpec`, `OrderByExpr`
+//! - And many more supporting types
+//!
+//! # Migration from Display
+//!
+//! If you currently use `format!("{}", statement)` or `statement.to_string()` and need
+//! dialect-aware formatting, change to:
+//!
+//! ```ignore
+//! use sqlparser::ast::ToSql;
+//! let sql = statement.to_sql(&dialect);
+//! ```
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+use core::fmt::{self, Write};
+
+use crate::dialect::Dialect;
+
+/// Trait for dialect-aware SQL serialization.
+///
+/// Types implementing this trait can be converted to SQL strings while respecting
+/// dialect-specific formatting rules, such as ClickHouse's requirement for
+/// PascalCase type names.
+///
+/// The default `to_sql` implementation calls `write_sql` with a string buffer.
+/// Types should implement `write_sql` to perform the actual formatting.
+pub trait ToSql {
+    /// Converts this AST node to a SQL string using dialect-specific formatting.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sqlparser::ast::{DataType, ToSql};
+    /// use sqlparser::dialect::{ClickHouseDialect, GenericDialect};
+    ///
+    /// let dt = DataType::Int64;
+    ///
+    /// // ClickHouse requires PascalCase
+    /// assert_eq!(dt.to_sql(&ClickHouseDialect {}), "Int64");
+    ///
+    /// // Other dialects use uppercase
+    /// assert_eq!(dt.to_sql(&GenericDialect {}), "INT64");
+    /// ```
+    fn to_sql(&self, dialect: &dyn Dialect) -> String {
+        let mut s = String::new();
+        // write_sql should not fail when writing to a String
+        self.write_sql(&mut s, dialect).unwrap();
+        s
+    }
+
+    /// Writes this AST node as SQL to the given formatter using dialect-specific formatting.
+    ///
+    /// Implementors should use this method to perform the actual SQL generation,
+    /// calling `write_sql` on nested types that contain dialect-sensitive elements
+    /// (like `DataType`).
+    fn write_sql(&self, f: &mut dyn Write, dialect: &dyn Dialect) -> fmt::Result;
+}
+
+/// Macro to implement `ToSql` by delegating to `Display`.
+///
+/// Use this macro for types that don't contain `DataType` fields and can
+/// safely use their existing `Display` implementation for all dialects.
+///
+/// # Example
+///
+/// ```ignore
+/// impl_to_sql_display!(CreateDatabase, CreateSchema, CreateIndex);
+/// ```
+#[macro_export]
+macro_rules! impl_to_sql_display {
+    ($($t:ty),+ $(,)?) => {
+        $(
+            impl $crate::ast::ToSql for $t {
+                fn write_sql(
+                    &self,
+                    f: &mut dyn ::core::fmt::Write,
+                    _dialect: &dyn $crate::dialect::Dialect,
+                ) -> ::core::fmt::Result {
+                    write!(f, "{}", self)
+                }
+            }
+        )+
+    };
+}
+
+/// Helper to write a comma-separated list of items using dialect-aware formatting.
+pub fn write_comma_separated_tosql<T: ToSql>(
+    f: &mut dyn Write,
+    items: &[T],
+    dialect: &dyn Dialect,
+) -> fmt::Result {
+    let mut first = true;
+    for item in items {
+        if !first {
+            write!(f, ", ")?;
+        }
+        first = false;
+        item.write_sql(f, dialect)?;
+    }
+    Ok(())
+}

--- a/src/dialect/clickhouse.rs
+++ b/src/dialect/clickhouse.rs
@@ -100,4 +100,12 @@ impl Dialect for ClickHouseDialect {
     fn supports_nested_comments(&self) -> bool {
         true
     }
+
+    /// ClickHouse requires PascalCase for type names (e.g., `String`, `Int64`, `Nullable`).
+    /// Using uppercase like `STRING` or `INT64` results in `UNKNOWN_TYPE` errors.
+    ///
+    /// See <https://clickhouse.com/docs/en/sql-reference/data-types>
+    fn requires_pascalcase_types(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1216,6 +1216,18 @@ pub trait Dialect: Debug + Any {
     fn supports_quote_delimited_string(&self) -> bool {
         false
     }
+
+    /// Returns true if the dialect requires PascalCase for type names.
+    ///
+    /// ClickHouse requires PascalCase type names (e.g., `String`, `Int64`, `Nullable`).
+    /// Other dialects like BigQuery and PostgreSQL use uppercase (e.g., `STRING`, `INT64`).
+    ///
+    /// This affects how data types are formatted when using dialect-aware SQL generation.
+    ///
+    /// [ClickHouse data types](https://clickhouse.com/docs/en/sql-reference/data-types)
+    fn requires_pascalcase_types(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined


### PR DESCRIPTION
## feat: Add dialect-aware SQL serialization with `ToSql` trait for ClickHouse PascalCase types

### Summary

This PR introduces a new `ToSql` trait that enables dialect-aware SQL serialization, specifically addressing ClickHouse's requirement for PascalCase type names (e.g., `String`, `Int64`, `Nullable(String)`) instead of the standard uppercase convention (`STRING`, `INT64`).

**Related Issue:** https://github.com/apache/datafusion-sqlparser-rs/issues/2153

### Problem

ClickHouse is case-sensitive for data type names and requires PascalCase. When using `sqlparser-rs` to parse and regenerate SQL:

```rust
let sql = "CREATE TABLE t (col String)";
let ast = Parser::parse_sql(&dialect, sql)?;
let regenerated = format!("{}", ast[0]);  // Produces "CREATE TABLE t (col STRING)"
```

The regenerated SQL fails with `UNKNOWN_TYPE` errors when executed against ClickHouse because `STRING` is not recognized—only `String` is valid.

### Solution

Introduce a `ToSql` trait that accepts dialect context:

```rust
pub trait ToSql {
    fn to_sql(&self, dialect: &dyn Dialect) -> String;
    fn write_sql(&self, f: &mut dyn Write, dialect: &dyn Dialect) -> fmt::Result;
}
```

Usage:
```rust
use sqlparser::ast::ToSql;

let sql = "CREATE TABLE t (col String)";
let ast = Parser::parse_sql(&ClickHouseDialect {}, sql)?;
let regenerated = ast[0].to_sql(&ClickHouseDialect {});
// Produces: "CREATE TABLE t (col String)" ✓
```

### Design Decisions

1. **Coexistence with `Display`**: The existing `Display` trait continues to work unchanged (uppercase types). `ToSql` is opt-in for users who need dialect-aware formatting.

2. **`impl_to_sql_display!` macro**: Types without `DataType` fields delegate to their `Display` implementation via macro, avoiding code duplication.

3. **Recursive propagation**: Types containing `DataType` fields implement `write_sql` explicitly, calling `write_sql` on nested types to propagate dialect context through the AST.

4. **`requires_pascalcase_types()` dialect method**: A new method on the `Dialect` trait that returns `true` for ClickHouse.

### Changes

| File | Description |
|------|-------------|
| `src/ast/to_sql.rs` | New module with `ToSql` trait, `impl_to_sql_display!` macro, and helpers |
| `src/ast/data_type.rs` | `ToSql` impl for `DataType` with PascalCase formatting |
| `src/ast/mod.rs` | `ToSql` impls for `Expr`, `Statement`, `Function`, window types, etc. |
| `src/ast/ddl.rs` | `ToSql` impls for `CreateTable`, `AlterTable`, `ColumnDef`, etc. |
| `src/ast/query.rs` | `ToSql` impls for `Query`, `Select`, `TableFactor`, etc. |
| `src/dialect/mod.rs` | Add `requires_pascalcase_types()` to `Dialect` trait |
| `src/dialect/clickhouse.rs` | Override `requires_pascalcase_types()` to return `true` |
| `tests/sqlparser_clickhouse.rs` | Comprehensive tests including round-trip verification |

### Coverage

`ToSql` is implemented for all major AST types users are likely to serialize:

- **Statements**: `Statement`, `Query`, `Select`, `CreateTable`, `AlterTable`, `CreateView`, `CreateFunction`, `Declare`, `Prepare`
- **Expressions**: `Expr` (all variants including `Cast`, `Case`, `BinaryOp`, `Function`, etc.)
- **Types**: `DataType`, `ColumnDef`, `ViewColumnDef`, `StructField`, `UnionField`
- **Query components**: `TableFactor`, `Join`, `OrderByExpr`, `WindowSpec`, `Cte`, `With`
- **Functions**: `Function`, `FunctionArg`, `FunctionArguments`, window functions

### Testing

Added 8 new tests covering:
- Basic `DataType` PascalCase formatting
- `CREATE TABLE` with nested types (`Nullable`, `Array`, `Map`)
- `ALTER TABLE` operations
- `SELECT` with `CAST` expressions
- Complex expressions (`CASE`, nested `CAST`)
- `CREATE VIEW` statements
- **Round-trip test**: parse → `to_sql` → parse → verify equivalence

```
test result: ok. 55 passed; 0 failed (ClickHouse tests)
```

### Migration Guide

If you currently use `Display` and need dialect-aware formatting:

```rust
// Before
let sql = format!("{}", statement);

// After
use sqlparser::ast::ToSql;
let sql = statement.to_sql(&dialect);
```

### Breaking Changes

None. This is a purely additive change. Existing code using `Display` continues to work unchanged.

Disclaimer: This was worked on with AI