### PR TITLE
Accept CREATE OR REPLACE SCHEMA

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4356,6 +4356,8 @@ pub enum Statement {
     CreateSchema {
         /// `<schema name> | AUTHORIZATION <schema authorization identifier>  | <schema name>  AUTHORIZATION <schema authorization identifier>`
         schema_name: SchemaName,
+        /// `true` when `OR REPLACE` was present.
+        or_replace: bool,
         /// `true` when `IF NOT EXISTS` was present.
         if_not_exists: bool,
         /// Schema properties.
@@ -6018,6 +6020,7 @@ impl fmt::Display for Statement {
             }
             Statement::CreateSchema {
                 schema_name,
+                or_replace,
                 if_not_exists,
                 with,
                 options,
@@ -6026,7 +6029,8 @@ impl fmt::Display for Statement {
             } => {
                 write!(
                     f,
-                    "CREATE SCHEMA {if_not_exists}{name}",
+                    "CREATE {or_replace}SCHEMA {if_not_exists}{name}",
+                    or_replace = if *or_replace { "OR REPLACE " } else { "" },
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
                     name = schema_name
                 )?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5283,9 +5283,11 @@ impl<'a> Parser<'a> {
             self.parse_create_secret(or_replace, temporary, persistent)
         } else if self.parse_keyword(Keyword::USER) {
             self.parse_create_user(or_replace).map(Into::into)
+        } else if self.parse_keyword(Keyword::SCHEMA) {
+            self.parse_create_schema(or_replace)
         } else if or_replace {
             self.expected_ref(
-                "[EXTERNAL] TABLE or [MATERIALIZED] VIEW or FUNCTION after CREATE OR REPLACE",
+                "[EXTERNAL] TABLE or [MATERIALIZED] VIEW or FUNCTION or SCHEMA after CREATE OR REPLACE",
                 self.peek_token_ref(),
             )
         } else if self.parse_keyword(Keyword::EXTENSION) {
@@ -5296,8 +5298,6 @@ impl<'a> Parser<'a> {
             self.parse_create_index(true).map(Into::into)
         } else if self.parse_keyword(Keyword::VIRTUAL) {
             self.parse_create_virtual_table()
-        } else if self.parse_keyword(Keyword::SCHEMA) {
-            self.parse_create_schema()
         } else if self.parse_keyword(Keyword::DATABASE) {
             self.parse_create_database()
         } else if self.parse_keyword(Keyword::ROLE) {
@@ -5611,7 +5611,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a `CREATE SCHEMA` statement.
-    pub fn parse_create_schema(&mut self) -> Result<Statement, ParserError> {
+    pub fn parse_create_schema(&mut self, or_replace: bool) -> Result<Statement, ParserError> {
         let if_not_exists = self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
 
         let schema_name = self.parse_schema_name()?;
@@ -5642,6 +5642,7 @@ impl<'a> Parser<'a> {
 
         Ok(Statement::CreateSchema {
             schema_name,
+            or_replace,
             if_not_exists,
             with,
             options,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4546,6 +4546,25 @@ fn parse_create_schema() {
 }
 
 #[test]
+fn parse_create_or_replace_schema() {
+    match verified_stmt("CREATE OR REPLACE SCHEMA X") {
+        Statement::CreateSchema {
+            schema_name,
+            or_replace,
+            if_not_exists,
+            ..
+        } => {
+            assert_eq!(schema_name.to_string(), "X".to_owned());
+            assert!(or_replace);
+            assert!(!if_not_exists);
+        }
+        _ => unreachable!(),
+    }
+
+    verified_stmt("CREATE OR REPLACE SCHEMA IF NOT EXISTS X");
+}
+
+#[test]
 fn parse_create_schema_with_authorization() {
     let sql = "CREATE SCHEMA AUTHORIZATION Y";
 


### PR DESCRIPTION
CREATE OR REPLACE SCHEMA did not parse. `CREATE SCHEMA` was handled after the `OR REPLACE` allowlist bail-out in `parse_create`, so any `OR REPLACE` in front of it produced an error:

```sql
CREATE OR REPLACE SCHEMA foo
CREATE OR REPLACE SCHEMA IF NOT EXISTS foo
```

This routes the `SCHEMA` keyword ahead of that bail-out and adds an `or_replace: bool` field to `Statement::CreateSchema`. Display round-trips `OR REPLACE`.
