### PR TITLE
MSSQL: support multi-statement T-SQL scripts with line-break delimiters

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18536,6 +18536,9 @@ impl<'a> Parser<'a> {
 
     /// Parse a SQL `EXECUTE` statement
     pub fn parse_execute(&mut self) -> Result<Statement, ParserError> {
+        // Track whether the procedure/expression name itself was wrapped in parens,
+        // i.e. `EXEC (@sql)` (dynamic string execution) vs `EXEC sp_name`.
+        // When the name has parens there are no additional parameters.
         let name = if self.dialect.supports_execute_immediate()
             && self.parse_keyword(Keyword::IMMEDIATE)
         {
@@ -18546,10 +18549,18 @@ impl<'a> Parser<'a> {
             if has_parentheses {
                 self.expect_token(&Token::RParen)?;
             }
-            Some(name)
+            Some((name, has_parentheses))
         };
 
-        let has_parentheses = self.consume_token(&Token::LParen);
+        let name_had_parentheses = name.as_ref().map(|(_, p)| *p).unwrap_or(false);
+
+        // Only look for a parameter list when the name was NOT wrapped in parens.
+        // `EXEC (@sql)` is dynamic SQL execution and takes no parameters here.
+        let has_parentheses = if name_had_parentheses {
+            false
+        } else {
+            self.consume_token(&Token::LParen)
+        };
 
         let end_kws = &[Keyword::USING, Keyword::OUTPUT, Keyword::DEFAULT];
         let end_token = match (has_parentheses, self.peek_token().token) {
@@ -18559,11 +18570,17 @@ impl<'a> Parser<'a> {
             (false, _) => Token::SemiColon,
         };
 
-        let parameters = self.parse_comma_separated0(Parser::parse_expr, end_token)?;
+        let parameters = if name_had_parentheses {
+            vec![]
+        } else {
+            self.parse_comma_separated0(Parser::parse_expr, end_token)?
+        };
 
         if has_parentheses {
             self.expect_token(&Token::RParen)?;
         }
+
+        let name = name.map(|(n, _)| n);
 
         let into = if self.parse_keyword(Keyword::INTO) {
             self.parse_comma_separated(Self::parse_identifier)?


### PR DESCRIPTION
Two issues were blocking the `tsql()` dialect from parsing multi-statement scripts that use newline delimiters instead of semicolons:

### 1. Implicit alias disambiguation

Keywords that begin T-SQL statements (`DECLARE`, `EXEC`/`EXECUTE`, `INSERT`, `UPDATE`, `DELETE`, `DROP`, `CREATE`, `ALTER`, `TRUNCATE`, `PRINT`, `WHILE`, `RETURN`, `THROW`, `RAISERROR`, `MERGE`) were being consumed as implicit aliases for the preceding `SELECT` item or table reference. Added them to both `is_select_item_alias()` and `is_table_factor_alias()` in `MsSqlDialect` so they are never treated as implicit aliases.

### 2. `EXEC (@sql)` – dynamic SQL execution

`parse_execute()` was attempting to consume a second parameter list after already parsing the parenthesised expression name, causing parse failures on tokens that immediately followed the `EXEC` statement. Fixed by detecting that the name was itself wrapped in parens and skipping the parameter-list parse in that case.

### Test

Adds `test_tsql_multi_statement_with_xml_nodes` covering a realistic multi-statement script that exercises `DECLARE`/`SET` chains, XML variable assignment, `SELECT … INTO #temp`, `EXEC (@sql)`, `DROP TABLE`, and plain `SELECT` statements.