### PR TITLE
Add recursion checks for parse_interval

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3368,7 +3368,10 @@ impl<'a> Parser<'a> {
     /// ```
     ///
     /// Note that we do not currently attempt to parse the quoted value.
+    #[cfg_attr(feature = "recursive-protection", recursive::recursive)]
     pub fn parse_interval(&mut self) -> Result<Expr, ParserError> {
+        let _guard = self.recursion_counter.try_decrease()?;
+
         // The SQL standard allows an optional sign before the value string, but
         // it is not clear if any implementations support that syntax, so we
         // don't currently try to parse it. (The sign can instead be included

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11420,6 +11420,20 @@ fn parse_deeply_nested_subquery_expr_hits_recursion_limits() {
 }
 
 #[test]
+fn parse_deeply_nested_interval_hits_recursion_limits() {
+    let dialect = GenericDialect {};
+
+    let sql = format!("SELECT {}1", "INTERVAL ".repeat(1000));
+
+    let res = Parser::new(&dialect)
+        .try_with_sql(&sql)
+        .expect("tokenize to work")
+        .parse_statements();
+
+    assert_eq!(res, Err(ParserError::RecursionLimitExceeded));
+}
+
+#[test]
 fn parse_with_recursion_limit() {
     let dialect = GenericDialect {};
 


### PR DESCRIPTION
```sql
SELECT INTERVAL INTERVAL INTERVAL ... 1   -- 600 repetitions, ~5 KB
```

This aborts the process with `fatal runtime error: stack overflow` on a 2 MiB stack
(the default for a spawned thread) instead of returning `RecursionLimitExceeded`.

For dialects where `require_interval_qualifier()` is false, `parse_interval` calls
`parse_prefix` directly rather than `parse_expr`, so it never passes through the
recursion counter that lives in `parse_subexpr`. `parse_prefix` re-enters
`parse_interval` on the next INTERVAL keyword, leaving that cycle unguarded.
Reproduced on generic, duckdb, snowflake and postgres.

The fix applies the same two guards #2199 used for the parenthesis gap; the 600-level
input then returns `Err(RecursionLimitExceeded)`.

Test added beside the existing recursion-limit tests in `tests/sqlparser_common.rs`.
Without the parser change it fails as a stack-overflow abort. Same defect class as
#2411, on a different path.
