### PR TITLE
PostgreSQL: support right-deep join chains (deferred ON clauses)

### DIFF
--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -299,6 +299,12 @@ impl Dialect for PostgreSqlDialect {
         true
     }
 
+    /// PostgreSQL supports right-deep join chains: `t0 JOIN t1 JOIN t2 ON c1 ON c2`
+    /// See: <https://www.postgresql.org/docs/current/queries-table-expressions.html#QUERIES-JOIN>
+    fn supports_left_associative_joins_without_parens(&self) -> bool {
+        false
+    }
+
     /// Postgres supports `NOTNULL` as an alias for `IS NOT NULL`
     /// See: <https://www.postgresql.org/docs/17/functions-comparison.html>
     fn supports_notnull_operator(&self) -> bool {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -9582,3 +9582,20 @@ fn parse_limit_after_locking_clause() {
     // The pre-existing ordering keeps round-tripping unchanged.
     pg().verified_stmt("SELECT * FROM t ORDER BY id LIMIT 5 FOR UPDATE SKIP LOCKED");
 }
+
+#[test]
+fn parse_right_deep_join_chain() {
+    // PostgreSQL supports right-deep join syntax where ON clauses follow all JOIN keywords:
+    //   t0 JOIN t1 JOIN t2 ON c1 ON c2
+    // which is equivalent to (and serialized as) t0 JOIN (t1 JOIN t2 ON c1) ON c2.
+    pg().one_statement_parses_to(
+        "SELECT * FROM t0 INNER JOIN t1 INNER JOIN t2 ON true ON true",
+        "SELECT * FROM t0 INNER JOIN (t1 INNER JOIN t2 ON true) ON true",
+    );
+    pg().one_statement_parses_to(
+        "SELECT * FROM t0 INNER JOIN t1 INNER JOIN t2 INNER JOIN t3 ON true ON true ON true",
+        "SELECT * FROM t0 INNER JOIN (t1 INNER JOIN (t2 INNER JOIN t3 ON true) ON true) ON true",
+    );
+    // NATURAL JOIN followed by a constrained join must stay left-associative.
+    pg().verified_stmt("SELECT * FROM t0 NATURAL JOIN t1 INNER JOIN t2 ON true");
+}


### PR DESCRIPTION
PostgreSQL accepts join chains where ON clauses are deferred to the end, e.g.:

    t0 JOIN t1 JOIN t2 ON c1 ON c2

This is equivalent to `t0 JOIN (t1 JOIN t2 ON c1) ON c2` per the SQL standard's
right-associative interpretation when parentheses are absent. PostgreSQL documents
this in its JOIN syntax:
https://www.postgresql.org/docs/current/queries-table-expressions.html#QUERIES-JOIN

The parser already handles this correctly for dialects that return `false` from
`supports_left_associative_joins_without_parens()` (Snowflake does this). The
PostgreSQL dialect was missing the override and fell through to the default `true`,
causing a parse error on any right-deep chain of depth >= 3.

This adds the override and a test that verifies both the parse and the canonical
round-trip serialization (with explicit parens).

`cargo test --all-features` passes locally.