### PR TITLE
PostgreSQL: Support more COMMENT ON object types

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2439,30 +2439,54 @@ impl fmt::Display for ShowCreateObject {
 pub enum CommentObject {
     /// A table column.
     Column,
-    /// A table.
-    Table,
-    /// An extension.
-    Extension,
-    /// A schema.
-    Schema,
     /// A database.
     Database,
-    /// A user.
-    User,
+    /// A domain.
+    Domain,
+    /// An extension.
+    Extension,
+    /// A function.
+    Function,
+    /// An index.
+    Index,
+    /// A materialized view.
+    MaterializedView,
+    /// A procedure.
+    Procedure,
     /// A role.
     Role,
+    /// A schema.
+    Schema,
+    /// A sequence.
+    Sequence,
+    /// A table.
+    Table,
+    /// A type.
+    Type,
+    /// A user.
+    User,
+    /// A view.
+    View,
 }
 
 impl fmt::Display for CommentObject {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             CommentObject::Column => f.write_str("COLUMN"),
-            CommentObject::Table => f.write_str("TABLE"),
-            CommentObject::Extension => f.write_str("EXTENSION"),
-            CommentObject::Schema => f.write_str("SCHEMA"),
             CommentObject::Database => f.write_str("DATABASE"),
-            CommentObject::User => f.write_str("USER"),
+            CommentObject::Domain => f.write_str("DOMAIN"),
+            CommentObject::Extension => f.write_str("EXTENSION"),
+            CommentObject::Function => f.write_str("FUNCTION"),
+            CommentObject::Index => f.write_str("INDEX"),
+            CommentObject::MaterializedView => f.write_str("MATERIALIZED VIEW"),
+            CommentObject::Procedure => f.write_str("PROCEDURE"),
             CommentObject::Role => f.write_str("ROLE"),
+            CommentObject::Schema => f.write_str("SCHEMA"),
+            CommentObject::Sequence => f.write_str("SEQUENCE"),
+            CommentObject::Table => f.write_str("TABLE"),
+            CommentObject::Type => f.write_str("TYPE"),
+            CommentObject::User => f.write_str("USER"),
+            CommentObject::View => f.write_str("VIEW"),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -899,23 +899,51 @@ impl<'a> Parser<'a> {
             Token::Word(w) if w.keyword == Keyword::COLUMN => {
                 (CommentObject::Column, self.parse_object_name(false)?)
             }
-            Token::Word(w) if w.keyword == Keyword::TABLE => {
-                (CommentObject::Table, self.parse_object_name(false)?)
+            Token::Word(w) if w.keyword == Keyword::DATABASE => {
+                (CommentObject::Database, self.parse_object_name(false)?)
+            }
+            Token::Word(w) if w.keyword == Keyword::DOMAIN => {
+                (CommentObject::Domain, self.parse_object_name(false)?)
             }
             Token::Word(w) if w.keyword == Keyword::EXTENSION => {
                 (CommentObject::Extension, self.parse_object_name(false)?)
             }
+            Token::Word(w) if w.keyword == Keyword::FUNCTION => {
+                (CommentObject::Function, self.parse_object_name(false)?)
+            }
+            Token::Word(w) if w.keyword == Keyword::INDEX => {
+                (CommentObject::Index, self.parse_object_name(false)?)
+            }
+            Token::Word(w) if w.keyword == Keyword::MATERIALIZED => {
+                self.expect_keyword_is(Keyword::VIEW)?;
+                (
+                    CommentObject::MaterializedView,
+                    self.parse_object_name(false)?,
+                )
+            }
+            Token::Word(w) if w.keyword == Keyword::PROCEDURE => {
+                (CommentObject::Procedure, self.parse_object_name(false)?)
+            }
+            Token::Word(w) if w.keyword == Keyword::ROLE => {
+                (CommentObject::Role, self.parse_object_name(false)?)
+            }
             Token::Word(w) if w.keyword == Keyword::SCHEMA => {
                 (CommentObject::Schema, self.parse_object_name(false)?)
             }
-            Token::Word(w) if w.keyword == Keyword::DATABASE => {
-                (CommentObject::Database, self.parse_object_name(false)?)
+            Token::Word(w) if w.keyword == Keyword::SEQUENCE => {
+                (CommentObject::Sequence, self.parse_object_name(false)?)
+            }
+            Token::Word(w) if w.keyword == Keyword::TABLE => {
+                (CommentObject::Table, self.parse_object_name(false)?)
+            }
+            Token::Word(w) if w.keyword == Keyword::TYPE => {
+                (CommentObject::Type, self.parse_object_name(false)?)
             }
             Token::Word(w) if w.keyword == Keyword::USER => {
                 (CommentObject::User, self.parse_object_name(false)?)
             }
-            Token::Word(w) if w.keyword == Keyword::ROLE => {
-                (CommentObject::Role, self.parse_object_name(false)?)
+            Token::Word(w) if w.keyword == Keyword::VIEW => {
+                (CommentObject::View, self.parse_object_name(false)?)
             }
             _ => self.expected("comment object_type", token)?,
         };

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15172,14 +15172,23 @@ fn parse_comments() {
         _ => unreachable!(),
     }
 
+    // https://www.postgresql.org/docs/current/sql-comment.html
     let object_types = [
         ("COLUMN", CommentObject::Column),
-        ("EXTENSION", CommentObject::Extension),
-        ("TABLE", CommentObject::Table),
-        ("SCHEMA", CommentObject::Schema),
         ("DATABASE", CommentObject::Database),
-        ("USER", CommentObject::User),
+        ("DOMAIN", CommentObject::Domain),
+        ("EXTENSION", CommentObject::Extension),
+        ("FUNCTION", CommentObject::Function),
+        ("INDEX", CommentObject::Index),
+        ("MATERIALIZED VIEW", CommentObject::MaterializedView),
+        ("PROCEDURE", CommentObject::Procedure),
         ("ROLE", CommentObject::Role),
+        ("SCHEMA", CommentObject::Schema),
+        ("SEQUENCE", CommentObject::Sequence),
+        ("TABLE", CommentObject::Table),
+        ("TYPE", CommentObject::Type),
+        ("USER", CommentObject::User),
+        ("VIEW", CommentObject::View),
     ];
     for (keyword, expected_object_type) in object_types.iter() {
         match all_dialects_where(|d| d.supports_comment_on())


### PR DESCRIPTION
## Why                                                                                                               
  
PostgreSQL supports COMMENT ON for many object types, but the parser only handled a subset.                       
                                                                                       
## How

- Add Domain, Function, Index, MaterializedView, Procedure, Sequence, Type, and View to CommentObject
- Extend parser to handle the new object type keywords
- Expand test coverage to verify all supported object types