### PR TITLE
Updated `parse_infix(..)` in `mysql.rs` and `sqlite.rs` to handle error rather than `unwrap()`

### DIFF
--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -102,14 +102,15 @@ impl Dialect for MySqlDialect {
     ) -> Option<Result<crate::ast::Expr, ParserError>> {
         // Parse DIV as an operator
         if parser.parse_keyword(Keyword::DIV) {
-            let right = match parser.parse_expr() {
-                Ok(val) => val,
+            let left = Box::new(expr.clone());
+            let right = Box::new(match parser.parse_expr() {
+                Ok(expr) => expr,
                 Err(e) => return Some(Err(e)),
-            };
+            });
             Some(Ok(Expr::BinaryOp {
-                left: Box::new(expr.clone()),
+                left,
                 op: BinaryOperator::MyIntegerDivide,
-                right: Box::new(right),
+                right,
             }))
         } else {
             None

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -89,15 +89,11 @@ impl Dialect for SQLiteDialect {
         ] {
             if parser.parse_keyword(keyword) {
                 let left = Box::new(expr.clone());
-                let right = match parser.parse_expr() {
-                    Ok(val) => val,
+                let right = Box::new(match parser.parse_expr() {
+                    Ok(expr) => expr,
                     Err(e) => return Some(Err(e)),
-                };
-                return Some(Ok(Expr::BinaryOp {
-                    left,
-                    op,
-                    right: Box::new(right),
-                }));
+                });
+                return Some(Ok(Expr::BinaryOp { left, op, right }));
             }
         }
         None


### PR DESCRIPTION
Previously for both `sqlite` and `mysql` the `parse_infix` would panic if passed `parser: &mut crate::parser::Parser` returned an error:
```rust
    fn parse_infix(
        &self,
        parser: &mut crate::parser::Parser,
        expr: &crate::ast::Expr,
        _precedence: u8,
    ) -> Option<Result<crate::ast::Expr, ParserError>> {
        // Parse DIV as an operator
        if parser.parse_keyword(Keyword::DIV) {
            Some(Ok(Expr::BinaryOp {
                left: Box::new(expr.clone()),
                op: BinaryOperator::MyIntegerDivide,
                right: Box::new(parser.parse_expr().unwrap()),
            }))
        } else {
            None
        }
    }
```
Now Errors are being passed, and the `parse_expr()` error returned will be returned for `parse_infix` rather than panic:
```rust
    fn parse_infix(
        &self,
        parser: &mut crate::parser::Parser,
        expr: &crate::ast::Expr,
        _precedence: u8,
    ) -> Option<Result<crate::ast::Expr, ParserError>> {
        // Parse DIV as an operator
        if parser.parse_keyword(Keyword::DIV) {
            let left = Box::new(expr.clone());
            let right = Box::new(match parser.parse_expr() {
                Ok(expr) => expr,
                Err(e) => return Some(Err(e)),
            });
            Some(Ok(Expr::BinaryOp {
                left,
                op: BinaryOperator::MyIntegerDivide,
                right,
            }))
        } else {
            None
        }
    }
```