### PR TITLE
Support `${placeholder}` syntax in tokenizer

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1920,6 +1920,21 @@ impl<'a> Tokenizer<'a> {
 
         chars.next();
 
+        // Handle ${placeholder} syntax
+        if matches!(chars.peek(), Some('{')) {
+            chars.next(); // consume '{'
+            let placeholder = peeking_take_while(chars, |ch| ch != '}');
+            if matches!(chars.peek(), Some('}')) {
+                chars.next(); // consume '}'
+                return Ok(Token::Placeholder(format!("${{{placeholder}}}")));
+            } else {
+                return self.tokenizer_error(
+                    chars.location(),
+                    "Unterminated dollar-brace placeholder, expected '}'",
+                );
+            }
+        }
+
         // If the dialect does not support dollar-quoted strings, then `$$` is rather a placeholder.
         if matches!(chars.peek(), Some('$')) && !self.dialect.supports_dollar_placeholder() {
             chars.next();
@@ -3216,6 +3231,36 @@ mod tests {
                 Token::Placeholder("$ABC".into()),
             ]
         );
+    }
+
+    #[test]
+    fn tokenize_dollar_brace_placeholder() {
+        let sql = String::from("SELECT ${name}, ${1}");
+        let dialect = GenericDialect {};
+        let tokens = Tokenizer::new(&dialect, &sql).tokenize().unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::make_keyword("SELECT"),
+                Token::Whitespace(Whitespace::Space),
+                Token::Placeholder("${name}".into()),
+                Token::Comma,
+                Token::Whitespace(Whitespace::Space),
+                Token::Placeholder("${1}".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenize_dollar_brace_placeholder_unterminated() {
+        let sql = String::from("SELECT ${name");
+        let dialect = GenericDialect {};
+        let result = Tokenizer::new(&dialect, &sql).tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Unterminated dollar-brace placeholder"));
     }
 
     #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -10469,7 +10469,7 @@ fn test_placeholder() {
         })
     );
 
-    let sql = "SELECT $fromage_français, :x, ?123";
+    let sql = "SELECT $fromage_français, :x, ?123, ${placeholder}";
     let ast = dialects.verified_only_select(sql);
     assert_eq!(
         ast.projection,
@@ -10482,6 +10482,9 @@ fn test_placeholder() {
             )),
             UnnamedExpr(Expr::Value(
                 (Value::Placeholder("?123".into())).with_empty_span()
+            )),
+            UnnamedExpr(Expr::Value(
+                (Value::Placeholder("${placeholder}".into())).with_empty_span()
             )),
         ]
     );


### PR DESCRIPTION
Add support for dollar-brace placeholders (`${name}`, `${1}`, etc.) in the tokenizer, storing the full `${...}` string in the existing `Token::Placeholder` / `Value::Placeholder` variants with zero breaking changes. Unterminated `${name` produces a clear error.