### PR TITLE
Allow visits from both visitor and VisitorMut at the same time without using trait disambiguation

### DIFF
--- a/derive/README.md
+++ b/derive/README.md
@@ -188,11 +188,11 @@ impl sqlparser::ast::VisitMut for ShowStatementIn {
         &mut self,
         visitor: &mut V,
     ) -> ::std::ops::ControlFlow<V::Break> {
-        sqlparser::ast::VisitMut::visit(&mut self.clause, visitor)?;
-        sqlparser::ast::VisitMut::visit(&mut self.parent_type, visitor)?;
+        sqlparser::ast::VisitMut::visit_mut(&mut self.clause, visitor)?;
+        sqlparser::ast::VisitMut::visit_mut(&mut self.parent_type, visitor)?;
         if let Some(value) = &mut self.parent_name {
             visitor.pre_visit_relation(value)?;
-            sqlparser::ast::VisitMut::visit(value, visitor)?;
+            sqlparser::ast::VisitMut::visit_mut(value, visitor)?;
             visitor.post_visit_relation(value)?;
         }
         ::std::ops::ControlFlow::Continue(())

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -35,6 +35,7 @@ pub fn derive_visit_mut(input: proc_macro::TokenStream) -> proc_macro::TokenStre
         input,
         &visit::VisitType {
             visit_trait: quote!(VisitMut),
+            visit_method: quote!(visit_mut),
             visitor_trait: quote!(VisitorMut),
             modifier: Some(quote!(mut)),
         },
@@ -49,6 +50,7 @@ pub fn derive_visit_immutable(input: proc_macro::TokenStream) -> proc_macro::Tok
         input,
         &visit::VisitType {
             visit_trait: quote!(Visit),
+            visit_method: quote!(visit),
             visitor_trait: quote!(Visitor),
             modifier: None,
         },

--- a/derive/src/visit.rs
+++ b/derive/src/visit.rs
@@ -29,6 +29,7 @@ use syn::{Path, PathArguments};
 
 pub(crate) struct VisitType {
     pub visit_trait: TokenStream,
+    pub visit_method: TokenStream,
     pub visitor_trait: TokenStream,
     pub modifier: Option<TokenStream>,
 }
@@ -41,6 +42,7 @@ pub(crate) fn derive_visit(
 
     let VisitType {
         visit_trait,
+        visit_method,
         visitor_trait,
         modifier,
     } = visit_type;
@@ -59,7 +61,7 @@ pub(crate) fn derive_visit(
         // See tests in https://github.com/apache/datafusion-sqlparser-rs/pull/1522/ for more info.
         impl #impl_generics sqlparser::ast::#visit_trait for #name #ty_generics #where_clause {
              #[cfg_attr(feature = "recursive-protection", recursive::recursive)]
-            fn visit<V: sqlparser::ast::#visitor_trait>(
+            fn #visit_method<V: sqlparser::ast::#visitor_trait>(
                 &#modifier self,
                 visitor: &mut V
             ) -> ::core::ops::ControlFlow<V::Break> {
@@ -154,6 +156,7 @@ fn visit_children(
     data: &Data,
     VisitType {
         visit_trait,
+        visit_method,
         modifier,
         ..
     }: &VisitType,
@@ -169,13 +172,13 @@ fn visit_children(
                         let (pre_visit, post_visit) = attributes.visit(quote!(value));
                         quote_spanned!(f.span() =>
                             if let Some(value) = &#modifier self.#name {
-                                #pre_visit sqlparser::ast::#visit_trait::visit(value, visitor)?; #post_visit
+                                #pre_visit sqlparser::ast::#visit_trait::#visit_method(value, visitor)?; #post_visit
                             }
                         )
                     } else {
                         let (pre_visit, post_visit) = attributes.visit(quote!(&#modifier self.#name));
                         quote_spanned!(f.span() =>
-                            #pre_visit sqlparser::ast::#visit_trait::visit(&#modifier self.#name, visitor)?; #post_visit
+                            #pre_visit sqlparser::ast::#visit_trait::#visit_method(&#modifier self.#name, visitor)?; #post_visit
                         )
                     }
                 });
@@ -188,7 +191,7 @@ fn visit_children(
                     let index = Index::from(i);
                     let attributes = Attributes::parse(&f.attrs);
                     let (pre_visit, post_visit) = attributes.visit(quote!(&self.#index));
-                    quote_spanned!(f.span() => #pre_visit sqlparser::ast::#visit_trait::visit(&#modifier self.#index, visitor)?; #post_visit)
+                    quote_spanned!(f.span() => #pre_visit sqlparser::ast::#visit_trait::#visit_method(&#modifier self.#index, visitor)?; #post_visit)
                 });
                 quote! {
                     #(#recurse)*
@@ -208,7 +211,7 @@ fn visit_children(
                             let name = &f.ident;
                             let attributes = Attributes::parse(&f.attrs);
                             let (pre_visit, post_visit) = attributes.visit(name.to_token_stream());
-                            quote_spanned!(f.span() => #pre_visit sqlparser::ast::#visit_trait::visit(#name, visitor)?; #post_visit)
+                            quote_spanned!(f.span() => #pre_visit sqlparser::ast::#visit_trait::#visit_method(#name, visitor)?; #post_visit)
                         });
 
                         quote!(
@@ -223,7 +226,7 @@ fn visit_children(
                             let name = format_ident!("_{}", i);
                             let attributes = Attributes::parse(&f.attrs);
                             let (pre_visit, post_visit) = attributes.visit(name.to_token_stream());
-                            quote_spanned!(f.span() => #pre_visit sqlparser::ast::#visit_trait::visit(#name, visitor)?; #post_visit)
+                            quote_spanned!(f.span() => #pre_visit sqlparser::ast::#visit_trait::#visit_method(#name, visitor)?; #post_visit)
                         });
 
                         quote! {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -402,7 +402,7 @@ impl Visit for Ident {
 
 #[cfg(feature = "visitor")]
 impl VisitMut for Ident {
-    fn visit<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
+    fn visit_mut<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
         visitor.pre_visit_ident(self)?;
         visitor.post_visit_ident(self)
     }

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -59,7 +59,7 @@ pub trait VisitMut {
     /// Implementations should call the appropriate mutable visitor hooks to
     /// traverse and allow in-place mutation of child nodes. Returning a
     /// `ControlFlow` value permits early termination of the traversal.
-    fn visit<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break>;
+    fn visit_mut<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break>;
 }
 
 impl<T: Visit> Visit for Option<T> {
@@ -87,26 +87,26 @@ impl<T: Visit> Visit for Box<T> {
 }
 
 impl<T: VisitMut> VisitMut for Option<T> {
-    fn visit<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
+    fn visit_mut<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
         if let Some(s) = self {
-            s.visit(visitor)?;
+            s.visit_mut(visitor)?;
         }
         ControlFlow::Continue(())
     }
 }
 
 impl<T: VisitMut> VisitMut for Vec<T> {
-    fn visit<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
+    fn visit_mut<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
         for v in self {
-            v.visit(visitor)?;
+            v.visit_mut(visitor)?;
         }
         ControlFlow::Continue(())
     }
 }
 
 impl<T: VisitMut> VisitMut for Box<T> {
-    fn visit<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
-        T::visit(self, visitor)
+    fn visit_mut<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
+        T::visit_mut(self, visitor)
     }
 }
 
@@ -118,7 +118,7 @@ macro_rules! visit_noop {
             }
         })+
         $(impl VisitMut for $t {
-            fn visit<V: VisitorMut>(&mut self, _visitor: &mut V) -> ControlFlow<V::Break> {
+            fn visit_mut<V: VisitorMut>(&mut self, _visitor: &mut V) -> ControlFlow<V::Break> {
                ControlFlow::Continue(())
             }
         })+
@@ -320,7 +320,7 @@ pub trait Visitor {
 /// let mut statements = Parser::parse_sql(&GenericDialect{}, sql).unwrap();
 ///
 /// // Drive the visitor through the AST
-/// statements.visit(&mut Replacer);
+/// statements.visit_mut(&mut Replacer);
 ///
 /// assert_eq!(statements[0].to_string(), "SELECT replaced FROM foo WHERE replaced IN (SELECT replaced FROM bar)");
 /// ```
@@ -503,7 +503,7 @@ where
     F: FnMut(&mut ObjectName) -> ControlFlow<E>,
 {
     let mut visitor = RelationVisitor(f);
-    v.visit(&mut visitor)?;
+    v.visit_mut(&mut visitor)?;
     ControlFlow::Continue(())
 }
 
@@ -633,7 +633,7 @@ where
     V: VisitMut,
     F: FnMut(&mut Expr) -> ControlFlow<E>,
 {
-    v.visit(&mut ExprVisitor(f))?;
+    v.visit_mut(&mut ExprVisitor(f))?;
     ControlFlow::Continue(())
 }
 
@@ -720,7 +720,7 @@ where
     V: VisitMut,
     F: FnMut(&mut Statement) -> ControlFlow<E>,
 {
-    v.visit(&mut StatementVisitor(f))?;
+    v.visit_mut(&mut StatementVisitor(f))?;
     ControlFlow::Continue(())
 }
 
@@ -1059,7 +1059,7 @@ mod tests {
 
 #[cfg(test)]
 mod visit_mut_tests {
-    use crate::ast::{Ident, Statement, Value, ValueWithSpan, VisitMut, VisitorMut};
+    use crate::ast::{Ident, Statement, Value, ValueWithSpan, Visit, VisitMut, Visitor, VisitorMut};
     use crate::dialect::GenericDialect;
     use crate::parser::Parser;
     use crate::tokenizer::Tokenizer;
@@ -1092,7 +1092,7 @@ mod visit_mut_tests {
             .parse_statement()
             .unwrap();
 
-        let flow = s.visit(visitor);
+        let flow = s.visit_mut(visitor);
         assert_eq!(flow, ControlFlow::Continue(()));
         s
     }
@@ -1138,5 +1138,27 @@ mod visit_mut_tests {
         let mut visitor = IdentMutator;
         let mutated = do_visit_mut("SELECT a, b FROM t", &mut visitor);
         assert_eq!(mutated.to_string(), "SELECT A, B FROM T");
+    }
+
+    struct DummyVisitor;
+    impl Visitor for DummyVisitor {
+        type Break = ();
+    }
+
+    struct DummyVisitorMut;
+    impl VisitorMut for DummyVisitorMut {
+        type Break = ();
+    }
+
+    #[test]
+    fn test_both_visit_and_visit_mut() {
+        let mut visitor = DummyVisitor;
+        let mut visitor_mut = DummyVisitorMut;
+        let mut statements = Parser::parse_sql(&GenericDialect {}, "SELECT 1").unwrap();
+
+        let _ = statements.visit(&mut visitor);
+        let _ = statements.visit_mut(&mut visitor_mut);
+
+        assert_eq!(statements[0].to_string(), "SELECT 1");
     }
 }


### PR DESCRIPTION
Closes #2067 .

Hello! I just now realize that I could have used [overlapping trait Disambiguation](https://doc.rust-lang.org/rust-by-example/trait/disambiguating.html#disambiguating-overlapping-traits):

```
let _ = Visit::visit(&statements, &mut whitelist);
let _ = VisitMut::visit(&mut statements, &mut VisitOrderBy(order));
```

But here I am with this proposition anyway.