### PR TITLE
PostgreSQL: Fix REPLICA IDENTITY to use NOTHING

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -99,8 +99,8 @@ impl fmt::Display for IndexColumn {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum ReplicaIdentity {
-    /// No replica identity (`REPLICA IDENTITY NONE`).
-    None,
+    /// No replica identity (`REPLICA IDENTITY NOTHING`).
+    Nothing,
     /// Full replica identity (`REPLICA IDENTITY FULL`).
     Full,
     /// Default replica identity (`REPLICA IDENTITY DEFAULT`).
@@ -112,7 +112,7 @@ pub enum ReplicaIdentity {
 impl fmt::Display for ReplicaIdentity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ReplicaIdentity::None => f.write_str("NONE"),
+            ReplicaIdentity::Nothing => f.write_str("NOTHING"),
             ReplicaIdentity::Full => f.write_str("FULL"),
             ReplicaIdentity::Default => f.write_str("DEFAULT"),
             ReplicaIdentity::Index(idx) => write!(f, "USING INDEX {idx}"),
@@ -1893,7 +1893,7 @@ pub enum ColumnOption {
     /// [ MATCH { FULL | PARTIAL | SIMPLE } ]
     /// { [ON DELETE <referential_action>] [ON UPDATE <referential_action>] |
     ///   [ON UPDATE <referential_action>] [ON DELETE <referential_action>]
-    /// }         
+    /// }
     /// [<constraint_characteristics>]
     /// `).
     ForeignKey(ForeignKeyConstraint),
@@ -4345,7 +4345,7 @@ impl Spanned for CreateExtension {
     }
 }
 
-/// DROP EXTENSION statement  
+/// DROP EXTENSION statement
 /// Note: this is a PostgreSQL-specific statement
 ///
 /// # References

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10119,8 +10119,8 @@ impl<'a> Parser<'a> {
             let value = self.parse_number_value()?;
             AlterTableOperation::AutoIncrement { equals, value }
         } else if self.parse_keywords(&[Keyword::REPLICA, Keyword::IDENTITY]) {
-            let identity = if self.parse_keyword(Keyword::NONE) {
-                ReplicaIdentity::None
+            let identity = if self.parse_keyword(Keyword::NOTHING) {
+                ReplicaIdentity::Nothing
             } else if self.parse_keyword(Keyword::FULL) {
                 ReplicaIdentity::Full
             } else if self.parse_keyword(Keyword::DEFAULT) {
@@ -10129,7 +10129,7 @@ impl<'a> Parser<'a> {
                 ReplicaIdentity::Index(self.parse_identifier()?)
             } else {
                 return self.expected(
-                    "NONE, FULL, DEFAULT, or USING INDEX index_name after REPLICA IDENTITY",
+                    "NOTHING, FULL, DEFAULT, or USING INDEX index_name after REPLICA IDENTITY",
                     self.peek_token(),
                 );
             };

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -6568,6 +6568,30 @@ fn parse_alter_table_replica_identity() {
         }
         _ => unreachable!(),
     }
+
+    match pg_and_generic().verified_stmt("ALTER TABLE foo REPLICA IDENTITY NOTHING") {
+        Statement::AlterTable(AlterTable { operations, .. }) => {
+            assert_eq!(
+                operations,
+                vec![AlterTableOperation::ReplicaIdentity {
+                    identity: ReplicaIdentity::Nothing
+                }]
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    match pg_and_generic().verified_stmt("ALTER TABLE foo REPLICA IDENTITY DEFAULT") {
+        Statement::AlterTable(AlterTable { operations, .. }) => {
+            assert_eq!(
+                operations,
+                vec![AlterTableOperation::ReplicaIdentity {
+                    identity: ReplicaIdentity::Default
+                }]
+            );
+        }
+        _ => unreachable!(),
+    }
 }
 
 #[test]


### PR DESCRIPTION
PR #1844 added `REPLICA IDENTITY` support, but mistakenly used `NONE` instead of `NOTHING`.