### PR TITLE
Postgres regression 7b

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1332,6 +1332,12 @@ pub enum Expr {
     Lambda(LambdaFunction),
     /// Checks membership of a value in a JSON array
     MemberOf(MemberOf),
+    /// PostgreSQL `XMLCONCAT(xml[, ...])` — concatenates a list of
+    /// individual XML values to create a single value containing an
+    /// XML content fragment.
+    ///
+    /// [PostgreSQL](https://www.postgresql.org/docs/current/functions-xml.html#FUNCTIONS-PRODUCING-XML-XMLCONCAT)
+    XmlConcat(Vec<Expr>),
 }
 
 impl Expr {
@@ -2182,6 +2188,9 @@ impl fmt::Display for Expr {
             Expr::Prior(expr) => write!(f, "PRIOR {expr}"),
             Expr::Lambda(lambda) => write!(f, "{lambda}"),
             Expr::MemberOf(member_of) => write!(f, "{member_of}"),
+            Expr::XmlConcat(exprs) => {
+                write!(f, "XMLCONCAT({})", display_comma_separated(exprs))
+            }
         }
     }
 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1651,6 +1651,7 @@ impl Spanned for Expr {
             Expr::Prior(expr) => expr.span(),
             Expr::Lambda(_) => Span::empty(),
             Expr::MemberOf(member_of) => member_of.value.span().union(&member_of.array.span()),
+            Expr::XmlConcat(exprs) => union_spans(exprs.iter().map(|e| e.span())),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2430,7 +2430,45 @@ impl<'a> Parser<'a> {
 
     /// Parse a function call expression named by `name` and return it as an `Expr`.
     pub fn parse_function(&mut self, name: ObjectName) -> Result<Expr, ParserError> {
+        if let Some(expr) = self.maybe_parse_xml_function(&name)? {
+            return Ok(expr);
+        }
         self.parse_function_call(name).map(Expr::Function)
+    }
+
+    /// If `name` is a PostgreSQL XML function and the current dialect
+    /// supports XML expressions, parse it as a dedicated [`Expr`]
+    /// variant rather than a generic function call.
+    ///
+    /// Returns `Ok(None)` when the name is not an XML function or the
+    /// dialect does not support XML expressions, in which case the
+    /// caller should fall back to the regular function-call parser.
+    fn maybe_parse_xml_function(
+        &mut self,
+        name: &ObjectName,
+    ) -> Result<Option<Expr>, ParserError> {
+        if !self.dialect.supports_xml_expressions() {
+            return Ok(None);
+        }
+        let [ObjectNamePart::Identifier(ident)] = name.0.as_slice() else {
+            return Ok(None);
+        };
+        if ident.quote_style.is_some() {
+            return Ok(None);
+        }
+        if ident.value.eq_ignore_ascii_case("xmlconcat") {
+            return Ok(Some(self.parse_xmlconcat_expr()?));
+        }
+        Ok(None)
+    }
+
+    /// Parse the argument list of a PostgreSQL `XMLCONCAT` expression:
+    /// `(expr [, expr]...)`.
+    fn parse_xmlconcat_expr(&mut self) -> Result<Expr, ParserError> {
+        self.expect_token(&Token::LParen)?;
+        let exprs = self.parse_comma_separated(Parser::parse_expr)?;
+        self.expect_token(&Token::RParen)?;
+        Ok(Expr::XmlConcat(exprs))
     }
 
     fn parse_function_call(&mut self, name: ObjectName) -> Result<Function, ParserError> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2443,10 +2443,7 @@ impl<'a> Parser<'a> {
     /// Returns `Ok(None)` when the name is not an XML function or the
     /// dialect does not support XML expressions, in which case the
     /// caller should fall back to the regular function-call parser.
-    fn maybe_parse_xml_function(
-        &mut self,
-        name: &ObjectName,
-    ) -> Result<Option<Expr>, ParserError> {
+    fn maybe_parse_xml_function(&mut self, name: &ObjectName) -> Result<Option<Expr>, ParserError> {
         if !self.dialect.supports_xml_expressions() {
             return Ok(None);
         }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -18785,14 +18785,11 @@ fn parse_non_pg_dialects_keep_xml_names_as_regular_functions() {
     // On dialects that do NOT support XML expressions, `xmlconcat(...)`
     // should parse as a plain function call, not as `Expr::XmlConcat`.
     let dialects = all_dialects_except(|d| d.supports_xml_expressions());
-    for fn_name in ["xmlconcat"] {
-        let sql = format!("SELECT {fn_name}(1, 2)");
-        let select = dialects.verified_only_select(&sql);
-        match expr_from_projection(&select.projection[0]) {
-            Expr::Function(func) => {
-                assert_eq!(func.name.to_string(), fn_name);
-            }
-            other => panic!("Expected Expr::Function for {fn_name}, got: {other:?}"),
+    let select = dialects.verified_only_select("SELECT xmlconcat(1, 2)");
+    match expr_from_projection(&select.projection[0]) {
+        Expr::Function(func) => {
+            assert_eq!(func.name.to_string(), "xmlconcat");
         }
+        other => panic!("Expected Expr::Function, got: {other:?}"),
     }
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -18779,3 +18779,20 @@ fn parse_non_pg_dialects_keep_xml_names_as_regular_identifiers() {
     let dialects = all_dialects_except(|d| d.supports_xml_expressions());
     dialects.verified_only_select("SELECT xml FROM t");
 }
+
+#[test]
+fn parse_non_pg_dialects_keep_xml_names_as_regular_functions() {
+    // On dialects that do NOT support XML expressions, `xmlconcat(...)`
+    // should parse as a plain function call, not as `Expr::XmlConcat`.
+    let dialects = all_dialects_except(|d| d.supports_xml_expressions());
+    for fn_name in ["xmlconcat"] {
+        let sql = format!("SELECT {fn_name}(1, 2)");
+        let select = dialects.verified_only_select(&sql);
+        match expr_from_projection(&select.projection[0]) {
+            Expr::Function(func) => {
+                assert_eq!(func.name.to_string(), fn_name);
+            }
+            other => panic!("Expected Expr::Function for {fn_name}, got: {other:?}"),
+        }
+    }
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3751,6 +3751,31 @@ fn parse_on_commit() {
 }
 
 #[test]
+fn parse_xmlconcat_expression() {
+    // XMLCONCAT should parse as a dedicated Expr::XmlConcat variant on
+    // PostgreSQL and Generic, preserving argument order.
+    let sql = "SELECT XMLCONCAT('<a/>', '<b/>', '<c/>')";
+    let select = pg_and_generic().verified_only_select(sql);
+    match expr_from_projection(&select.projection[0]) {
+        Expr::XmlConcat(exprs) => {
+            assert_eq!(exprs.len(), 3);
+            let strings: Vec<String> = exprs
+                .iter()
+                .map(|e| match e {
+                    Expr::Value(v) => match &v.value {
+                        Value::SingleQuotedString(s) => s.clone(),
+                        other => panic!("Expected SingleQuotedString, got: {other:?}"),
+                    },
+                    other => panic!("Expected Value, got: {other:?}"),
+                })
+                .collect();
+            assert_eq!(strings, vec!["<a/>", "<b/>", "<c/>"]);
+        }
+        other => panic!("Expected Expr::XmlConcat, got: {other:?}"),
+    }
+}
+
+#[test]
 fn parse_xml_typed_string() {
     // xml '...' should parse as a TypedString on PostgreSQL and Generic
     let sql = "SELECT xml '<foo/>'";


### PR DESCRIPTION
- Add `Expr::XmlConcat(Vec<Expr>)` variant with `Display` and `Spanned` implementations for PostgreSQL's [`XMLCONCAT(xml[, ...])`](https://www.postgresql.org/docs/current/functions-xml.html#FUNCTIONS-PRODUCING-XML-XMLCONCAT) function
- Introduce `maybe_parse_xml_function` dispatcher in the parser, hooked at the top of `parse_function`, which routes XML function names to dedicated AST nodes on dialects where `supports_xml_expressions()` is true
- Guards on a single unquoted identifier with case-insensitive matching, so only bare `xmlconcat(...)` on PostgreSQL and Generic dialects takes the new path — all other dialects and qualified/quoted names fall through to the normal function-call parser

This is the second PR in a chain splitting #2252 (XML function support) into reviewable units. Builds on #2299 which introduced the `supports_xml_expressions()` dialect method.