### PR TITLE
minor: reduce unnecessary string allocations

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4921,9 +4921,9 @@ impl fmt::Display for Statement {
                     f,
                     "{tables}{read}{export}",
                     tables = if !tables.is_empty() {
-                        " ".to_string() + &display_comma_separated(tables).to_string()
+                        format!(" {}", display_comma_separated(tables))
                     } else {
-                        "".to_string()
+                        String::new()
                     },
                     export = if *export { " FOR EXPORT" } else { "" },
                     read = if *read_lock { " WITH READ LOCK" } else { "" }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11146,16 +11146,14 @@ impl<'a> Parser<'a> {
     /// Parse a single tab-separated value row used by `COPY` payload parsing.
     pub fn parse_tab_value(&mut self) -> Vec<Option<String>> {
         let mut values = vec![];
-        let mut content = String::from("");
+        let mut content = String::new();
         while let Some(t) = self.next_token_no_skip().map(|t| &t.token) {
             match t {
                 Token::Whitespace(Whitespace::Tab) => {
-                    values.push(Some(content.to_string()));
-                    content.clear();
+                    values.push(Some(core::mem::take(&mut content)));
                 }
                 Token::Whitespace(Whitespace::Newline) => {
-                    values.push(Some(content.to_string()));
-                    content.clear();
+                    values.push(Some(core::mem::take(&mut content)));
                 }
                 Token::Backslash => {
                     if self.consume_token(&Token::Period) {
@@ -11280,7 +11278,7 @@ impl<'a> Parser<'a> {
                     Token::Number(w, false) => Ok(Ident::with_span(next_token.span, w)),
                     _ => self.expected("placeholder", next_token),
                 }?;
-                Ok(Value::Placeholder(tok.to_string() + &ident.value)
+                Ok(Value::Placeholder(format!("{tok}{}", ident.value))
                     .with_span(Span::new(span.start, ident.span.end)))
             }
             unexpected => self.expected(

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1755,7 +1755,7 @@ impl<'a> Tokenizer<'a> {
                 '?' => {
                     chars.next();
                     let s = peeking_take_while(chars, |ch| ch.is_numeric());
-                    Ok(Some(Token::Placeholder(String::from("?") + &s)))
+                    Ok(Some(Token::Placeholder(format!("?{s}"))))
                 }
 
                 // identifier or keyword
@@ -1904,7 +1904,7 @@ impl<'a> Tokenizer<'a> {
                     }
                 }
             } else {
-                return Ok(Token::Placeholder(String::from("$") + &value));
+                return Ok(Token::Placeholder(format!("${value}")));
             }
         }
 


### PR DESCRIPTION
## Summary

Replace string concatenation patterns with more efficient alternatives.

**Changes:**

1. **Tokenizer** - Replace `String::from() + &str` with `format!()`:
   ```rust
   // Before
   Token::Placeholder(String::from("?") + &s)
   Token::Placeholder(String::from("$") + &value)

   // After
   Token::Placeholder(format!("?{s}"))
   Token::Placeholder(format!("${value}"))
   ```

2. **Parser** - Replace placeholder value concatenation:
   ```rust
   // Before
   tok.to_string() + &ident.value

   // After
   format!("{tok}{}", ident.value)
   ```

3. **AST Display** - Replace string concatenation in FLUSH statement:
   ```rust
   // Before
   " ".to_string() + &display_comma_separated(tables).to_string()

   // After
   format!(" {}", display_comma_separated(tables))
   ```

4. **Parser COPY TSV** - Avoid unnecessary clone:
   ```rust
   // Before
   let mut content = String::from("");
   values.push(Some(content.to_string()));
   content.clear();

   // After
   let mut content = String::new();
   values.push(Some(std::mem::take(&mut content)));
   ```

The `format!()` macro calculates required capacity upfront and allocates once. `std::mem::take()` moves the String instead of cloning it.

## Test plan

- [x] All existing tests pass
- [x] `cargo clippy` passes

🤖 Generated with [Claude Code](https://claude.ai/code)
