### PR TITLE
Fix credentials parsing for redshift

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -9217,6 +9217,9 @@ pub enum CopyLegacyOption {
     TruncateColumns,
     /// ZSTD
     Zstd,
+    /// Redshift `CREDENTIALS 'auth-args'`
+    /// <https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html>
+    Credentials(String),
 }
 
 impl fmt::Display for CopyLegacyOption {
@@ -9327,6 +9330,7 @@ impl fmt::Display for CopyLegacyOption {
             }
             TruncateColumns => write!(f, "TRUNCATECOLUMNS"),
             Zstd => write!(f, "ZSTD"),
+            Credentials(s) => write!(f, "CREDENTIALS '{}'", value::escape_single_quote_string(s)),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11176,6 +11176,7 @@ impl<'a> Parser<'a> {
             Keyword::BZIP2,
             Keyword::CLEANPATH,
             Keyword::COMPUPDATE,
+            Keyword::CREDENTIALS,
             Keyword::CSV,
             Keyword::DATEFORMAT,
             Keyword::DELIMITER,
@@ -11232,6 +11233,9 @@ impl<'a> Parser<'a> {
                     _ => None,
                 };
                 CopyLegacyOption::CompUpdate { preset, enabled }
+            }
+            Some(Keyword::CREDENTIALS) => {
+                CopyLegacyOption::Credentials(self.parse_literal_string()?)
             }
             Some(Keyword::CSV) => CopyLegacyOption::Csv({
                 let mut opts = vec![];

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -467,3 +467,10 @@ fn test_create_table_diststyle() {
     redshift().verified_stmt("CREATE TABLE t1 (c1 INT) DISTSTYLE KEY DISTKEY(c1)");
     redshift().verified_stmt("CREATE TABLE t1 (c1 INT) DISTSTYLE ALL");
 }
+
+#[test]
+fn test_copy_credentials() {
+    redshift().verified_stmt(
+        "COPY t1 FROM 's3://bucket/file.csv' CREDENTIALS 'aws_access_key_id=AK;aws_secret_access_key=SK' CSV",
+    );
+}


### PR DESCRIPTION
Fix CREDENTIALS keyword parsing for redshift

Sample query:

```
COPY table1
FROM 's3://my-bucket/my-file.csv'
CREDENTIALS 'aws_access_key_id=AKIAEXAMPLE;aws_secret_access_key=SECRETEXAMPLE'
CSV;
```

Spec: https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html?utm_source=chatgpt.com