### PR TITLE
Dialects: implement identifier_quote_style for remaining dialect

### DIFF
--- a/src/dialect/ansi.rs
+++ b/src/dialect/ansi.rs
@@ -23,6 +23,11 @@ use crate::dialect::Dialect;
 pub struct AnsiDialect {}
 
 impl Dialect for AnsiDialect {
+    /// The SQL standard uses double quotes for delimited identifiers.
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('"')
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         ch.is_ascii_lowercase() || ch.is_ascii_uppercase()
     }

--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -67,6 +67,11 @@ impl Dialect for BigQueryDialect {
         ch == '`'
     }
 
+    /// See <https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/lexical#quoted_identifiers>
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('`')
+    }
+
     fn supports_projection_trailing_commas(&self) -> bool {
         true
     }

--- a/src/dialect/clickhouse.rs
+++ b/src/dialect/clickhouse.rs
@@ -32,6 +32,13 @@ impl Dialect for ClickHouseDialect {
         self.is_identifier_start(ch) || ch.is_ascii_digit()
     }
 
+    /// ClickHouse accepts both backticks and double quotes, but its own
+    /// formatter emits backticks by default.
+    /// See <https://clickhouse.com/docs/en/sql-reference/syntax#identifiers>
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('`')
+    }
+
     fn supports_string_literal_backslash_escape(&self) -> bool {
         true
     }

--- a/src/dialect/databricks.rs
+++ b/src/dialect/databricks.rs
@@ -31,6 +31,11 @@ impl Dialect for DatabricksDialect {
         matches!(ch, '`')
     }
 
+    /// See <https://docs.databricks.com/en/sql/language-manual/sql-ref-identifiers.html>
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('`')
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         matches!(ch, 'a'..='z' | 'A'..='Z' | '_')
     }

--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -36,6 +36,11 @@ impl Dialect for DuckDbDialect {
         ch.is_alphabetic() || ch.is_ascii_digit() || ch == '$' || ch == '_'
     }
 
+    /// See <https://duckdb.org/docs/stable/sql/dialect/keywords_and_identifiers>
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('"')
+    }
+
     fn supports_filter_during_aggregation(&self) -> bool {
         true
     }

--- a/src/dialect/hive.rs
+++ b/src/dialect/hive.rs
@@ -27,6 +27,11 @@ impl Dialect for HiveDialect {
         (ch == '"') || (ch == '`')
     }
 
+    /// See <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RulesforColumnNames>
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('`')
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         ch.is_ascii_lowercase() || ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '$'
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -2001,9 +2001,22 @@ mod tests {
     #[test]
     fn identifier_quote_style() {
         let tests: Vec<(&dyn Dialect, &str, Option<char>)> = vec![
+            (&AnsiDialect {}, "id", Some('"')),
+            (&BigQueryDialect {}, "id", Some('`')),
+            (&ClickHouseDialect {}, "id", Some('`')),
+            (&DatabricksDialect {}, "id", Some('`')),
+            (&DuckDbDialect {}, "id", Some('"')),
             (&GenericDialect {}, "id", None),
-            (&SQLiteDialect {}, "id", Some('`')),
+            (&HiveDialect {}, "id", Some('`')),
+            (&MsSqlDialect {}, "id", Some('[')),
+            (&MySqlDialect {}, "id", Some('`')),
+            (&OracleDialect {}, "id", Some('"')),
             (&PostgreSqlDialect {}, "id", Some('"')),
+            (&RedshiftSqlDialect {}, "id", Some('"')),
+            (&SnowflakeDialect {}, "id", Some('"')),
+            (&SQLiteDialect {}, "id", Some('`')),
+            (&SparkSqlDialect {}, "id", Some('`')),
+            (&TeradataDialect {}, "id", Some('"')),
         ];
 
         for (dialect, ident, expected) in tests {

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -92,6 +92,11 @@ impl Dialect for RedshiftSqlDialect {
         PostgreSqlDialect {}.is_identifier_part(ch) || ch == '#'
     }
 
+    /// See <https://docs.aws.amazon.com/redshift/latest/dg/r_names.html>
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('"')
+    }
+
     /// redshift has `CONVERT(type, value)` instead of `CONVERT(value, type)`
     /// <https://docs.aws.amazon.com/redshift/latest/dg/r_CONVERT_function.html>
     fn convert_type_before_value(&self) -> bool {

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -140,6 +140,11 @@ impl Dialect for SnowflakeDialect {
         ch.is_ascii_lowercase() || ch.is_ascii_uppercase() || ch == '_'
     }
 
+    /// See <https://docs.snowflake.com/en/sql-reference/identifiers-syntax>
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('"')
+    }
+
     fn supports_projection_trailing_commas(&self) -> bool {
         true
     }

--- a/src/dialect/spark.rs
+++ b/src/dialect/spark.rs
@@ -36,6 +36,11 @@ impl Dialect for SparkSqlDialect {
         matches!(ch, '`')
     }
 
+    /// See <https://spark.apache.org/docs/latest/sql-ref-identifier.html>
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('`')
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         matches!(ch, 'a'..='z' | 'A'..='Z' | '_')
     }


### PR DESCRIPTION
`Dialect::identifier_quote_style` returned the default `None` for most dialects even when the database has a documented identifier quote character. 
For example `SnowflakeDialect {}.identifier_quote_style("id")` returned `None`, so downstream SQL generators could not tell how to quote identifiers for these dialects.

This PR implements the method for the remaining dialects: backticks for BigQuery, ClickHouse, Databricks, Hive and Spark, and double quotes for ANSI, DuckDB, Redshift and Snowflake, each with a reference to the database's documentation. `GenericDialect` intentionally keeps returning `None` since it does not assume any specific database.

The existing unit test in `src/dialect/mod.rs` is extended to cover all dialects.