### PR TITLE
Updated Fuzzer harness to address all dialects

### DIFF
--- a/fuzz/fuzz_targets/fuzz_parse_sql.rs
+++ b/fuzz/fuzz_targets/fuzz_parse_sql.rs
@@ -16,14 +16,35 @@
 // under the License.
 
 use honggfuzz::fuzz;
-use sqlparser::dialect::GenericDialect;
+use sqlparser::dialect::{
+    AnsiDialect, BigQueryDialect, ClickHouseDialect, DatabricksDialect, DuckDbDialect,
+    GenericDialect, HiveDialect, MsSqlDialect, MySqlDialect, OracleDialect, PostgreSqlDialect,
+    RedshiftSqlDialect, SQLiteDialect, SnowflakeDialect,
+};
 use sqlparser::parser::Parser;
 
 fn main() {
+    let dialects: Vec<Box<dyn sqlparser::dialect::Dialect>> = vec![
+        Box::new(AnsiDialect::default()),
+        Box::new(BigQueryDialect::default()),
+        Box::new(ClickHouseDialect::default()),
+        Box::new(DatabricksDialect::default()),
+        Box::new(DuckDbDialect::default()),
+        Box::new(GenericDialect::default()),
+        Box::new(HiveDialect::default()),
+        Box::new(MsSqlDialect::default()),
+        Box::new(MySqlDialect::default()),
+        Box::new(OracleDialect::default()),
+        Box::new(PostgreSqlDialect::default()),
+        Box::new(RedshiftSqlDialect::default()),
+        Box::new(SQLiteDialect::default()),
+        Box::new(SnowflakeDialect::default()),
+    ];
     loop {
         fuzz!(|data: String| {
-            let dialect = GenericDialect {};
-            let _ = Parser::parse_sql(&dialect, &data);
+            for dialect in &dialects {
+                let _ = Parser::parse_sql(dialect.as_ref(), &data);
+            }
         });
     }
 }


### PR DESCRIPTION
The fuzzer harness was formerly only fuzzing `GenericDialect` and none of the other `Dialect` types. I modified the harness to account for all dialects and it should now be fuzzing all dialects. 