### PR TITLE
fix(redshift): support wildcard select items with alias (e.g. t.* AS alias)

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -933,6 +933,9 @@ pub struct WildcardAdditionalOptions {
     pub opt_replace: Option<ReplaceSelectItem>,
     /// `[RENAME ...]`.
     pub opt_rename: Option<RenameSelectItem>,
+    /// `[AS <alias>]`.
+    ///  Redshift syntax: <https://docs.aws.amazon.com/redshift/latest/dg/r_SELECT_list.html>
+    pub opt_alias: Option<Ident>,
 }
 
 impl Default for WildcardAdditionalOptions {
@@ -944,6 +947,7 @@ impl Default for WildcardAdditionalOptions {
             opt_except: None,
             opt_replace: None,
             opt_rename: None,
+            opt_alias: None,
         }
     }
 }
@@ -964,6 +968,9 @@ impl fmt::Display for WildcardAdditionalOptions {
         }
         if let Some(rename) = &self.opt_rename {
             write!(f, " {rename}")?;
+        }
+        if let Some(alias) = &self.opt_alias {
+            write!(f, " AS {alias}")?;
         }
         Ok(())
     }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1824,6 +1824,7 @@ impl Spanned for WildcardAdditionalOptions {
             opt_except,
             opt_replace,
             opt_rename,
+            opt_alias,
         } = self;
 
         union_spans(
@@ -1832,7 +1833,8 @@ impl Spanned for WildcardAdditionalOptions {
                 .chain(opt_exclude.as_ref().map(|i| i.span()))
                 .chain(opt_rename.as_ref().map(|i| i.span()))
                 .chain(opt_replace.as_ref().map(|i| i.span()))
-                .chain(opt_except.as_ref().map(|i| i.span())),
+                .chain(opt_except.as_ref().map(|i| i.span()))
+                .chain(opt_alias.as_ref().map(|i| i.span)),
         )
     }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1512,6 +1512,18 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if this dialect supports aliasing a wildcard select item.
+    ///
+    /// Example:
+    /// ```sql
+    /// SELECT t.* AS alias FROM t
+    /// ```
+    ///
+    /// [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_SELECT_list.html)
+    fn supports_select_wildcard_with_alias(&self) -> bool {
+        false
+    }
+
     /// Returns true if this dialect supports the `OPTIMIZE TABLE` statement.
     ///
     /// Example:

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -141,6 +141,10 @@ impl Dialect for RedshiftSqlDialect {
         true
     }
 
+    fn supports_select_wildcard_with_alias(&self) -> bool {
+        true
+    }
+
     fn supports_select_exclude(&self) -> bool {
         true
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17847,6 +17847,16 @@ impl<'a> Parser<'a> {
             None
         };
 
+        let opt_alias = if self.dialect.supports_select_wildcard_with_alias() {
+            if self.parse_keyword(Keyword::AS) {
+                Some(self.parse_identifier()?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         Ok(WildcardAdditionalOptions {
             wildcard_token: wildcard_token.into(),
             opt_ilike,
@@ -17854,6 +17864,7 @@ impl<'a> Parser<'a> {
             opt_except,
             opt_rename,
             opt_replace,
+            opt_alias,
         })
     }
 

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -452,3 +452,22 @@ fn parse_vacuum() {
         _ => unreachable!(),
     }
 }
+
+
+#[test]
+fn test_redshift_select_wildcard_with_alias() {
+    // qualified wildcard with alias: t.* AS alias
+    redshift()
+        .parse_sql_statements(r#"SELECT t.* AS all_cols FROM t"#)
+        .unwrap();
+
+    // unqualified wildcard with alias
+    redshift()
+        .parse_sql_statements(r#"SELECT * AS all_cols FROM t"#)
+        .unwrap();
+
+    // mixed: regular column + qualified wildcard with alias in a multi-join query
+    redshift()
+        .parse_sql_statements(r#"SELECT a.id, b.* AS b_cols FROM a JOIN b ON (a.id = b.a_id)"#)
+        .unwrap();
+}


### PR DESCRIPTION
## Problem

Redshift supports aliasing wildcard expressions in SELECT statements:
```sql
SELECT t.* AS alias FROM t
```

Previously the parser would fail with:
```
ParserError("Expected: end of statement, found: AS")
```

This was confirmed working on a live Redshift database.

## Solution

- Added `opt_alias: Option<Ident>` field to `WildcardAdditionalOptions`
- Added `supports_select_wildcard_with_alias()` method to the `Dialect` trait (default: `false`)
- Enabled the method in `RedshiftSqlDialect`
- In `parse_wildcard_additional_options`, parse an optional `AS <alias>` when the dialect supports it
- Updated `Display` and span tracking for the new field

## Tests

Added regression tests in `tests/sqlparser_redshift.rs`:
- Qualified wildcard with alias: `SELECT t.* AS all_cols FROM t`
- Unqualified wildcard with alias: `SELECT * AS all_cols FROM t`
- Mixed multi-join query with regular column + qualified wildcard alias