### PR TITLE
Added encode, distkey, sortkey in attributes support for redshift

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2001,6 +2001,21 @@ pub enum ColumnOption {
     /// ```
     /// [MySQL]: https://dev.mysql.com/doc/refman/8.4/en/invisible-columns.html
     Invisible,
+    /// Redshift specific: Column compression encoding
+    /// Syntax: `ENCODE encoding`
+    ///
+    /// [Redshift]: https://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html
+    Encode(Ident),
+    /// Redshift specific: Column-level `DISTKEY` attribute
+    /// Syntax: `DISTKEY`
+    ///
+    /// [Redshift]: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
+    DistKey,
+    /// Redshift specific: Column-level `SORTKEY` attribute
+    /// Syntax: `SORTKEY`
+    ///
+    /// [Redshift]: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
+    SortKey,
 }
 
 impl From<UniqueConstraint> for ColumnOption {
@@ -2150,6 +2165,9 @@ impl fmt::Display for ColumnOption {
             Invisible => {
                 write!(f, "INVISIBLE")
             }
+            Encode(encoding) => write!(f, "ENCODE {encoding}"),
+            DistKey => write!(f, "DISTKEY"),
+            SortKey => write!(f, "SORTKEY"),
         }
     }
 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -825,6 +825,9 @@ impl Spanned for ColumnOption {
             ColumnOption::Tags(..) => Span::empty(),
             ColumnOption::Srid(..) => Span::empty(),
             ColumnOption::Invisible => Span::empty(),
+            ColumnOption::Encode(_) => Span::empty(),
+            ColumnOption::DistKey => Span::empty(),
+            ColumnOption::SortKey => Span::empty(),
         }
     }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -360,6 +360,7 @@ define_keywords!(
     EMPTYASNULL,
     ENABLE,
     ENABLE_SCHEMA_EVOLUTION,
+    ENCODE,
     ENCODING,
     ENCRYPTED,
     ENCRYPTION,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9331,6 +9331,12 @@ impl<'a> Parser<'a> {
             )))
         } else if self.parse_keyword(Keyword::INVISIBLE) {
             Ok(Some(ColumnOption::Invisible))
+        } else if self.parse_keyword(Keyword::ENCODE) {
+            Ok(Some(ColumnOption::Encode(self.parse_identifier()?)))
+        } else if self.parse_keyword(Keyword::DISTKEY) {
+            Ok(Some(ColumnOption::DistKey))
+        } else if self.parse_keyword(Keyword::SORTKEY) {
+            Ok(Some(ColumnOption::SortKey))
         } else {
             Ok(None)
         }

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -500,3 +500,17 @@ fn test_alter_table_alter_sortkey() {
     redshift().verified_stmt("ALTER TABLE users ALTER SORTKEY(created_at)");
     redshift().verified_stmt("ALTER TABLE users ALTER SORTKEY(c1, c2)");
 }
+
+#[test]
+fn test_create_table_with_column_options() {
+    // Column-level ENCODE, DISTKEY, SORTKEY
+    redshift().verified_stmt(
+        "CREATE TABLE player_activity (date DATE ENCODE raw DISTKEY NOT NULL, userid INTEGER ENCODE az64 NOT NULL) DISTSTYLE KEY SORTKEY(date, userid)",
+    );
+
+    redshift().verified_stmt("CREATE TABLE t1 (c1 INT DISTKEY, c2 INT SORTKEY)");
+
+    redshift().verified_stmt(
+        "CREATE TABLE t1 (c1 INT ENCODE az64 NOT NULL, c2 VARCHAR(100) ENCODE lzo DEFAULT 'x')",
+    );
+}


### PR DESCRIPTION
Sample query:
```sql
CREATE TABLE player_activity (date DATE ENCODE raw DISTKEY NOT NULL, userid INTEGER ENCODE az64 NOT NULL) DISTSTYLE KEY SORTKEY(date, userid)
```

Spec: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html