### PR TITLE
Expose Parser::into_comments

### DIFF
--- a/src/ast/comments.rs
+++ b/src/ast/comments.rs
@@ -33,7 +33,7 @@ impl Comments {
     /// last accepted comment.  In other words, this method will skip the
     /// comment if its comming out of order (as encountered in the parsed
     /// source code.)
-    pub(crate) fn offer(&mut self, comment: CommentWithSpan) {
+    pub fn offer(&mut self, comment: CommentWithSpan) {
         if self
             .0
             .last()

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -559,7 +559,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Consumes this parser returning comments from the parsed token stream.
-    fn into_comments(self) -> comments::Comments {
+    pub fn into_comments(self) -> comments::Comments {
         let mut comments = comments::Comments::default();
         for t in self.tokens.into_iter() {
             match t.token {


### PR DESCRIPTION
* [Back then](https://github.com/apache/datafusion-sqlparser-rs/pull/2107) we didn't make the method public to guarantee the binary search over the comments
* Later in the process we skipped adding out-of-order comments: https://github.com/apache/datafusion-sqlparser-rs/blob/main/src/ast/comments.rs#L40
* therefore exposing the method should be just fine now
* exposing the method allows to use the parser (e.g. extract the statements individually) and still obtain the `Comments` instances without calling `parse_sql_with_comments`