### PR TITLE
MSSQL: Add support for TRAN shorthand

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -6369,7 +6369,7 @@ impl Display for CascadeOption {
     }
 }
 
-/// Transaction started with [ TRANSACTION | WORK ]
+/// Transaction started with [ TRANSACTION | WORK | TRAN ]
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
@@ -6378,6 +6378,9 @@ pub enum BeginTransactionKind {
     Transaction,
     /// Alternate `WORK` keyword.
     Work,
+    /// MSSQL shorthand `TRAN` keyword.
+    /// See <https://learn.microsoft.com/en-us/sql/t-sql/language-elements/begin-transaction-transact-sql>
+    Tran,
 }
 
 impl Display for BeginTransactionKind {
@@ -6385,6 +6388,7 @@ impl Display for BeginTransactionKind {
         match self {
             BeginTransactionKind::Transaction => write!(f, "TRANSACTION"),
             BeginTransactionKind::Work => write!(f, "WORK"),
+            BeginTransactionKind::Tran => write!(f, "TRAN"),
         }
     }
 }

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -151,8 +151,12 @@ impl Dialect for MsSqlDialect {
             let is_block = parser
                 .maybe_parse(|p| {
                     if p.parse_transaction_modifier().is_some()
-                        || p.parse_one_of_keywords(&[Keyword::TRANSACTION, Keyword::WORK])
-                            .is_some()
+                        || p.parse_one_of_keywords(&[
+                            Keyword::TRANSACTION,
+                            Keyword::WORK,
+                            Keyword::TRAN,
+                        ])
+                        .is_some()
                         || matches!(p.peek_token_ref().token, Token::SemiColon | Token::EOF)
                     {
                         p.expected("statement", p.peek_token())

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1051,6 +1051,7 @@ define_keywords!(
     TOTP,
     TRACE,
     TRAILING,
+    TRAN,
     TRANSACTION,
     TRANSIENT,
     TRANSLATE,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18099,11 +18099,14 @@ impl<'a> Parser<'a> {
     /// Parse a 'BEGIN' statement
     pub fn parse_begin(&mut self) -> Result<Statement, ParserError> {
         let modifier = self.parse_transaction_modifier();
-        let transaction = match self.parse_one_of_keywords(&[Keyword::TRANSACTION, Keyword::WORK]) {
-            Some(Keyword::TRANSACTION) => Some(BeginTransactionKind::Transaction),
-            Some(Keyword::WORK) => Some(BeginTransactionKind::Work),
-            _ => None,
-        };
+        let transaction =
+            match self.parse_one_of_keywords(&[Keyword::TRANSACTION, Keyword::WORK, Keyword::TRAN])
+            {
+                Some(Keyword::TRANSACTION) => Some(BeginTransactionKind::Transaction),
+                Some(Keyword::WORK) => Some(BeginTransactionKind::Work),
+                Some(Keyword::TRAN) => Some(BeginTransactionKind::Tran),
+                _ => None,
+            };
         Ok(Statement::StartTransaction {
             modes: self.parse_transaction_modes()?,
             begin: true,
@@ -18237,7 +18240,7 @@ impl<'a> Parser<'a> {
 
     /// Parse an optional `AND [NO] CHAIN` clause for `COMMIT` and `ROLLBACK` statements
     pub fn parse_commit_rollback_chain(&mut self) -> Result<bool, ParserError> {
-        let _ = self.parse_one_of_keywords(&[Keyword::TRANSACTION, Keyword::WORK]);
+        let _ = self.parse_one_of_keywords(&[Keyword::TRANSACTION, Keyword::WORK, Keyword::TRAN]);
         if self.parse_keyword(Keyword::AND) {
             let chain = !self.parse_keyword(Keyword::NO);
             self.expect_keyword_is(Keyword::CHAIN)?;


### PR DESCRIPTION
## Why

MSSQL supports TRAN as a shorthand for TRANSACTION in BEGIN/COMMIT/ROLLBACK statements, but the
parser did not recognize it.

## How

- Add TRAN variant to BeginTransactionKind enum and the keywords list
- Accept TRAN alongside TRANSACTION and WORK in BEGIN, COMMIT, and ROLLBACK parsing
- Add tests for BEGIN TRAN, COMMIT TRAN, and ROLLBACK TRAN