### PR TITLE
PostgreSQL: add support for `ABORT TRANSACTION`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -674,7 +674,8 @@ impl<'a> Parser<'a> {
                     self.prev_token();
                     self.parse_throw().map(Into::into)
                 }
-                Keyword::ROLLBACK | Keyword::ABORT => self.parse_rollback(),
+                Keyword::ROLLBACK => self.parse_rollback(),
+                Keyword::ABORT => self.parse_abort(),
                 Keyword::ASSERT => self.parse_assert(),
                 // `PREPARE`, `EXECUTE` and `DEALLOCATE` are Postgres-specific
                 // syntaxes. They are used for Postgres prepared statement.
@@ -19273,6 +19274,20 @@ impl<'a> Parser<'a> {
         let savepoint = self.parse_rollback_savepoint()?;
 
         Ok(Statement::Rollback { chain, savepoint })
+    }
+
+    /// Parse an 'ABORT' statement
+    ///
+    /// ```sql
+    /// ABORT [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]
+    /// ```
+    pub fn parse_abort(&mut self) -> Result<Statement, ParserError> {
+        let chain = self.parse_commit_rollback_chain()?;
+
+        Ok(Statement::Rollback {
+            chain,
+            savepoint: None,
+        })
     }
 
     /// Parse an optional `AND [NO] CHAIN` clause for `COMMIT` and `ROLLBACK` statements

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -674,7 +674,7 @@ impl<'a> Parser<'a> {
                     self.prev_token();
                     self.parse_throw().map(Into::into)
                 }
-                Keyword::ROLLBACK => self.parse_rollback(),
+                Keyword::ROLLBACK | Keyword::ABORT => self.parse_rollback(),
                 Keyword::ASSERT => self.parse_assert(),
                 // `PREPARE`, `EXECUTE` and `DEALLOCATE` are Postgres-specific
                 // syntaxes. They are used for Postgres prepared statement.

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -9476,6 +9476,22 @@ fn parse_rollback() {
 }
 
 #[test]
+fn parse_abort() {
+    one_statement_parses_to("ABORT", "ROLLBACK");
+    one_statement_parses_to("ABORT TRANSACTION", "ROLLBACK");
+    one_statement_parses_to("ABORT WORK", "ROLLBACK");
+    one_statement_parses_to("ABORT AND CHAIN", "ROLLBACK AND CHAIN");
+    one_statement_parses_to("ABORT AND NO CHAIN", "ROLLBACK");
+    one_statement_parses_to("ABORT TRANSACTION AND CHAIN", "ROLLBACK AND CHAIN");
+    one_statement_parses_to("ABORT WORK AND NO CHAIN", "ROLLBACK");
+    one_statement_parses_to("ABORT TO test1", "ROLLBACK TO SAVEPOINT test1");
+    one_statement_parses_to(
+        "ABORT AND CHAIN TO test1",
+        "ROLLBACK AND CHAIN TO SAVEPOINT test1",
+    );
+}
+
+#[test]
 #[should_panic(expected = "Parse results with GenericDialect are different from PostgreSqlDialect")]
 fn ensure_multiple_dialects_are_tested() {
     // The SQL here must be parsed differently by different dialects.

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -9484,10 +9484,10 @@ fn parse_abort() {
     one_statement_parses_to("ABORT AND NO CHAIN", "ROLLBACK");
     one_statement_parses_to("ABORT TRANSACTION AND CHAIN", "ROLLBACK AND CHAIN");
     one_statement_parses_to("ABORT WORK AND NO CHAIN", "ROLLBACK");
-    one_statement_parses_to("ABORT TO test1", "ROLLBACK TO SAVEPOINT test1");
-    one_statement_parses_to(
-        "ABORT AND CHAIN TO test1",
-        "ROLLBACK AND CHAIN TO SAVEPOINT test1",
+
+    assert_eq!(
+        parse_sql_statements("ABORT TO test1").unwrap_err(),
+        ParserError::ParserError("Expected: end of statement, found: TO".to_string()),
     );
 }
 


### PR DESCRIPTION
In postgres, `abort transaction` is completely identical to `rollback transaction`. It's used in foreign data wrapper to fetch data from cursor. This patch adds support for it.