### PR TITLE
Fix MAP literals parsing

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3503,7 +3503,8 @@ impl<'a> Parser<'a> {
     ///
     /// [map]: https://duckdb.org/docs/sql/data_types/map.html#creating-maps
     fn parse_duckdb_map_field(&mut self) -> Result<MapEntry, ParserError> {
-        let key = self.parse_expr()?;
+        // Stop before `:` so it can act as a key/value separator
+        let key = self.parse_subexpr(self.dialect.prec_value(Precedence::Colon))?;
 
         self.expect_token(&Token::Colon)?;
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -13584,6 +13584,10 @@ fn test_map_syntax() {
         Expr::value(number(s))
     }
 
+    fn null_expr() -> Expr {
+        Expr::Value((Value::Null).with_empty_span())
+    }
+
     check(
         "MAP {1: 10.0, 2: 20.0}",
         Expr::Map(Map {
@@ -13648,6 +13652,55 @@ fn test_map_syntax() {
     );
 
     check("MAP {}", Expr::Map(Map { entries: vec![] }));
+
+    check(
+        "MAP {'a': 1, 'b': NULL}",
+        Expr::Map(Map {
+            entries: vec![
+                MapEntry {
+                    key: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("a".to_owned())).with_empty_span(),
+                    )),
+                    value: Box::new(number_expr("1")),
+                },
+                MapEntry {
+                    key: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("b".to_owned())).with_empty_span(),
+                    )),
+                    value: Box::new(null_expr()),
+                },
+            ],
+        }),
+    );
+
+    check(
+        "MAP {1: [1, NULL, 3], 2: [4, NULL, 6], 3: [7, 8, 9]}",
+        Expr::Map(Map {
+            entries: vec![
+                MapEntry {
+                    key: Box::new(number_expr("1")),
+                    value: Box::new(Expr::Array(Array {
+                        elem: vec![number_expr("1"), null_expr(), number_expr("3")],
+                        named: false,
+                    })),
+                },
+                MapEntry {
+                    key: Box::new(number_expr("2")),
+                    value: Box::new(Expr::Array(Array {
+                        elem: vec![number_expr("4"), null_expr(), number_expr("6")],
+                        named: false,
+                    })),
+                },
+                MapEntry {
+                    key: Box::new(number_expr("3")),
+                    value: Box::new(Expr::Array(Array {
+                        elem: vec![number_expr("7"), number_expr("8"), number_expr("9")],
+                        named: false,
+                    })),
+                },
+            ],
+        }),
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Fixes https://github.com/apache/datafusion-sqlparser-rs/issues/2204
- Make map_field parsing aware of Colon token.
- This regression was likely introduced in https://github.com/apache/datafusion-sqlparser-rs/pull/2124
- Added some tests for this.
    - Not sure how the existing tests are passing, but I have verified that the new tests catch this bug (they fail without the fix).