### PR TITLE
Microsoft sql server: Escape quotes in national string display

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -273,7 +273,7 @@ impl fmt::Display for Value {
             Value::DollarQuotedString(v) => write!(f, "{v}"),
             Value::EscapedStringLiteral(v) => write!(f, "E'{}'", escape_escaped_string(v)),
             Value::UnicodeStringLiteral(v) => write!(f, "U&'{}'", escape_unicode_string(v)),
-            Value::NationalStringLiteral(v) => write!(f, "N'{v}'"),
+            Value::NationalStringLiteral(v) => write!(f, "N'{}'", escape_single_quote_string(v)),
             Value::QuoteDelimitedStringLiteral(v) => v.fmt(f),
             Value::NationalQuoteDelimitedStringLiteral(v) => write!(f, "N{v}"),
             Value::HexStringLiteral(v) => write!(f, "X'{v}'"),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6192,6 +6192,10 @@ fn parse_literal_string() {
 
     one_statement_parses_to("SELECT x'deadBEEF'", "SELECT X'deadBEEF'");
     one_statement_parses_to("SELECT n'national string'", "SELECT N'national string'");
+    one_statement_parses_to(
+        r#"SELECT n'Tu geres '';'' et ''"'' ?'"#,
+        r#"SELECT N'Tu geres '';'' et ''"'' ?'"#,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Valid T-SQL (mssql dialect) such as `N' '' '` would not round-trip and serialized to invalid SQL.

This bug is potentially a security vulnerability depending on how the library is used.