### PR TITLE
Inline small identifier and span helpers

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21181,6 +21181,7 @@ impl Word {
     /// Use this method when you need to keep the original `Word` around.
     /// If you can consume the `Word`, prefer [`into_ident`](Self::into_ident) instead
     /// to avoid cloning.
+    #[inline]
     pub fn to_ident(&self, span: Span) -> Ident {
         Ident {
             value: self.value.clone(),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -757,6 +757,7 @@ impl TokenWithSpan {
     }
 
     /// Wrap a token with a location from `start` to `end`
+    #[inline]
     pub fn at(token: Token, start: Location, end: Location) -> Self {
         Self::new(token, Span::new(start, end))
     }


### PR DESCRIPTION
## Summary

This adds `#[inline]` to two very small helper methods: `Word::to_ident` and `TokenWithSpan::at`.

## Why this can improve performance

Both helpers are small wrapper-style methods used while constructing identifiers and token spans. Marking them inline gives the optimizer more room to remove call overhead on parser/tokenizer paths that call these helpers frequently.

## Validation

- `git diff --check`
- `cargo check`

## Benchmark

Current machine, release microbenchmark, 9 samples, median:

| Benchmark | Base | This change | Delta |
|---|---:|---:|---:|
| 1024 identifier/span helper calls | 42,798.232 ns | 38,391.700 ns | 10.30% faster |
