### PR TITLE
Added support AUTO REFRESH in CREATE MATERIALIZED VIEW for redshift

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -4334,6 +4334,9 @@ pub struct CreateView {
     pub to: Option<ObjectName>,
     /// MySQL: Optional parameters for the view algorithm, definer, and security context
     pub params: Option<CreateViewParams>,
+    /// Redshift: `AUTO REFRESH { YES | NO }`
+    /// <https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-create-sql-command.html>
+    pub auto_refresh: Option<bool>,
 }
 
 impl fmt::Display for CreateView {
@@ -4393,6 +4396,13 @@ impl fmt::Display for CreateView {
         }
         if matches!(self.options, CreateTableOptions::Options(_)) {
             write!(f, " {}", self.options)?;
+        }
+        if let Some(auto_refresh) = self.auto_refresh {
+            write!(
+                f,
+                " AUTO REFRESH {}",
+                if auto_refresh { "YES" } else { "NO" }
+            )?;
         }
         f.write_str(" AS")?;
         SpaceOrNewline.fmt(f)?;

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1171,6 +1171,7 @@ define_keywords!(
     XOR,
     YEAR,
     YEARS,
+    YES,
     ZONE,
     ZORDER,
     ZSTD

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6474,6 +6474,17 @@ impl<'a> Parser<'a> {
             None
         };
 
+        let auto_refresh = if self.parse_keywords(&[Keyword::AUTO, Keyword::REFRESH]) {
+            if self.parse_keyword(Keyword::YES) {
+                Some(true)
+            } else {
+                self.expect_keyword_is(Keyword::NO)?;
+                Some(false)
+            }
+        } else {
+            None
+        };
+
         self.expect_keyword_is(Keyword::AS)?;
         let query = self.parse_query()?;
         // Optional `WITH [ CASCADED | LOCAL ] CHECK OPTION` is widely supported here.
@@ -6504,6 +6515,7 @@ impl<'a> Parser<'a> {
             to,
             params: create_view_params,
             name_before_not_exists,
+            auto_refresh,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8318,6 +8318,7 @@ fn parse_create_view() {
             name_before_not_exists: _,
             secure: _,
             copy_grants: _,
+            auto_refresh: _,
         }) => {
             assert_eq!(or_alter, false);
             assert_eq!("myschema.myview", name.to_string());
@@ -8437,6 +8438,7 @@ fn parse_create_view_temporary() {
             name_before_not_exists: _,
             secure: _,
             copy_grants: _,
+            auto_refresh: _,
         }) => {
             assert_eq!(or_alter, false);
             assert_eq!("myschema.myview", name.to_string());
@@ -8479,6 +8481,7 @@ fn parse_create_or_replace_view() {
             name_before_not_exists: _,
             secure: _,
             copy_grants: _,
+            auto_refresh: _,
         }) => {
             assert_eq!(or_alter, false);
             assert_eq!("v", name.to_string());
@@ -8525,6 +8528,7 @@ fn parse_create_or_replace_materialized_view() {
             name_before_not_exists: _,
             secure: _,
             copy_grants: _,
+            auto_refresh: _,
         }) => {
             assert_eq!(or_alter, false);
             assert_eq!("v", name.to_string());
@@ -8567,6 +8571,7 @@ fn parse_create_materialized_view() {
             name_before_not_exists: _,
             secure: _,
             copy_grants: _,
+            auto_refresh: _,
         }) => {
             assert_eq!(or_alter, false);
             assert_eq!("myschema.myview", name.to_string());
@@ -8609,6 +8614,7 @@ fn parse_create_materialized_view_with_cluster_by() {
             name_before_not_exists: _,
             secure: _,
             copy_grants: _,
+            auto_refresh: _,
         }) => {
             assert_eq!(or_alter, false);
             assert_eq!("myschema.myview", name.to_string());

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -500,3 +500,15 @@ fn test_alter_table_alter_sortkey() {
     redshift().verified_stmt("ALTER TABLE users ALTER SORTKEY(created_at)");
     redshift().verified_stmt("ALTER TABLE users ALTER SORTKEY(c1, c2)");
 }
+
+#[test]
+fn test_create_materialized_view_auto_refresh() {
+    redshift().verified_stmt(
+        r#"CREATE MATERIALIZED VIEW mview AUTO REFRESH YES AS (SELECT MAX("a"."b") AS "max" FROM "table1")"#,
+    );
+
+    redshift().verified_stmt("CREATE MATERIALIZED VIEW mv1 AUTO REFRESH NO AS SELECT 1");
+
+    // Without AUTO REFRESH
+    redshift().verified_stmt("CREATE MATERIALIZED VIEW mv1 AS SELECT 1");
+}


### PR DESCRIPTION
Sample query:
```
CREATE MATERIALIZED VIEW pg_automv.auto_mv_937042222 AUTO REFRESH YES AS (SELECT MAX("transhistory_paymentmethod"."transid") AS "aggvar_2" FROM "payments"."transhistory_paymentmethod" AS "transhistory_paymentmethod");
```

Spec: https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-create-sql-command.html