### PR TITLE
ClickHouse: Support unparenthesized IN right-hand side

### DIFF
--- a/src/dialect/clickhouse.rs
+++ b/src/dialect/clickhouse.rs
@@ -80,6 +80,7 @@ impl Dialect for ClickHouseDialect {
         true
     }
 
+    // See <https://clickhouse.com/docs/sql-reference/operators/in>
     fn supports_in_unparenthesized_expr(&self) -> bool {
         true
     }

--- a/src/dialect/clickhouse.rs
+++ b/src/dialect/clickhouse.rs
@@ -80,6 +80,10 @@ impl Dialect for ClickHouseDialect {
         true
     }
 
+    fn supports_in_unparenthesized_expr(&self) -> bool {
+        true
+    }
+
     /// See <https://clickhouse.com/docs/en/sql-reference/functions#higher-order-functions---operator-and-lambdaparams-expr-function>
     fn supports_lambda_functions(&self) -> bool {
         true

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -435,6 +435,15 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports a bare expression as the right-hand
+    /// side of `IN`, without a parenthesized list — as in `x IN 'a'` or the
+    /// ClickHouse `{name:Type}` query-parameter placeholder `x IN {ids:Array(UInt64)}`.
+    /// The expression is wrapped into a single-element list, matching ClickHouse,
+    /// which reformats `x IN 'a'` to `x IN ('a')`.
+    fn supports_in_unparenthesized_expr(&self) -> bool {
+        false
+    }
+
     /// Returns true if the dialect supports `BEGIN {DEFERRED | IMMEDIATE | EXCLUSIVE | TRY | CATCH} [TRANSACTION]` statements
     fn supports_start_transaction_modifier(&self) -> bool {
         false
@@ -2049,6 +2058,10 @@ mod tests {
 
             fn supports_in_empty_list(&self) -> bool {
                 self.0.supports_in_empty_list()
+            }
+
+            fn supports_in_unparenthesized_expr(&self) -> bool {
+                self.0.supports_in_unparenthesized_expr()
             }
 
             fn convert_type_before_value(&self) -> bool {

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -436,10 +436,7 @@ pub trait Dialect: Debug + Any {
     }
 
     /// Returns true if the dialect supports a bare expression as the right-hand
-    /// side of `IN`, without a parenthesized list — as in `x IN 'a'` or the
-    /// ClickHouse `{name:Type}` query-parameter placeholder `x IN {ids:Array(UInt64)}`.
-    /// The expression is wrapped into a single-element list, matching ClickHouse,
-    /// which reformats `x IN 'a'` to `x IN ('a')`.
+    /// side of `IN`, without a parenthesized list — as in `x IN 'a'`.
     fn supports_in_unparenthesized_expr(&self) -> bool {
         false
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4392,8 +4392,6 @@ impl<'a> Parser<'a> {
                 negated,
             });
         }
-        // ClickHouse accepts a bare expression as the IN RHS (e.g. `x IN 'a'` or
-        // a `{name:Type}` placeholder), wrapping it into a single-element list.
         if self.dialect.supports_in_unparenthesized_expr()
             && self.peek_token_ref().token != Token::LParen
         {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4392,6 +4392,17 @@ impl<'a> Parser<'a> {
                 negated,
             });
         }
+        // ClickHouse accepts a bare expression as the IN RHS (e.g. `x IN 'a'` or
+        // a `{name:Type}` placeholder), wrapping it into a single-element list.
+        if self.dialect.supports_in_unparenthesized_expr()
+            && self.peek_token_ref().token != Token::LParen
+        {
+            return Ok(Expr::InList {
+                expr: Box::new(expr),
+                list: vec![self.parse_expr()?],
+                negated,
+            });
+        }
         self.expect_token(&Token::LParen)?;
         let in_op = match self.maybe_parse(|p| p.parse_query())? {
             Some(subquery) => Expr::InSubquery {

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1849,28 +1849,24 @@ fn parse_inner_array_join() {
 #[test]
 fn parse_in_unparenthesized_expr() {
     // IN [expr] parses to IN ([expr]) and does not cause regressions
-    let dialects = all_dialects_where(|d| d.supports_in_unparenthesized_expr());
-    dialects.expr_parses_to("x IN 'a'", "x IN ('a')");
+    clickhouse().expr_parses_to("x IN 'a'", "x IN ('a')");
 
     // The branch must not fire when the next token is `(` (regressions).
-    dialects.verified_expr("x IN (1, 2, 3)");
-    dialects.verified_stmt("SELECT * FROM t WHERE x IN (SELECT y FROM u)");
+    clickhouse().verified_expr("x IN (1, 2, 3)");
+    clickhouse().verified_stmt("SELECT * FROM t WHERE x IN (SELECT y FROM u)");
 }
 
 #[test]
 fn parse_in_unparenthesized_dictionary_placeholder() {
     // IN [{placeholder:Type}] parses to IN ({placholder:Type})
-    let dialects = all_dialects_where(|d| {
-        d.supports_in_unparenthesized_expr() && d.supports_dictionary_syntax()
-    });
-    dialects.expr_parses_to("x IN {ids:Array(UInt64)}", "x IN ({ids: Array(UInt64)})");
-    dialects.expr_parses_to(
+    clickhouse().expr_parses_to("x IN {ids:Array(UInt64)}", "x IN ({ids: Array(UInt64)})");
+    clickhouse().expr_parses_to(
         "x NOT IN {ids:Array(UInt64)}",
         "x NOT IN ({ids: Array(UInt64)})",
     );
-    dialects.verified_expr("x IN ({ids: Array(UInt64)})");
+    clickhouse().verified_expr("x IN ({ids: Array(UInt64)})");
     // Precedence: the trailing `AND` is not swallowed.
-    dialects.verified_expr("x IN ({p: Array(UInt64)}) AND y = 1");
+    clickhouse().verified_expr("x IN ({p: Array(UInt64)}) AND y = 1");
 }
 
 fn clickhouse() -> TestedDialects {

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1847,41 +1847,30 @@ fn parse_inner_array_join() {
 }
 
 #[test]
-fn parse_in_unparenthesized_placeholder() {
-    // ClickHouse `{name:Type}` query-parameter placeholder as the IN RHS, without parens.
-    match clickhouse().expr_parses_to("x IN {ids:Array(UInt64)}", "x IN ({ids: Array(UInt64)})") {
-        Expr::InList { list, negated, .. } => {
-            assert!(!negated);
-            assert_eq!(list.len(), 1);
-            assert!(matches!(list[0], Expr::Dictionary(_)));
-        }
-        other => panic!("expected InList, got {other:?}"),
-    }
+fn parse_in_unparenthesized_expr() {
+    // IN [expr] parses to IN ([expr]) and does not cause regressions
+    let dialects = all_dialects_where(|d| d.supports_in_unparenthesized_expr());
+    dialects.expr_parses_to("x IN 'a'", "x IN ('a')");
 
-    // NOT IN sets negated.
-    match clickhouse().expr_parses_to(
+    // The branch must not fire when the next token is `(` (regressions).
+    dialects.verified_expr("x IN (1, 2, 3)");
+    dialects.verified_stmt("SELECT * FROM t WHERE x IN (SELECT y FROM u)");
+}
+
+#[test]
+fn parse_in_unparenthesized_dictionary_placeholder() {
+    // IN [{placeholder:Type}] parses to IN ({placholder:Type})
+    let dialects = all_dialects_where(|d| {
+        d.supports_in_unparenthesized_expr() && d.supports_dictionary_syntax()
+    });
+    dialects.expr_parses_to("x IN {ids:Array(UInt64)}", "x IN ({ids: Array(UInt64)})");
+    dialects.expr_parses_to(
         "x NOT IN {ids:Array(UInt64)}",
         "x NOT IN ({ids: Array(UInt64)})",
-    ) {
-        Expr::InList { negated, .. } => assert!(negated),
-        other => panic!("expected InList, got {other:?}"),
-    }
-
-    // A bare scalar is also wrapped, matching ClickHouse (`x IN 'a'` -> `x IN ('a')`).
-    clickhouse().expr_parses_to("x IN 'a'", "x IN ('a')");
-
-    // The new branch must not fire when the next token is `(` (regressions).
-    clickhouse().verified_expr("x IN ({ids: Array(UInt64)})");
-    clickhouse().verified_expr("x IN (1, 2, 3)");
-    clickhouse().verified_stmt("SELECT * FROM t WHERE x IN (SELECT y FROM u)");
-
-    // Precedence: the trailing `AND` is not swallowed into the placeholder.
-    clickhouse().verified_expr("x IN ({p: Array(UInt64)}) AND y = 1");
-
-    // Dialect-scoped: GenericDialect (capability defaults false) still errors.
-    assert!(TestedDialects::new(vec![Box::new(GenericDialect {})])
-        .parse_sql_statements("SELECT * FROM t WHERE x IN {ids:Array(UInt64)}")
-        .is_err());
+    );
+    dialects.verified_expr("x IN ({ids: Array(UInt64)})");
+    // Precedence: the trailing `AND` is not swallowed.
+    dialects.verified_expr("x IN ({p: Array(UInt64)}) AND y = 1");
 }
 
 fn clickhouse() -> TestedDialects {

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1846,6 +1846,44 @@ fn parse_inner_array_join() {
     }
 }
 
+#[test]
+fn parse_in_unparenthesized_placeholder() {
+    // ClickHouse `{name:Type}` query-parameter placeholder as the IN RHS, without parens.
+    match clickhouse().expr_parses_to("x IN {ids:Array(UInt64)}", "x IN ({ids: Array(UInt64)})") {
+        Expr::InList { list, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(list.len(), 1);
+            assert!(matches!(list[0], Expr::Dictionary(_)));
+        }
+        other => panic!("expected InList, got {other:?}"),
+    }
+
+    // NOT IN sets negated.
+    match clickhouse().expr_parses_to(
+        "x NOT IN {ids:Array(UInt64)}",
+        "x NOT IN ({ids: Array(UInt64)})",
+    ) {
+        Expr::InList { negated, .. } => assert!(negated),
+        other => panic!("expected InList, got {other:?}"),
+    }
+
+    // A bare scalar is also wrapped, matching ClickHouse (`x IN 'a'` -> `x IN ('a')`).
+    clickhouse().expr_parses_to("x IN 'a'", "x IN ('a')");
+
+    // The new branch must not fire when the next token is `(` (regressions).
+    clickhouse().verified_expr("x IN ({ids: Array(UInt64)})");
+    clickhouse().verified_expr("x IN (1, 2, 3)");
+    clickhouse().verified_stmt("SELECT * FROM t WHERE x IN (SELECT y FROM u)");
+
+    // Precedence: the trailing `AND` is not swallowed into the placeholder.
+    clickhouse().verified_expr("x IN ({p: Array(UInt64)}) AND y = 1");
+
+    // Dialect-scoped: GenericDialect (capability defaults false) still errors.
+    assert!(TestedDialects::new(vec![Box::new(GenericDialect {})])
+        .parse_sql_statements("SELECT * FROM t WHERE x IN {ids:Array(UInt64)}")
+        .is_err());
+}
+
 fn clickhouse() -> TestedDialects {
     TestedDialects::new(vec![Box::new(ClickHouseDialect {})])
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2399,22 +2399,6 @@ fn parse_in_unparenthesized_expr() {
 }
 
 #[test]
-fn parse_in_unparenthesized_dictionary_placeholder() {
-    // The `{name:Type}` placeholder form additionally requires dictionary syntax.
-    let dialects = all_dialects_where(|d| {
-        d.supports_in_unparenthesized_expr() && d.supports_dictionary_syntax()
-    });
-    dialects.expr_parses_to("x IN {ids:Array(UInt64)}", "x IN ({ids: Array(UInt64)})");
-    dialects.expr_parses_to(
-        "x NOT IN {ids:Array(UInt64)}",
-        "x NOT IN ({ids: Array(UInt64)})",
-    );
-    dialects.verified_expr("x IN ({ids: Array(UInt64)})");
-    // Precedence: the trailing `AND` is not swallowed.
-    dialects.verified_expr("x IN ({p: Array(UInt64)}) AND y = 1");
-}
-
-#[test]
 fn parse_string_agg() {
     let sql = "SELECT a || b";
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -10857,6 +10857,14 @@ fn parse_position_negative() {
         ParserError::ParserError("Expected: (, found: )".to_string()),
         res.unwrap_err()
     );
+
+    let result_unparenthesized =
+        all_dialects_where(|d| d.supports_in_unparenthesized_expr()).parse_sql_statements(sql);
+
+    assert_eq!(
+        ParserError::ParserError("Expected: an expression, found: )".to_string()),
+        result_unparenthesized.unwrap_err()
+    );
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2375,9 +2375,11 @@ fn parse_in_unnest() {
 
 #[test]
 fn parse_in_error() {
-    // <expr> IN <expr> is no valid
+    // <expr> IN <expr> is no valid, except in dialects that accept an
+    // unparenthesized expression as the IN right-hand side (e.g. ClickHouse).
     let sql = "SELECT * FROM customers WHERE segment in segment";
-    let res = parse_sql_statements(sql);
+    let res =
+        all_dialects_except(|d| d.supports_in_unparenthesized_expr()).parse_sql_statements(sql);
     assert_eq!(
         ParserError::ParserError("Expected: (, found: segment".to_string()),
         res.unwrap_err()
@@ -10834,8 +10836,11 @@ fn parse_position() {
 
 #[test]
 fn parse_position_negative() {
+    // Dialects that accept an unparenthesized IN right-hand side (e.g. ClickHouse)
+    // report a different error here, so exclude them.
     let sql = "SELECT POSITION(foo IN) from bar";
-    let res = parse_sql_statements(sql);
+    let res =
+        all_dialects_except(|d| d.supports_in_unparenthesized_expr()).parse_sql_statements(sql);
     assert_eq!(
         ParserError::ParserError("Expected: (, found: )".to_string()),
         res.unwrap_err()

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2387,6 +2387,34 @@ fn parse_in_error() {
 }
 
 #[test]
+fn parse_in_unparenthesized_expr() {
+    // Dialects supporting an unparenthesized IN right-hand side wrap a bare expression
+    // into a single-element list (e.g. `x IN 'a'` -> `x IN ('a')`).
+    let dialects = all_dialects_where(|d| d.supports_in_unparenthesized_expr());
+    dialects.expr_parses_to("x IN 'a'", "x IN ('a')");
+
+    // The branch must not fire when the next token is `(` (regressions).
+    dialects.verified_expr("x IN (1, 2, 3)");
+    dialects.verified_stmt("SELECT * FROM t WHERE x IN (SELECT y FROM u)");
+}
+
+#[test]
+fn parse_in_unparenthesized_dictionary_placeholder() {
+    // The `{name:Type}` placeholder form additionally requires dictionary syntax.
+    let dialects = all_dialects_where(|d| {
+        d.supports_in_unparenthesized_expr() && d.supports_dictionary_syntax()
+    });
+    dialects.expr_parses_to("x IN {ids:Array(UInt64)}", "x IN ({ids: Array(UInt64)})");
+    dialects.expr_parses_to(
+        "x NOT IN {ids:Array(UInt64)}",
+        "x NOT IN ({ids: Array(UInt64)})",
+    );
+    dialects.verified_expr("x IN ({ids: Array(UInt64)})");
+    // Precedence: the trailing `AND` is not swallowed.
+    dialects.verified_expr("x IN ({p: Array(UInt64)}) AND y = 1");
+}
+
+#[test]
 fn parse_string_agg() {
     let sql = "SELECT a || b";
 


### PR DESCRIPTION
Fixes #2384

Note: The fix is a little broader than just the parameterized ClickHouse queries, e.g. `WHERE id IN {ids: Array(UUID)}`.

After opening the issue, I experimented a little more with ClickHouse, and found that it wraps in parenthesis anything on the RHS of `IN`, even for singular values, e.g.

```sql
SELECT * from users WHERE name in 'a';
-- becomes
SELECT * from users WHERE name in ('a');
```
