### PR TITLE
perf: remove unnecessary string clone in maybe_concat_string_literal

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11299,7 +11299,7 @@ impl<'a> Parser<'a> {
             while let Token::SingleQuotedString(ref s) | Token::DoubleQuotedString(ref s) =
                 self.peek_token_ref().token
             {
-                str.push_str(s.clone().as_str());
+                str.push_str(s);
                 self.advance_token();
             }
         }


### PR DESCRIPTION
## Summary

Remove an unnecessary `String::clone()` in `maybe_concat_string_literal()`.

## Changes

```rust
// Before:
str.push_str(s.clone().as_str());

// After:
str.push_str(s);
```

Since `s` is already a `&String` (from the `ref s` pattern match), it can be passed directly to `push_str()` which accepts `&str`. The deref coercion handles the conversion automatically.

## Impact

This removes one heap allocation per concatenated string literal when parsing SQL with adjacent string literals like:

```sql
SELECT 'foo' 'bar'  -- Concatenates to 'foobar'
```

Small change but in the spirit of avoiding unnecessary allocations in the parser hot path.

## Test plan

- [x] All existing tests pass
- [x] `cargo clippy` passes

🤖 Generated with [Claude Code](https://claude.ai/code)