### PR TITLE
Fix issue #2353: Incorrect canonicalization of `NATURAL JOIN`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15994,6 +15994,7 @@ impl<'a> Parser<'a> {
                 if !self
                     .dialect
                     .supports_left_associative_joins_without_parens()
+                    && !natural
                     && self.peek_parens_less_nested_join()
                 {
                     let joins = self.parse_joins()?;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -17439,8 +17439,7 @@ fn column_check_enforced() {
 
 #[test]
 fn join_precedence() {
-    all_dialects_except(|d| !d.supports_left_associative_joins_without_parens())
-        .verified_query_with_canonical(
+    all_dialects().verified_query_with_canonical(
         "SELECT *
          FROM t1
          NATURAL JOIN t5
@@ -17448,15 +17447,6 @@ fn join_precedence() {
          WHERE t0.v1 = t1.v0",
         // canonical string without parentheses
         "SELECT * FROM t1 NATURAL JOIN t5 INNER JOIN t0 ON (t0.v1 + t5.v0) > 0 WHERE t0.v1 = t1.v0",
-    );
-    all_dialects_except(|d| d.supports_left_associative_joins_without_parens()).verified_query_with_canonical(
-        "SELECT *
-         FROM t1
-         NATURAL JOIN t5
-         INNER JOIN t0 ON (t0.v1 + t5.v0) > 0
-         WHERE t0.v1 = t1.v0",
-        // canonical string with parentheses
-        "SELECT * FROM t1 NATURAL JOIN (t5 INNER JOIN t0 ON (t0.v1 + t5.v0) > 0) WHERE t0.v1 = t1.v0",
     );
 }
 


### PR DESCRIPTION
…R JOIN in Snowflake dialect produces non-equivalent query
Closes #2353

The current canonicalization rewrites queries such as:

SELECT *
FROM t1
NATURAL JOIN t5
INNER JOIN t0 ON (t0.v1 + t5.v0) > 0

into:

t1 NATURAL JOIN (t5 INNER JOIN t0 ...)

This transformation is not semantics-preserving.

NATURAL JOIN implicitly generates join predicates based on all shared column names.
Moving t0 into the right-hand side of the NATURAL JOIN changes the set of visible columns, which may introduce additional implicit join conditions and lead to different results.

Minimal example (see issue for full repro):

SELECT *
FROM t1
NATURAL JOIN t5
INNER JOIN t0 ON (t0.v1 + t5.v0) > 0

Expected behavior:
The canonicalization should preserve semantics, e.g.:

(t1 NATURAL JOIN t5) INNER JOIN t0 ...

Fix:
Avoid right-associative parsing when NATURAL JOIN is present, ensuring that NATURAL JOIN is evaluated left-to-right.

Tests:
- Fixed the `join_precedence` test, which previously assumed incorrect Snowflake behavior.
- Verified the actual behavior against Snowflake.
- Updated the test to reflect the behavior observed in Snowflake.
