### PR TITLE
Resolve breaking change that set "supports_lambda_functions" on `GenericDialect`

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -225,10 +225,6 @@ impl Dialect for GenericDialect {
         true
     }
 
-    fn supports_lambda_functions(&self) -> bool {
-        true
-    }
-
     fn supports_select_wildcard_replace(&self) -> bool {
         true
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1663,6 +1663,7 @@ fn parse_json_ops_without_colon() {
             Arrow,
             all_dialects_except(|d| d.supports_lambda_functions()),
         ),
+        ("->", Arrow, pg_and_generic()),
         ("->>", LongArrow, all_dialects()),
         ("#>", HashArrow, pg_and_generic()),
         ("#>>", HashLongArrow, pg_and_generic()),

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -882,17 +882,17 @@ fn parse_extract_single_quotes() {
 fn test_duckdb_lambda_function() {
     // Test basic lambda with list_filter
     let sql = "SELECT [3, 4, 5, 6].list_filter(lambda x : x > 4)";
-    duckdb_and_generic().verified_stmt(sql);
+    duckdb().verified_stmt(sql);
 
     // Test lambda with arrow syntax (also supported by DuckDB)
     let sql_arrow = "SELECT list_filter([1, 2, 3], x -> x > 1)";
-    duckdb_and_generic().verified_stmt(sql_arrow);
+    duckdb().verified_stmt(sql_arrow);
 
     // Test lambda with multiple parameters (with index)
     let sql_multi = "SELECT list_filter([1, 3, 1, 5], lambda x, i : x > i)";
-    duckdb_and_generic().verified_stmt(sql_multi);
+    duckdb().verified_stmt(sql_multi);
 
     // Test lambda in list_transform
     let sql_transform = "SELECT list_transform([1, 2, 3], lambda x : x * 2)";
-    duckdb_and_generic().verified_stmt(sql_transform);
+    duckdb().verified_stmt(sql_transform);
 }


### PR DESCRIPTION
#2149 set "supports_lambda_functions" true for `DuckDbDialect` (which is fine), but also (accidentally?) set it for `GenericDialect` as well, breaking the existing use of `->` as a binary operator. 

This was previously identified in https://github.com/apache/datafusion-sqlparser-rs/pull/1686#discussion_r1934222955 as something that shouldn't be done; the `->` operator should remain a binary operator in `GenericDialect`. 

This PR keeps the `DuckDbDialect` addition, reverts the change to `GenericDialect`, and adds a line of additional coverage to try and prevent any future regression.