### PR TITLE
PostgreSQL: Parse optimizer hints in leading comments

### DIFF
--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -318,4 +318,12 @@ impl Dialect for PostgreSqlDialect {
     fn supports_xml_expressions(&self) -> bool {
         true
     }
+
+    /// Postgres supports query optimizer hints via the `pg_hint_plan` extension,
+    /// using the same comment-prefixed-with-`+` syntax as MySQL and Oracle.
+    ///
+    /// See <https://github.com/ossc-db/pg_hint_plan>
+    fn supports_comment_optimizer_hint(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
Enable comment-based optimizer hint parsing for the PostgreSQL dialect by overriding `supports_comment_optimizer_hint` to return `true`.

PostgreSQL itself does not ship a built-in hint system, but the widely used `pg_hint_plan` extension (https://github.com/ossc-db/pg_hint_plan) introduces hints using the exact same `/*+ ... */` block-comment and `--+ ...` single-line-comment syntax already supported for MySQL and Oracle (#2162). Without this flag, parsing a `pg_hint_plan` statement such as:

    SELECT /*+ SeqScan(t) */ * FROM t;

discards the hint as an ordinary comment, making it impossible for downstream tools (query rewriters, proxies, planners) built on `sqlparser-rs` to preserve or act on hints when targeting PostgreSQL.

The parser side already handles this via `maybe_parse_optimizer_hint` across SELECT / INSERT / UPDATE / DELETE / MERGE, so no parser or AST changes are required — this is purely a dialect opt-in. The default remains `false`, so no other dialect is affected.