### PR TITLE
Allow custom OptimizerHints

### DIFF
--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -43,11 +43,11 @@ use super::{
 pub struct Insert {
     /// Token for the `INSERT` keyword (or its substitutes)
     pub insert_token: AttachedToken,
-    /// A query optimizer hint
+    /// Query optimizer hints
     ///
     /// [MySQL](https://dev.mysql.com/doc/refman/8.4/en/optimizer-hints.html)
     /// [Oracle](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Comments.html#GUID-D316D545-89E2-4D54-977F-FC97815CD62E)
-    pub optimizer_hint: Option<OptimizerHint>,
+    pub optimizer_hints: Vec<OptimizerHint>,
     /// Only for Sqlite
     pub or: Option<SqliteOnConflict>,
     /// Only for mysql
@@ -133,7 +133,7 @@ impl Display for Insert {
 
         if let Some(on_conflict) = self.or {
             f.write_str("INSERT")?;
-            if let Some(hint) = self.optimizer_hint.as_ref() {
+            for hint in &self.optimizer_hints {
                 write!(f, " {hint}")?;
             }
             write!(f, " {on_conflict} INTO {table_name} ")?;
@@ -147,7 +147,7 @@ impl Display for Insert {
                     "INSERT"
                 }
             )?;
-            if let Some(hint) = self.optimizer_hint.as_ref() {
+            for hint in &self.optimizer_hints {
                 write!(f, " {hint}")?;
             }
             if let Some(priority) = self.priority {
@@ -267,11 +267,11 @@ impl Display for Insert {
 pub struct Delete {
     /// Token for the `DELETE` keyword
     pub delete_token: AttachedToken,
-    /// A query optimizer hint
+    /// Query optimizer hints
     ///
     /// [MySQL](https://dev.mysql.com/doc/refman/8.4/en/optimizer-hints.html)
     /// [Oracle](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Comments.html#GUID-D316D545-89E2-4D54-977F-FC97815CD62E)
-    pub optimizer_hint: Option<OptimizerHint>,
+    pub optimizer_hints: Vec<OptimizerHint>,
     /// Multi tables delete are supported in mysql
     pub tables: Vec<ObjectName>,
     /// FROM
@@ -291,7 +291,7 @@ pub struct Delete {
 impl Display for Delete {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("DELETE")?;
-        if let Some(hint) = self.optimizer_hint.as_ref() {
+        for hint in &self.optimizer_hints {
             f.write_str(" ")?;
             hint.fmt(f)?;
         }
@@ -345,11 +345,11 @@ impl Display for Delete {
 pub struct Update {
     /// Token for the `UPDATE` keyword
     pub update_token: AttachedToken,
-    /// A query optimizer hint
+    /// Query optimizer hints
     ///
     /// [MySQL](https://dev.mysql.com/doc/refman/8.4/en/optimizer-hints.html)
     /// [Oracle](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Comments.html#GUID-D316D545-89E2-4D54-977F-FC97815CD62E)
-    pub optimizer_hint: Option<OptimizerHint>,
+    pub optimizer_hints: Vec<OptimizerHint>,
     /// TABLE
     pub table: TableWithJoins,
     /// Column assignments
@@ -368,11 +368,12 @@ pub struct Update {
 
 impl Display for Update {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("UPDATE ")?;
-        if let Some(hint) = self.optimizer_hint.as_ref() {
-            hint.fmt(f)?;
+        f.write_str("UPDATE")?;
+        for hint in &self.optimizer_hints {
             f.write_str(" ")?;
+            hint.fmt(f)?;
         }
+        f.write_str(" ")?;
         if let Some(or) = &self.or {
             or.fmt(f)?;
             f.write_str(" ")?;
@@ -419,10 +420,10 @@ impl Display for Update {
 pub struct Merge {
     /// The `MERGE` token that starts the statement.
     pub merge_token: AttachedToken,
-    /// A query optimizer hint
+    /// Query optimizer hints
     ///
     /// [Oracle](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Comments.html#GUID-D316D545-89E2-4D54-977F-FC97815CD62E)
-    pub optimizer_hint: Option<OptimizerHint>,
+    pub optimizer_hints: Vec<OptimizerHint>,
     /// optional INTO keyword
     pub into: bool,
     /// Specifies the table to merge
@@ -440,7 +441,7 @@ pub struct Merge {
 impl Display for Merge {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("MERGE")?;
-        if let Some(hint) = self.optimizer_hint.as_ref() {
+        for hint in &self.optimizer_hints {
             write!(f, " {hint}")?;
         }
         if self.into {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -11579,12 +11579,19 @@ pub struct ResetStatement {
 /// `SELECT`, `INSERT`, `UPDATE`, `REPLACE`, `MERGE`, and `DELETE` keywords in
 /// the corresponding statements.
 ///
-/// See [Select::optimizer_hint]
+/// See [Select::optimizer_hints]
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct OptimizerHint {
-    /// the raw test of the optimizer hint without its markers
+    /// An optional prefix between the comment marker and `+`.
+    ///
+    /// Standard optimizer hints like `/*+ ... */` have an empty prefix,
+    /// while system-specific hints like `/*abc+ ... */` have `prefix = "abc"`.
+    /// The prefix is any sequence of ASCII alphanumeric characters
+    /// immediately before the `+` marker.
+    pub prefix: String,
+    /// the raw text of the optimizer hint without its markers
     pub text: String,
     /// the style of the comment which `text` was extracted from,
     /// e.g. `/*+...*/` or `--+...`
@@ -11614,11 +11621,14 @@ impl fmt::Display for OptimizerHint {
         match &self.style {
             OptimizerHintStyle::SingleLine { prefix } => {
                 f.write_str(prefix)?;
+                f.write_str(&self.prefix)?;
                 f.write_str("+")?;
                 f.write_str(&self.text)
             }
             OptimizerHintStyle::MultiLine => {
-                f.write_str("/*+")?;
+                f.write_str("/*")?;
+                f.write_str(&self.prefix)?;
+                f.write_str("+")?;
                 f.write_str(&self.text)?;
                 f.write_str("*/")
             }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -445,11 +445,11 @@ impl SelectModifiers {
 pub struct Select {
     /// Token for the `SELECT` keyword
     pub select_token: AttachedToken,
-    /// A query optimizer hint
+    /// Query optimizer hints
     ///
     /// [MySQL](https://dev.mysql.com/doc/refman/8.4/en/optimizer-hints.html)
     /// [Oracle](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Comments.html#GUID-D316D545-89E2-4D54-977F-FC97815CD62E)
-    pub optimizer_hint: Option<OptimizerHint>,
+    pub optimizer_hints: Vec<OptimizerHint>,
     /// `SELECT [DISTINCT] ...`
     pub distinct: Option<Distinct>,
     /// MySQL-specific SELECT modifiers.
@@ -521,7 +521,7 @@ impl fmt::Display for Select {
             }
         }
 
-        if let Some(hint) = self.optimizer_hint.as_ref() {
+        for hint in &self.optimizer_hints {
             f.write_str(" ")?;
             hint.fmt(f)?;
         }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -897,7 +897,7 @@ impl Spanned for Delete {
     fn span(&self) -> Span {
         let Delete {
             delete_token,
-            optimizer_hint: _,
+            optimizer_hints: _,
             tables,
             from,
             using,
@@ -931,7 +931,7 @@ impl Spanned for Update {
     fn span(&self) -> Span {
         let Update {
             update_token,
-            optimizer_hint: _,
+            optimizer_hints: _,
             table,
             assignments,
             from,
@@ -1295,7 +1295,7 @@ impl Spanned for Insert {
     fn span(&self) -> Span {
         let Insert {
             insert_token,
-            optimizer_hint: _,
+            optimizer_hints: _,
             or: _,     // enum, sqlite specific
             ignore: _, // bool
             into: _,   // bool
@@ -2243,7 +2243,7 @@ impl Spanned for Select {
     fn span(&self) -> Span {
         let Select {
             select_token,
-            optimizer_hint: _,
+            optimizer_hints: _,
             distinct: _, // todo
             select_modifiers: _,
             top: _, // todo, mysql specific
@@ -2837,7 +2837,7 @@ WHERE id = 1
         // ~ individual tokens within the statement
         let Statement::Merge(Merge {
             merge_token,
-            optimizer_hint: _,
+            optimizer_hints: _,
             into: _,
             table: _,
             source: _,

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -1752,7 +1752,7 @@ fn parse_multi_table_insert(
 
     Ok(Statement::Insert(Insert {
         insert_token: insert_token.into(),
-        optimizer_hint: None,
+        optimizer_hints: vec![],
         or: None,
         ignore: false,
         into: false,

--- a/src/parser/merge.rs
+++ b/src/parser/merge.rs
@@ -43,7 +43,7 @@ impl Parser<'_> {
 
     /// Parse a `MERGE` statement
     pub fn parse_merge(&mut self, merge_token: TokenWithSpan) -> Result<Merge, ParserError> {
-        let optimizer_hint = self.maybe_parse_optimizer_hint()?;
+        let optimizer_hints = self.maybe_parse_optimizer_hints()?;
         let into = self.parse_keyword(Keyword::INTO);
 
         let table = self.parse_table_factor()?;
@@ -60,7 +60,7 @@ impl Parser<'_> {
 
         Ok(Merge {
             merge_token: merge_token.into(),
-            optimizer_hint,
+            optimizer_hints,
             into,
             table,
             source,

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2681,7 +2681,7 @@ fn test_export_data() {
                         }),
                         Span::empty()
                     )),
-                    optimizer_hint: None,
+                    optimizer_hints: vec![],
                     distinct: None,
                     select_modifiers: None,
                     top: None,
@@ -2787,7 +2787,7 @@ fn test_export_data() {
                         }),
                         Span::empty()
                     )),
-                    optimizer_hint: None,
+                    optimizer_hints: vec![],
                     distinct: None,
                     select_modifiers: None,
                     top: None,

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -41,7 +41,7 @@ fn parse_map_access_expr() {
     assert_eq!(
         Select {
             select_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             distinct: None,
             select_modifiers: None,
             top: None,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -455,7 +455,7 @@ fn parse_update_set_from() {
         stmt,
         Statement::Update(Update {
             update_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             table: TableWithJoins {
                 relation: table_from_name(ObjectName::from(vec![Ident::new("t1")])),
                 joins: vec![],
@@ -471,7 +471,7 @@ fn parse_update_set_from() {
                         with: None,
                         body: Box::new(SetExpr::Select(Box::new(Select {
                             select_token: AttachedToken::empty(),
-                            optimizer_hint: None,
+                            optimizer_hints: vec![],
                             distinct: None,
                             select_modifiers: None,
                             top: None,
@@ -551,9 +551,9 @@ fn parse_update_with_table_alias() {
             returning,
             or: None,
             limit: None,
-            optimizer_hint: None,
+            optimizer_hints,
             update_token: _,
-        }) => {
+        }) if optimizer_hints.is_empty() => {
             assert_eq!(
                 TableWithJoins {
                     relation: TableFactor::Table {
@@ -5818,7 +5818,7 @@ fn test_parse_named_window() {
     let actual_select_only = dialects.verified_only_select(sql);
     let expected = Select {
         select_token: AttachedToken::empty(),
-        optimizer_hint: None,
+        optimizer_hints: vec![],
         distinct: None,
         select_modifiers: None,
         top: None,
@@ -6550,7 +6550,7 @@ fn parse_interval_and_or_xor() {
         with: None,
         body: Box::new(SetExpr::Select(Box::new(Select {
             select_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             distinct: None,
             select_modifiers: None,
             top: None,
@@ -8928,7 +8928,7 @@ fn lateral_function() {
     let actual_select_only = verified_only_select(sql);
     let expected = Select {
         select_token: AttachedToken::empty(),
-        optimizer_hint: None,
+        optimizer_hints: vec![],
         distinct: None,
         select_modifiers: None,
         top: None,
@@ -9931,7 +9931,7 @@ fn parse_merge() {
                         with: None,
                         body: Box::new(SetExpr::Select(Box::new(Select {
                             select_token: AttachedToken::empty(),
-                            optimizer_hint: None,
+                            optimizer_hints: vec![],
                             distinct: None,
                             select_modifiers: None,
                             top: None,
@@ -12343,7 +12343,7 @@ fn parse_unload() {
             query: Some(Box::new(Query {
                 body: Box::new(SetExpr::Select(Box::new(Select {
                     select_token: AttachedToken::empty(),
-                    optimizer_hint: None,
+                    optimizer_hints: vec![],
                     distinct: None,
                     select_modifiers: None,
                     top: None,
@@ -12664,7 +12664,7 @@ fn parse_connect_by() {
         dialects.verified_only_select(connect_by_1),
         Select {
             select_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             distinct: None,
             select_modifiers: None,
             top: None,
@@ -12731,7 +12731,7 @@ fn parse_connect_by() {
         dialects.verified_only_select(connect_by_2),
         Select {
             select_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             distinct: None,
             select_modifiers: None,
             top: None,
@@ -12799,7 +12799,7 @@ fn parse_connect_by() {
         dialects.verified_only_select(connect_by_3),
         Select {
             select_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             distinct: None,
             select_modifiers: None,
             top: None,
@@ -12887,7 +12887,7 @@ fn parse_connect_by() {
         dialects.verified_only_select(connect_by_5),
         Select {
             select_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             distinct: None,
             select_modifiers: None,
             top: None,
@@ -13850,7 +13850,7 @@ fn test_extract_seconds_ok() {
         with: None,
         body: Box::new(SetExpr::Select(Box::new(Select {
             select_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             distinct: None,
             select_modifiers: None,
             top: None,
@@ -15991,7 +15991,7 @@ fn test_select_from_first() {
             with: None,
             body: Box::new(SetExpr::Select(Box::new(Select {
                 select_token: AttachedToken::empty(),
-                optimizer_hint: None,
+                optimizer_hints: vec![],
                 distinct: None,
                 select_modifiers: None,
                 top: None,

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -266,7 +266,7 @@ fn test_select_union_by_name() {
             set_quantifier: *expected_quantifier,
             left: Box::<SetExpr>::new(SetExpr::Select(Box::new(Select {
                 select_token: AttachedToken::empty(),
-                optimizer_hint: None,
+                optimizer_hints: vec![],
                 distinct: None,
                 select_modifiers: None,
                 top: None,
@@ -299,7 +299,7 @@ fn test_select_union_by_name() {
             }))),
             right: Box::<SetExpr>::new(SetExpr::Select(Box::new(Select {
                 select_token: AttachedToken::empty(),
-                optimizer_hint: None,
+                optimizer_hints: vec![],
                 distinct: None,
                 select_modifiers: None,
                 top: None,

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -141,7 +141,7 @@ fn parse_create_procedure() {
                     pipe_operators: vec![],
                     body: Box::new(SetExpr::Select(Box::new(Select {
                         select_token: AttachedToken::empty(),
-                        optimizer_hint: None,
+                        optimizer_hints: vec![],
                         distinct: None,
                         select_modifiers: None,
                         top: None,
@@ -1350,7 +1350,7 @@ fn parse_substring_in_select() {
 
                     body: Box::new(SetExpr::Select(Box::new(Select {
                         select_token: AttachedToken::empty(),
-                        optimizer_hint: None,
+                        optimizer_hints: vec![],
                         distinct: Some(Distinct::Distinct),
                         select_modifiers: None,
                         top: None,
@@ -1509,7 +1509,7 @@ fn parse_mssql_declare() {
 
                 body: Box::new(SetExpr::Select(Box::new(Select {
                     select_token: AttachedToken::empty(),
-                    optimizer_hint: None,
+                    optimizer_hints: vec![],
                     distinct: None,
                     select_modifiers: None,
                     top: None,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1291,7 +1291,7 @@ fn parse_copy_to() {
                 with: None,
                 body: Box::new(SetExpr::Select(Box::new(Select {
                     select_token: AttachedToken::empty(),
-                    optimizer_hint: None,
+                    optimizer_hints: vec![],
                     distinct: None,
                     select_modifiers: None,
                     top: None,
@@ -3073,7 +3073,7 @@ fn parse_array_subquery_expr() {
                     set_quantifier: SetQuantifier::None,
                     left: Box::new(SetExpr::Select(Box::new(Select {
                         select_token: AttachedToken::empty(),
-                        optimizer_hint: None,
+                        optimizer_hints: vec![],
                         distinct: None,
                         select_modifiers: None,
                         top: None,
@@ -3101,7 +3101,7 @@ fn parse_array_subquery_expr() {
                     }))),
                     right: Box::new(SetExpr::Select(Box::new(Select {
                         select_token: AttachedToken::empty(),
-                        optimizer_hint: None,
+                        optimizer_hints: vec![],
                         distinct: None,
                         select_modifiers: None,
                         top: None,
@@ -5397,7 +5397,7 @@ fn test_simple_postgres_insert_with_alias() {
         statement,
         Statement::Insert(Insert {
             insert_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             or: None,
             ignore: false,
             into: true,
@@ -5473,7 +5473,7 @@ fn test_simple_postgres_insert_with_alias() {
         statement,
         Statement::Insert(Insert {
             insert_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             or: None,
             ignore: false,
             into: true,
@@ -5551,7 +5551,7 @@ fn test_simple_insert_with_quoted_alias() {
         statement,
         Statement::Insert(Insert {
             insert_token: AttachedToken::empty(),
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             or: None,
             ignore: false,
             into: true,

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -477,7 +477,7 @@ fn parse_update_tuple_row_values() {
     assert_eq!(
         sqlite().verified_stmt("UPDATE x SET (a, b) = (1, 2)"),
         Statement::Update(Update {
-            optimizer_hint: None,
+            optimizer_hints: vec![],
             or: None,
             assignments: vec![Assignment {
                 target: AssignmentTarget::Tuple(vec![


### PR DESCRIPTION
Two orthogonal improvements to optimizer hint parsing:

1. `Option<OptimizerHint>` -> `Vec<OptimizerHint>`: the old Option silently dropped all but the first hint-style comment. Vec preserves all hint comments the parser encounters, letting consumers decide which to use. This is backwards compatible: `optimizer_hint: None` becomes `optimizer_hints: vec![]`, and `optimizer_hint.unwrap()` becomes `optimizer_hints[0]`.

2. Generic prefix extraction: the `/*+...*/` pattern is an established convention. Various systems extend it with `/*prefix+...*/` where the prefix is opaque alphanumeric text before `+`. Rather than adding a new dialect flag or struct for each system, the parser now captures any `[a-zA-Z0-9]*` run before `+` as a `prefix` field. Standard hints have `prefix: ""`. No new dialect surface -- same `supports_comment_optimizer_hint()` gate. This makes OptimizerHint a generic extension point: downstream consumers can define their own prefixed hint conventions and filter hints by prefix, without requiring any changes to the parser or dialect configuration.