### PR TITLE
Fixed BACKUP parsing for redshift

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -3051,6 +3051,9 @@ pub struct CreateTable {
     /// Redshift `SORTKEY` option
     /// <https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html>
     pub sortkey: Option<Vec<Expr>>,
+    /// Redshift `BACKUP` option: `BACKUP { YES | NO }`
+    /// <https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html>
+    pub backup: Option<bool>,
 }
 
 impl fmt::Display for CreateTable {
@@ -3348,6 +3351,9 @@ impl fmt::Display for CreateTable {
         }
         if self.strict {
             write!(f, " STRICT")?;
+        }
+        if let Some(backup) = self.backup {
+            write!(f, " BACKUP {}", if backup { "YES" } else { "NO" })?;
         }
         if let Some(diststyle) = &self.diststyle {
             write!(f, " DISTSTYLE {diststyle}")?;

--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -177,6 +177,8 @@ pub struct CreateTableBuilder {
     pub distkey: Option<Expr>,
     /// Redshift `SORTKEY` option.
     pub sortkey: Option<Vec<Expr>>,
+    /// Redshift `BACKUP` option.
+    pub backup: Option<bool>,
 }
 
 impl CreateTableBuilder {
@@ -239,6 +241,7 @@ impl CreateTableBuilder {
             diststyle: None,
             distkey: None,
             sortkey: None,
+            backup: None,
         }
     }
     /// Set `OR REPLACE` for the CREATE TABLE statement.
@@ -529,6 +532,11 @@ impl CreateTableBuilder {
         self.sortkey = sortkey;
         self
     }
+    /// Set the Redshift `BACKUP` option.
+    pub fn backup(mut self, backup: Option<bool>) -> Self {
+        self.backup = backup;
+        self
+    }
     /// Consume the builder and produce a `CreateTable`.
     pub fn build(self) -> CreateTable {
         CreateTable {
@@ -588,6 +596,7 @@ impl CreateTableBuilder {
             diststyle: self.diststyle,
             distkey: self.distkey,
             sortkey: self.sortkey,
+            backup: self.backup,
         }
     }
 }
@@ -666,6 +675,7 @@ impl From<CreateTable> for CreateTableBuilder {
             diststyle: table.diststyle,
             distkey: table.distkey,
             sortkey: table.sortkey,
+            backup: table.backup,
         }
     }
 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -585,6 +585,7 @@ impl Spanned for CreateTable {
             diststyle: _,
             distkey: _,
             sortkey: _,
+            backup: _,
         } = self;
 
         union_spans(

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -145,6 +145,7 @@ define_keywords!(
     AVG,
     AVG_ROW_LENGTH,
     AVRO,
+    BACKUP,
     BACKWARD,
     BASE64,
     BASE_LOCATION,
@@ -1168,6 +1169,7 @@ define_keywords!(
     XOR,
     YEAR,
     YEARS,
+    YES,
     ZONE,
     ZORDER,
     ZSTD

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8388,6 +8388,14 @@ impl<'a> Parser<'a> {
 
         let strict = self.parse_keyword(Keyword::STRICT);
 
+        // Redshift: BACKUP YES|NO
+        let backup = if self.parse_keyword(Keyword::BACKUP) {
+            let keyword = self.expect_one_of_keywords(&[Keyword::YES, Keyword::NO])?;
+            Some(keyword == Keyword::YES)
+        } else {
+            None
+        };
+
         // Redshift: DISTSTYLE, DISTKEY, SORTKEY
         let diststyle = if self.parse_keyword(Keyword::DISTSTYLE) {
             Some(self.parse_dist_style()?)
@@ -8450,6 +8458,7 @@ impl<'a> Parser<'a> {
             .table_options(create_table_config.table_options)
             .primary_key(primary_key)
             .strict(strict)
+            .backup(backup)
             .diststyle(diststyle)
             .distkey(distkey)
             .sortkey(sortkey)

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -791,6 +791,7 @@ fn test_duckdb_union_datatype() {
             diststyle: Default::default(),
             distkey: Default::default(),
             sortkey: Default::default(),
+            backup: Default::default(),
         }),
         stmt
     );

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2009,6 +2009,7 @@ fn parse_create_table_with_valid_options() {
                 diststyle: None,
                 distkey: None,
                 sortkey: None,
+                backup: None,
             })
         );
     }
@@ -2180,6 +2181,7 @@ fn parse_create_table_with_identity_column() {
                 diststyle: None,
                 distkey: None,
                 sortkey: None,
+                backup: None,
             }),
         );
     }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -6477,6 +6477,7 @@ fn parse_trigger_related_functions() {
             diststyle: None,
             distkey: None,
             sortkey: None,
+            backup: None,
         }
     );
 

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -500,3 +500,14 @@ fn test_alter_table_alter_sortkey() {
     redshift().verified_stmt("ALTER TABLE users ALTER SORTKEY(created_at)");
     redshift().verified_stmt("ALTER TABLE users ALTER SORTKEY(c1, c2)");
 }
+
+#[test]
+fn test_create_table_backup() {
+    redshift().verified_stmt("CREATE TABLE public.users (id INT, name VARCHAR(255)) BACKUP YES");
+
+    redshift().verified_stmt("CREATE TABLE staging.events (event_id INT) BACKUP NO");
+
+    redshift().verified_stmt(
+        "CREATE TABLE public.users_backup_test BACKUP YES DISTSTYLE AUTO AS SELECT id, name, email FROM public.users",
+    );
+}


### PR DESCRIPTION
Example of query:

```sql
CREATE TABLE public.users_backup_test
BACKUP YES
DISTSTYLE AUTO
SORTKEY (id)
AS
SELECT id, name, email
FROM public.users;
```

Spec: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html