### PR TITLE
Redshift/PostgreSQL: Parse optional implicit aliases for wildcard select items

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1556,10 +1556,9 @@ pub trait Dialect: Debug + Any {
     ///
     /// Example:
     /// ```sql
+    /// SELECT t.* alias FROM t
     /// SELECT t.* AS alias FROM t
     /// ```
-    ///
-    /// [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_SELECT_list.html)
     fn supports_select_wildcard_with_alias(&self) -> bool {
         false
     }

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -307,6 +307,10 @@ impl Dialect for PostgreSqlDialect {
         true
     }
 
+    fn supports_select_wildcard_with_alias(&self) -> bool {
+        true
+    }
+
     fn supports_comma_separated_trim(&self) -> bool {
         true
     }

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -141,6 +141,8 @@ impl Dialect for RedshiftSqlDialect {
         true
     }
 
+    /// Redshift supports aliasing wildcard expressions:
+    /// <https://docs.aws.amazon.com/redshift/latest/dg/r_SELECT_list.html>
     fn supports_select_wildcard_with_alias(&self) -> bool {
         true
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18448,11 +18448,7 @@ impl<'a> Parser<'a> {
         };
 
         let opt_alias = if self.dialect.supports_select_wildcard_with_alias() {
-            if self.parse_keyword(Keyword::AS) {
-                Some(self.parse_identifier()?)
-            } else {
-                None
-            }
+            self.maybe_parse_select_item_alias()?
         } else {
             None
         };

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1295,16 +1295,29 @@ fn parse_select_wildcard_with_alias() {
     dialects
         .parse_sql_statements("SELECT t.* AS all_cols FROM t")
         .unwrap();
+    dialects.one_statement_parses_to(
+        "SELECT t.* all_cols FROM t",
+        "SELECT t.* AS all_cols FROM t",
+    );
+    dialects.one_statement_parses_to(
+        "SELECT t.* all_cols, other_col FROM t",
+        "SELECT t.* AS all_cols, other_col FROM t",
+    );
 
     // unqualified wildcard with alias
     dialects
         .parse_sql_statements("SELECT * AS all_cols FROM t")
         .unwrap();
+    dialects.one_statement_parses_to("SELECT * all_cols FROM t", "SELECT * AS all_cols FROM t");
 
     // mixed: regular column + qualified wildcard with alias
     dialects
         .parse_sql_statements("SELECT a.id, b.* AS b_cols FROM a JOIN b ON (a.id = b.a_id)")
         .unwrap();
+    dialects.one_statement_parses_to(
+        "SELECT a.id, b.* b_cols FROM a JOIN b ON (a.id = b.a_id)",
+        "SELECT a.id, b.* AS b_cols FROM a JOIN b ON (a.id = b.a_id)",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Add support for implicit aliases of wildcard select items, for example: `SELECT c.* cols FROM tbl`, which previously the parser would fail on, but are accepted by the dialects.

Semantically, however, it looks like the databases are ignoring this construct. For example, when running the following statement, PostgreSQL fails with the error `column "c1" does not exist`:
```sql
SELECT c.* AS c1
FROM customers AS c
ORDER BY c1;
```
