### PR TITLE
Snowflake: Accept COPY GRANTS after CREATE VIEW column list

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6533,10 +6533,16 @@ impl<'a> Parser<'a> {
         let name_before_not_exists = !if_not_exists_first
             && self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
         let if_not_exists = if_not_exists_first || name_before_not_exists;
-        let copy_grants = self.parse_keywords(&[Keyword::COPY, Keyword::GRANTS]);
+        let mut copy_grants = self.parse_keywords(&[Keyword::COPY, Keyword::GRANTS]);
         // Many dialects support `OR ALTER` right after `CREATE`, but we don't (yet).
         // ANSI SQL and Postgres support RECURSIVE here, but we don't support it either.
         let columns = self.parse_view_columns()?;
+        // Snowflake also documents `COPY GRANTS` *after* the column list; accept
+        // either position, but not both.
+        // <https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax>
+        if !copy_grants {
+            copy_grants = self.parse_keywords(&[Keyword::COPY, Keyword::GRANTS]);
+        }
         let mut options = CreateTableOptions::None;
         let with_options = self.parse_options(Keyword::WITH)?;
         if !with_options.is_empty() {

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -4766,11 +4766,6 @@ fn test_snowflake_create_view_copy_grants() {
 
 #[test]
 fn test_snowflake_create_view_copy_grants_after_columns() {
-    // Snowflake's documented placement for `COPY GRANTS` on `CREATE VIEW` is
-    // *after* the column list. Display normalizes to the pre-columns form
-    // already supported, so use `one_statement_parses_to` to assert the
-    // post-columns input is accepted and the AST flag is set.
-    // <https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax>
     let cases = [
         (
             "CREATE OR REPLACE VIEW v (a, b) COPY GRANTS AS SELECT a, b FROM t",
@@ -4786,28 +4781,9 @@ fn test_snowflake_create_view_copy_grants_after_columns() {
         ),
     ];
     for (sql, parsed) in cases {
-        match snowflake().one_statement_parses_to(sql, parsed) {
-            Statement::CreateView(CreateView {
-                name,
-                copy_grants,
-                columns,
-                ..
-            }) => {
-                assert_eq!("v", name.to_string());
-                assert!(copy_grants, "copy_grants should be true for {sql:?}");
-                assert!(!columns.is_empty(), "columns should be set for {sql:?}");
-            }
-            _ => unreachable!(),
-        }
+        snowflake().one_statement_parses_to(sql, parsed);
     }
-
-    // Baseline: the same query without COPY GRANTS must not flip the flag.
-    match snowflake().verified_stmt("CREATE OR REPLACE VIEW v (a) AS SELECT a FROM t") {
-        Statement::CreateView(CreateView { copy_grants, .. }) => {
-            assert!(!copy_grants);
-        }
-        _ => unreachable!(),
-    }
+    snowflake().verified_stmt("CREATE OR REPLACE VIEW v (a) AS SELECT a FROM t");
 }
 
 #[test]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -4765,6 +4765,52 @@ fn test_snowflake_create_view_copy_grants() {
 }
 
 #[test]
+fn test_snowflake_create_view_copy_grants_after_columns() {
+    // Snowflake's documented placement for `COPY GRANTS` on `CREATE VIEW` is
+    // *after* the column list. Display normalizes to the pre-columns form
+    // already supported, so use `one_statement_parses_to` to assert the
+    // post-columns input is accepted and the AST flag is set.
+    // <https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax>
+    let cases = [
+        (
+            "CREATE OR REPLACE VIEW v (a, b) COPY GRANTS AS SELECT a, b FROM t",
+            "CREATE OR REPLACE VIEW v COPY GRANTS (a, b) AS SELECT a, b FROM t",
+        ),
+        (
+            "CREATE OR REPLACE SECURE VIEW v (a, b) COPY GRANTS AS SELECT a, b FROM t",
+            "CREATE OR REPLACE SECURE VIEW v COPY GRANTS (a, b) AS SELECT a, b FROM t",
+        ),
+        (
+            "CREATE MATERIALIZED VIEW v (a) COPY GRANTS AS SELECT a FROM t",
+            "CREATE MATERIALIZED VIEW v COPY GRANTS (a) AS SELECT a FROM t",
+        ),
+    ];
+    for (sql, parsed) in cases {
+        match snowflake().one_statement_parses_to(sql, parsed) {
+            Statement::CreateView(CreateView {
+                name,
+                copy_grants,
+                columns,
+                ..
+            }) => {
+                assert_eq!("v", name.to_string());
+                assert!(copy_grants, "copy_grants should be true for {sql:?}");
+                assert!(!columns.is_empty(), "columns should be set for {sql:?}");
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // Baseline: the same query without COPY GRANTS must not flip the flag.
+    match snowflake().verified_stmt("CREATE OR REPLACE VIEW v (a) AS SELECT a FROM t") {
+        Statement::CreateView(CreateView { copy_grants, .. }) => {
+            assert!(!copy_grants);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn test_snowflake_identifier_function() {
     // Using IDENTIFIER to reference a column
     match &snowflake()


### PR DESCRIPTION
## Summary

Snowflake's [`CREATE VIEW` syntax][docs] documents `COPY GRANTS` as appearing
*after* the column list:

```sql
CREATE OR REPLACE VIEW v (a, b) COPY GRANTS AS SELECT a, b FROM t;
```

The parser already accepted `COPY GRANTS` *before* the column list, but
rejected the documented post-columns position. This PR accepts either
position (but not both).

[docs]: https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax

## Changes

- `parse_create_view`: after consuming the column list, attempt a second
  `COPY GRANTS` match if one wasn't already seen.
- `Display` continues to emit the pre-columns form, so the post-columns input
  round-trips to the existing canonical shape.
- Tests: cover `VIEW`, `SECURE VIEW`, and `MATERIALIZED VIEW` with
  post-columns `COPY GRANTS`, and a baseline asserting the flag is not
  spuriously set when `COPY GRANTS` is absent.

## Test plan

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`