### PR TITLE
Redshift: Support implicit string concatenation using newline

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -489,6 +489,19 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports concatenating string literals with a newline.
+    /// For example, the following statement would return `true`:
+    /// ```sql
+    /// SELECT 'abc' in (
+    ///   'a'
+    ///   'b'
+    ///   'c'
+    /// );
+    /// ```
+    fn supports_string_literal_concatenation_with_newline(&self) -> bool {
+        false
+    }
+
     /// Does the dialect support trailing commas in the projection list?
     fn supports_projection_trailing_commas(&self) -> bool {
         self.supports_trailing_commas()

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -147,4 +147,8 @@ impl Dialect for RedshiftSqlDialect {
     fn supports_create_table_like_parenthesized(&self) -> bool {
         true
     }
+
+    fn supports_string_literal_concatenation_with_newline(&self) -> bool {
+        true
+    }
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -17647,6 +17647,25 @@ fn parse_adjacent_string_literal_concatenation() {
 
     let sql = "SELECT * FROM t WHERE col = 'Hello' \n ' ' \t 'World!'";
     dialects.one_statement_parses_to(sql, r"SELECT * FROM t WHERE col = 'Hello World!'");
+
+    let dialects = all_dialects_where(|d| d.supports_string_literal_concatenation_with_newline());
+    let sql = r#"
+    SELECT 'abc' in ('a'
+        'b'
+        'c',
+        'd'
+    )"#;
+    dialects.one_statement_parses_to(sql, "SELECT 'abc' IN ('abc', 'd')");
+
+    let sql = r#"
+    SELECT 'abc' in ('a'
+        'b'
+        -- COMMENT
+        'c',
+        -- COMMENT
+        'd'
+    )"#;
+    dialects.one_statement_parses_to(sql, "SELECT 'abc' IN ('abc', 'd')");
 }
 
 #[test]


### PR DESCRIPTION
We've encountered a statement of the following form that failed to parse due to a missing comma, that is accepted by Redshift:
```sql
SELECT 'ab' IN (
   'a'
   'b'
)
```

Turns out Redshift considers the `'a' <NEWLINE> 'b'` as a concatenation, so it's evaluted as `'ab'`. The fix here is to parse this construct as `'ab'`.