### PR TITLE
Fixed parsing `OPTIONS(format = 'CSV')` when creating external bigquery table

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6297,6 +6297,8 @@ impl<'a> Parser<'a> {
         let table_properties = self.parse_options(Keyword::TBLPROPERTIES)?;
         let table_options = if !table_properties.is_empty() {
             CreateTableOptions::TableProperties(table_properties)
+        } else if let Some(options) = self.maybe_parse_options(Keyword::OPTIONS)? {
+            CreateTableOptions::Options(options)
         } else {
             CreateTableOptions::None
         };

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -592,6 +592,16 @@ fn parse_create_table_with_options() {
 }
 
 #[test]
+fn parse_create_external_table_with_options() {
+    bigquery().verified_stmt(
+        "CREATE EXTERNAL TABLE dataset_id.table1 (hvr_tx_seq STRING) OPTIONS(format = 'CSV')",
+    );
+    bigquery().verified_stmt(
+        "CREATE EXTERNAL TABLE dataset_id.table1 (hvr_tx_seq STRING) OPTIONS(format = 'CSV', allow_quoted_newlines = true, encoding = 'UTF8')",
+    );
+}
+
+#[test]
 fn parse_nested_data_types() {
     let sql = "CREATE TABLE table (x STRUCT<a ARRAY<INT64>, b BYTES(42)>, y ARRAY<STRUCT<INT64>>)";
     match bigquery_and_generic().one_statement_parses_to(sql, sql) {


### PR DESCRIPTION
Sample query:
```sql
CREATE EXTERNAL TABLE `dataset_id.table1` (
    `hvr_tx_seq` STRING
) OPTIONS (
    format = 'CSV'
);
```

Spec: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_external_table_statement