### PR TITLE
ClickHouse: Fix MATERIALIZED column option docs typo

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1913,8 +1913,8 @@ pub enum ColumnOption {
     /// `DEFAULT <restricted-expr>`
     Default(Expr),
 
-    /// `MATERIALIZE <expr>`
-    /// Syntax: `b INT MATERIALIZE (a + 1)`
+    /// `MATERIALIZED <expr>`
+    /// Syntax: `b INT MATERIALIZED (a + 1)`
     ///
     /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/create/table#default_values)
     Materialized(Expr),


### PR DESCRIPTION
Fixes #1760

The `ColumnOption::Materialized` docs used `MATERIALIZE` in the syntax examples, but ClickHouse and the enum name both use `MATERIALIZED`. Updated the doc comments to match.

Before:
```sql
b INT MATERIALIZE (a + 1)
```

After:
```sql
b INT MATERIALIZED (a + 1)
```

Docs-only change.