### PR TITLE
Add ENFORCED/NOT ENFORCED support for column-level CHECK constraints

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8911,11 +8911,20 @@ impl<'a> Parser<'a> {
             // since `CHECK` requires parentheses, we can parse the inner expression in ParserState::Normal
             let expr: Expr = self.with_state(ParserState::Normal, |p| p.parse_expr())?;
             self.expect_token(&Token::RParen)?;
+
+            let enforced = if self.parse_keyword(Keyword::ENFORCED) {
+                Some(true)
+            } else if self.parse_keywords(&[Keyword::NOT, Keyword::ENFORCED]) {
+                Some(false)
+            } else {
+                None
+            };
+
             Ok(Some(
                 CheckConstraint {
                     name: None, // Column-level check constraints don't have names
                     expr: Box::new(expr),
-                    enforced: None, // Could be extended later to support MySQL ENFORCED/NOT ENFORCED
+                    enforced,
                 }
                 .into(),
             ))

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -16835,6 +16835,15 @@ fn check_enforced() {
 }
 
 #[test]
+fn column_check_enforced() {
+    all_dialects().verified_stmt("CREATE TABLE t (x INT CHECK (x > 1) NOT ENFORCED)");
+    all_dialects().verified_stmt("CREATE TABLE t (x INT CHECK (x > 1) ENFORCED)");
+    all_dialects().verified_stmt(
+        "CREATE TABLE t (a INT CHECK (a > 0) NOT ENFORCED, b INT CHECK (b > 0) ENFORCED, c INT CHECK (c > 0))",
+    );
+}
+
+#[test]
 fn join_precedence() {
     all_dialects_except(|d| !d.supports_left_associative_joins_without_parens())
         .verified_query_with_canonical(


### PR DESCRIPTION
This was already implemented for table level check constraints. We just add it to column level check constraints as well.