### PR TITLE
Spark: enable SQL pipe operator (`|>`)

### DIFF
--- a/src/dialect/spark.rs
+++ b/src/dialect/spark.rs
@@ -116,10 +116,6 @@ impl Dialect for SparkSqlDialect {
         true
     }
 
-    /// Spark 4.0 added SQL pipe syntax (`|>`), sharing the operator set with
-    /// the Google BigQuery / Pipe-SQL paper implementations already
-    /// supported by [`BigQueryDialect`](crate::dialect::BigQueryDialect).
-    ///
     /// See:
     /// - <https://spark.apache.org/docs/latest/sql-pipe-syntax.html>
     /// - <https://issues.apache.org/jira/browse/SPARK-49528>

--- a/src/dialect/spark.rs
+++ b/src/dialect/spark.rs
@@ -116,6 +116,17 @@ impl Dialect for SparkSqlDialect {
         true
     }
 
+    /// Spark 4.0 added SQL pipe syntax (`|>`), sharing the operator set with
+    /// the Google BigQuery / Pipe-SQL paper implementations already
+    /// supported by [`BigQueryDialect`](crate::dialect::BigQueryDialect).
+    ///
+    /// See:
+    /// - <https://spark.apache.org/docs/latest/sql-pipe-syntax.html>
+    /// - <https://issues.apache.org/jira/browse/SPARK-49528>
+    fn supports_pipe_operator(&self) -> bool {
+        true
+    }
+
     /// Parse the `DIV` keyword as integer division.
     ///
     /// Example: `SELECT 10 DIV 3` returns `3`.

--- a/tests/sqlparser_spark.rs
+++ b/tests/sqlparser_spark.rs
@@ -328,10 +328,6 @@ fn test_substring() {
     );
 }
 
-// --------------------------------
-// Pipe operator (`|>`)
-// --------------------------------
-
 #[test]
 fn test_pipe_operator() {
     spark().verified_stmt("SELECT * FROM t |> WHERE x > 1 |> SELECT x AS y |> ORDER BY y");

--- a/tests/sqlparser_spark.rs
+++ b/tests/sqlparser_spark.rs
@@ -327,3 +327,12 @@ fn test_substring() {
         "SELECT SUBSTRING(s, 1, 3) FROM t",
     );
 }
+
+// --------------------------------
+// Pipe operator (`|>`)
+// --------------------------------
+
+#[test]
+fn test_pipe_operator() {
+    spark().verified_stmt("SELECT * FROM t |> WHERE x > 1 |> SELECT x AS y |> ORDER BY y");
+}


### PR DESCRIPTION
Spark 4.0 added pipe-syntax SQL (`|>`), sharing the operator set already implemented for BigQuery and `GenericDialect`. This PR flips the `Dialect::supports_pipe_operator` flag on `SparkSqlDialect` so the existing pipe-operator parser path applies to Spark too — no new parser code.

**Before** — Spark rejected pipe syntax:
```
SELECT * FROM t |> WHERE x > 1 |> SELECT x AS y |> ORDER BY y
-- ParserError
```

**After** — parses and round-trips correctly under `SparkSqlDialect`.

### Tests
- The 19 `parse_pipe_operator_*` tests and `parse_pipeline_operator_negative_tests` in `tests/sqlparser_common.rs` gate on `all_dialects_where(|d| d.supports_pipe_operator())`, so they now exercise Spark automatically (all 20 pass).
- Adds a Spark-specific `test_pipe_operator` to `tests/sqlparser_spark.rs` to document the capability and guard against regressions if the shared gating changes.

`cargo test --all-features`, `cargo fmt --all`, and `cargo clippy --all-targets --all-features -- -D warnings` all pass locally.

### Refs
- Spark pipe-syntax docs: https://spark.apache.org/docs/latest/sql-pipe-syntax.html
- Spark 4.0 release notes: https://spark.apache.org/releases/spark-release-4-0-0.html