### PR TITLE
Handle nested parentheses in INSERT subquery detection

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18476,24 +18476,19 @@ impl<'a> Parser<'a> {
     }
 
     /// Returns true if the immediate tokens look like the
-    /// beginning of a subquery. `(SELECT ...`
+    /// beginning of a subquery. `(SELECT ...` or `((SELECT ...` etc.
     fn peek_subquery_start(&mut self) -> bool {
-        matches!(
-            self.peek_tokens_ref(),
-            [
-                TokenWithSpan {
-                    token: Token::LParen,
-                    ..
-                },
-                TokenWithSpan {
-                    token: Token::Word(Word {
-                        keyword: Keyword::SELECT,
-                        ..
-                    }),
-                    ..
-                },
-            ]
-        )
+        // Handle (SELECT, ((SELECT, (((SELECT, etc.
+        // This makes INSERT consistent with other contexts where nested
+        // parentheses around subqueries are handled by recursive descent.
+        let mut i = 0;
+        loop {
+            match &self.peek_nth_token_ref(i).token {
+                Token::LParen => i += 1,
+                Token::Word(w) if w.keyword == Keyword::SELECT => return i > 0,
+                _ => return false,
+            }
+        }
     }
 
     /// Returns true if the immediate tokens look like the

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -352,6 +352,14 @@ fn parse_insert_select_from_returning() {
 }
 
 #[test]
+fn parse_insert_nested_parenthesized_subquery() {
+    // The source query may be wrapped in one or more layers of parentheses;
+    // the leading parens must not be mistaken for a column list.
+    verified_stmt("INSERT INTO t ((SELECT 1))");
+    verified_stmt("INSERT INTO t (((SELECT 1)))");
+}
+
+#[test]
 fn parse_returning_as_column_alias() {
     verified_stmt("SELECT 1 AS RETURNING");
 }


### PR DESCRIPTION
```sql
INSERT INTO t ((SELECT 1));
```

Before this change the statement above failed to parse: a source query wrapped in more than one layer of parentheses was mistaken for an INSERT column list.

When parsing `INSERT INTO t <source>`, the parser must decide whether the tokens following the table name begin an explicit column list `(a, b, ...)` or the source query `(SELECT ...)`. It made this decision in `peek_subquery_start` by matching exactly `( SELECT`, so any extra leading paren tripped the column-list branch — even though the equivalent nested-parenthesized subquery parses fine in other positions.

This changes `peek_subquery_start` to skip any number of leading `(` and treat the tokens as a subquery start as long as at least one paren precedes the `SELECT`, making INSERT consistent with how nested parentheses around subqueries are already handled elsewhere via recursive descent.

A regression test is added in `tests/sqlparser_common.rs` covering `INSERT INTO t ((SELECT 1))` and `INSERT INTO t (((SELECT 1)))`.
