### PR TITLE
Snowflake: Fix COPY INTO transformation parsing for cast expressions

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -1545,6 +1545,14 @@ fn parse_select_item_for_data_load(
         }
     }
 
+    // A trailing `::` means this is a cast expression (e.g.
+    // `$1:"col"::NUMBER(38,0)`), not a stage-load-select-item. Bail so
+    // `maybe_parse` rewinds and the caller falls through to
+    // `parse_select_item`, which handles the cast correctly.
+    if matches!(parser.peek_token_ref().token, Token::DoubleColon) {
+        return parser.expected("stage load select item", parser.peek_token());
+    }
+
     // as
     if parser.parse_keyword(Keyword::AS) {
         item_as = Some(match parser.next_token().token {

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -1546,9 +1546,7 @@ fn parse_select_item_for_data_load(
     }
 
     // A trailing `::` means this is a cast expression (e.g.
-    // `$1:"col"::NUMBER(38,0)`), not a stage-load-select-item. Bail so
-    // `maybe_parse` rewinds and the caller falls through to
-    // `parse_select_item`, which handles the cast correctly.
+    // `$1:"col"::NUMBER(38,0)`), not a stage-load-select-item.
     if matches!(parser.peek_token_ref().token, Token::DoubleColon) {
         return parser.expected("stage load select item", parser.peek_token());
     }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2448,6 +2448,49 @@ fn test_copy_into_with_transformations() {
 }
 
 #[test]
+fn test_copy_into_with_cast_transformation() {
+    // Snowflake `COPY INTO` transformation lists support casts like
+    // `$1:"col"::TYPE` and `$1::TYPE`. These are distinct from the bare
+    // `$<n>[.<col>][:<elem>]` stage-load-select-item shape, so the parser
+    // must fall through to the generic select-item parser to handle the
+    // `::` cast operator.
+    //
+    // Regression: the Snowflake-specific parser used to successfully
+    // consume `$1:"col"` as a stage-load-select-item, leaving `::TYPE`
+    // behind and causing "Expected: FROM, found: ::" once the COPY INTO
+    // body tried to expect `FROM`.
+    let variants = [
+        concat!(
+            "COPY INTO my_company.emp_basic (a) FROM ",
+            r#"(SELECT $1:"A"::NUMBER(38, 0) FROM @stg)"#,
+        ),
+        concat!(
+            "COPY INTO my_company.emp_basic (a) FROM ",
+            "(SELECT $1::NUMBER(38, 0) FROM @stg)",
+        ),
+        concat!(
+            "COPY INTO my_company.emp_basic (a) FROM ",
+            "(SELECT $1:SEQUENCE::NUMBER(38, 0) FROM @stg)",
+        ),
+        concat!(
+            "COPY INTO my_company.emp_basic (a, b) FROM ",
+            r#"(SELECT $1:"A"::VARIANT, $1:"B"::TEXT FROM @stg)"#,
+        ),
+        // Mix with an ordinary stage-load-select-item in the same list,
+        // so we don't over-correct and break the existing shape.
+        concat!(
+            "COPY INTO my_company.emp_basic (a, b) FROM ",
+            r#"(SELECT t.$1:plain AS plain, $1:"B"::TEXT FROM @stg AS t)"#,
+        ),
+    ];
+    for sql in variants {
+        snowflake().parse_sql_statements(sql).unwrap_or_else(|e| {
+            panic!("expected {sql:?} to parse, got {e}");
+        });
+    }
+}
+
+#[test]
 fn test_copy_into_file_format() {
     let sql = concat!(
         "COPY INTO my_company.emp_basic ",

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2449,16 +2449,6 @@ fn test_copy_into_with_transformations() {
 
 #[test]
 fn test_copy_into_with_cast_transformation() {
-    // Snowflake `COPY INTO` transformation lists support casts like
-    // `$1:"col"::TYPE` and `$1::TYPE`. These are distinct from the bare
-    // `$<n>[.<col>][:<elem>]` stage-load-select-item shape, so the parser
-    // must fall through to the generic select-item parser to handle the
-    // `::` cast operator.
-    //
-    // Regression: the Snowflake-specific parser used to successfully
-    // consume `$1:"col"` as a stage-load-select-item, leaving `::TYPE`
-    // behind and causing "Expected: FROM, found: ::" once the COPY INTO
-    // body tried to expect `FROM`.
     let variants = [
         concat!(
             "COPY INTO my_company.emp_basic (a) FROM ",
@@ -2476,17 +2466,13 @@ fn test_copy_into_with_cast_transformation() {
             "COPY INTO my_company.emp_basic (a, b) FROM ",
             r#"(SELECT $1:"A"::VARIANT, $1:"B"::TEXT FROM @stg)"#,
         ),
-        // Mix with an ordinary stage-load-select-item in the same list,
-        // so we don't over-correct and break the existing shape.
         concat!(
             "COPY INTO my_company.emp_basic (a, b) FROM ",
             r#"(SELECT t.$1:plain AS plain, $1:"B"::TEXT FROM @stg AS t)"#,
         ),
     ];
     for sql in variants {
-        snowflake().parse_sql_statements(sql).unwrap_or_else(|e| {
-            panic!("expected {sql:?} to parse, got {e}");
-        });
+        snowflake().verified_stmt(sql);
     }
 }
 


### PR DESCRIPTION
## Summary

Snowflake `COPY INTO ... FROM (SELECT ...)` transformation lists support cast
expressions like `$1:"col"::TYPE` and `$1::TYPE`, e.g.:

```sql
COPY INTO my_company.emp_basic (a)
FROM (SELECT $1:"A"::NUMBER(38, 0) FROM @stg);
```

Today the Snowflake-specific stage-load-select-item parser successfully
consumes `$1:"A"` as a stage-load-select-item, leaves `::NUMBER(38, 0)` in
the token stream, and the surrounding `COPY INTO` body then fails with
`Expected: FROM, found: ::`.

## Changes

- `parse_select_item_for_data_load`: bail (so `maybe_parse` rewinds and the
  caller falls through to the generic `parse_select_item`) when the next
  token is `::`. The generic path already handles cast operators on `$<n>`
  references correctly.
- Tests: regression cases for `$1:"col"::TYPE`, `$1::TYPE`,
  `$1:SEQUENCE::TYPE`, multi-column lists, and a mixed list combining a
  plain stage-load-select-item with a cast item — verifying we don't
  over-correct and break the existing shape.

## Test plan

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`