### PR TITLE
PostgreSQL: Add support for `*` (descendant) option in TRUNCATE

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -6412,10 +6412,18 @@ pub struct TruncateTableTarget {
     /// name of the table being truncated
     #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
     pub name: ObjectName,
-    /// Postgres-specific option
-    /// [ TRUNCATE TABLE ONLY ]
+    /// Postgres-specific option: explicitly exclude descendants (also default without ONLY)
+    /// ```sql
+    /// TRUNCATE TABLE ONLY name
+    /// ```
     /// <https://www.postgresql.org/docs/current/sql-truncate.html>
     pub only: bool,
+    /// Postgres-specific option: asterisk after table name to explicitly indicate descendants
+    /// ```sql
+    /// TRUNCATE TABLE name [ * ]
+    /// ```
+    /// <https://www.postgresql.org/docs/current/sql-truncate.html>
+    pub has_asterisk: bool,
 }
 
 impl fmt::Display for TruncateTableTarget {
@@ -6423,7 +6431,11 @@ impl fmt::Display for TruncateTableTarget {
         if self.only {
             write!(f, "ONLY ")?;
         };
-        write!(f, "{}", self.name)
+        write!(f, "{}", self.name)?;
+        if self.has_asterisk {
+            write!(f, " *")?;
+        };
+        Ok(())
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1056,13 +1056,16 @@ impl<'a> Parser<'a> {
         let table = self.parse_keyword(Keyword::TABLE);
         let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
 
-        let table_names = self
-            .parse_comma_separated(|p| {
-                Ok((p.parse_keyword(Keyword::ONLY), p.parse_object_name(false)?))
-            })?
-            .into_iter()
-            .map(|(only, name)| TruncateTableTarget { name, only })
-            .collect();
+        let table_names = self.parse_comma_separated(|p| {
+            let only = p.parse_keyword(Keyword::ONLY);
+            let name = p.parse_object_name(false)?;
+            let has_asterisk = p.consume_token(&Token::Mul);
+            Ok(TruncateTableTarget {
+                name,
+                only,
+                has_asterisk,
+            })
+        })?;
 
         let mut partitions = None;
         if self.parse_keyword(Keyword::PARTITION) {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -16806,10 +16806,12 @@ fn parse_truncate_only() {
         TruncateTableTarget {
             name: ObjectName::from(vec![Ident::new("employee")]),
             only: false,
+            has_asterisk: false,
         },
         TruncateTableTarget {
             name: ObjectName::from(vec![Ident::new("dept")]),
             only: true,
+            has_asterisk: false,
         },
     ];
 


### PR DESCRIPTION
Add support for the PostgreSQL TRUNCATE syntax `TRUNCATE TABLE name *` which indicates that descendant tables should also be truncated. This is the opposite of the `ONLY` keyword, and Postgres doesn't allow both. We are more permissive when parsing it and allow both to appear.

Adds a `has_asterisk` field to `TruncateTableTarget` that is set to true when the `*` token follows a table name. This could be called `include_descendants` or something more semantically meaningful, but it's kind of peculiar syntax, so just mirroring the syntax itself seemed less confusing.